### PR TITLE
Make TimeOut annotation easier to read and use

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/fault/tolerance/inject/Timeout.java
+++ b/api/src/main/java/org/eclipse/microprofile/fault/tolerance/inject/Timeout.java
@@ -27,26 +27,26 @@ import java.lang.annotation.Target;
 import java.time.temporal.ChronoUnit;
 
 /**
- * The Timeout annotation to define the timeout period
- * retry counts.
+ * The annotation to define a method execution timeout.
+ *
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  */
 @Inherited
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE})
-public @interface TimeOut {
+public @interface Timeout {
 
     /**
      *
-     * @return the timeout
+     * @return the timeout value
      */
-    long timeOut() default 1000;
+    long value() default 1000;
 
     /**
      *
      * @return the timeout unit
      */
-    ChronoUnit timeOutUnit() default ChronoUnit.MILLIS;
+    ChronoUnit unit() default ChronoUnit.MILLIS;
 
 }


### PR DESCRIPTION
- rename annotation to Timeout
- rename timeOut() to value()
- rename timeOutUnit() to unit()

Signed-off-by: Martin Kouba <mkouba@redhat.com>

See also https://github.com/eclipse/microprofile-fault-tolerance/issues/13#issuecomment-308125929