### PR TITLE
Suggesting alignment of maven artifact groups

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,12 +19,12 @@
 
     <parent>
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
-        <groupId>org.eclipse.microprofile.fault.tolerance.parent</groupId>
+        <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
         <artifactId>microprofile-fault-tolerance-parent</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.eclipse.microprofile.fault.tolerance</groupId>
+    <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
     <artifactId>microprofile-fault-tolerance-api</artifactId>
     <version>1.0-SNAPSHOT</version>
     <name>microProfile-fault-tolerance-api</name>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.eclipse.microprofile.fault.tolerance.parent</groupId>
+    <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
     <artifactId>microprofile-fault-tolerance-parent</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <url>http://microprofile.io</url>
@@ -49,7 +49,7 @@
 
     <issueManagement>
         <system>GitHub</system>
-        <url>https://github.com/eclipse/microprofile-config/issues</url>
+        <url>https://github.com/eclipse/microprofile-fault-tolerance/issues</url>
     </issueManagement>
 
     <developers>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -19,12 +19,12 @@
 
     <parent>
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
-        <groupId>org.eclipse.microprofile.fault.tolerance.parent</groupId>
+        <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
         <artifactId>microprofile-fault-tolerance-parent</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.eclipse.microprofile.fault.tolerance</groupId>
+    <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
     <artifactId>microprofile-fault-tolerance-spec</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -19,12 +19,12 @@
 
     <parent>
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
-        <groupId>org.eclipse.microprofile.fault.tolerance.parent</groupId>
+        <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
         <artifactId>microprofile-fault-tolerance-parent</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.eclipse.microprofile.fault.tolerance</groupId>
+    <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
     <artifactId>microprofile-fault-tolerance-tck</artifactId>
     <version>1.0-SNAPSHOT</version>
 
@@ -48,7 +48,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.microprofile.fault.tolerance</groupId>
+            <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
             <artifactId>microprofile-fault-tolerance-api</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>provided</scope>


### PR DESCRIPTION
According to the [Contributing guidelines in the Wiki](https://wiki.eclipse.org/MicroProfile/ContributingGuidelines#Deliverable_group_and_artifact_naming_convention) and also according to the practice used with MP Config, I suggest that maven group of all artifacts is changed to `org.eclipse.microprofile.fault-tolerance`, even for the parent. Using `fault-tolerance` seems better to me than `fault.tolerance`, because it implies that both words together form a single name of a feature, rather than a nested feaure.

I also fixed the version of parent to 1.0-SNAPSHOT to be in line with the version of other parents to make it easier to do a release with maven release plugin later.

