### PR TITLE
Make TimeOut annotation easier to read and use

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/fault/tolerance/inject/CircuitBreaker.java
+++ b/api/src/main/java/org/eclipse/microprofile/fault/tolerance/inject/CircuitBreaker.java
@@ -20,6 +20,7 @@ package org.eclipse.microprofile.fault.tolerance.inject;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -30,6 +31,7 @@ import java.time.temporal.ChronoUnit;
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  *
  */
+@Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Target({ ElementType.METHOD, ElementType.TYPE })

--- a/api/src/main/java/org/eclipse/microprofile/fault/tolerance/inject/Retry.java
+++ b/api/src/main/java/org/eclipse/microprofile/fault/tolerance/inject/Retry.java
@@ -20,6 +20,7 @@ package org.eclipse.microprofile.fault.tolerance.inject;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -31,6 +32,7 @@ import java.time.temporal.ChronoUnit;
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  * @author John Ament
  */
+@Inherited
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE})

--- a/api/src/main/java/org/eclipse/microprofile/fault/tolerance/inject/TimeOut.java
+++ b/api/src/main/java/org/eclipse/microprofile/fault/tolerance/inject/TimeOut.java
@@ -20,6 +20,7 @@ package org.eclipse.microprofile.fault.tolerance.inject;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -30,6 +31,7 @@ import java.time.temporal.ChronoUnit;
  * retry counts.
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  */
+@Inherited
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE})

--- a/api/src/main/java/org/eclipse/microprofile/fault/tolerance/inject/Timeout.java
+++ b/api/src/main/java/org/eclipse/microprofile/fault/tolerance/inject/Timeout.java
@@ -27,26 +27,26 @@ import java.lang.annotation.Target;
 import java.time.temporal.ChronoUnit;
 
 /**
- * The Timeout annotation to define the timeout period
- * retry counts.
+ * The annotation to define a method execution timeout.
+ *
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  */
 @Inherited
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE})
-public @interface TimeOut {
+public @interface Timeout {
 
     /**
      *
-     * @return the timeout
+     * @return the timeout value
      */
-    long timeOut() default 1000;
+    long value() default 1000;
 
     /**
      *
      * @return the timeout unit
      */
-    ChronoUnit timeOutUnit() default ChronoUnit.MILLIS;
+    ChronoUnit unit() default ChronoUnit.MILLIS;
 
 }


### PR DESCRIPTION
- rename annotation to Timeout
- rename timeOut() to value()
- rename timeOutUnit() to unit()

See also https://github.com/eclipse/microprofile-fault-tolerance/issues/13#issuecomment-308125929