### PR TITLE
Gordon tck bulkhead tests timing issues1

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchRetryTest.java
@@ -19,6 +19,9 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.bulkhead;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhead55ClassAsynchronousRetryBean;
@@ -43,8 +46,8 @@ import org.testng.annotations.Test;
 
 /**
  * This collection of tests tests that failures, particularly Asynchronous
- * Bulkhead exception related failures will cause the Retry annotation logic to work
- * correctly.
+ * Bulkhead exception related failures will cause the Retry annotation logic to
+ * work correctly.
  *
  * @author Gordon Hutchison
  *
@@ -70,7 +73,7 @@ public class BulkheadAsynchRetryTest extends Arquillian {
     private BulkheadRapidRetry55ClassAsynchBean rrClassBean;
     @Inject
     private BulkheadRapidRetry55MethodAsynchBean rrMethodBean;
-    
+
     /**
      * This is the Arquillian deploy method that controls the contents of the
      * war that contains all the tests.
@@ -104,7 +107,14 @@ public class BulkheadAsynchRetryTest extends Arquillian {
     public void testBulkheadClassAsynchronousPassiveRetry55() {
         int iterations = 10;
         int expectedTasksScheduled = iterations;
-        Utils.loop(iterations, classBean, 5, expectedTasksScheduled);
+        CountDownLatch latch = new CountDownLatch(expectedTasksScheduled);
+        Utils.loop(iterations, classBean, 5, expectedTasksScheduled, latch);
+        try {
+            latch.await(50000, TimeUnit.MILLISECONDS);
+        }
+        catch (InterruptedException e) {
+            Utils.log(e.getLocalizedMessage());
+        }
         Utils.check();
     }
 
@@ -119,7 +129,14 @@ public class BulkheadAsynchRetryTest extends Arquillian {
         int iterations = 20;
         int expectedTasksScheduled = iterations;
         int maxSimultaneousWorkers = 5;
-        Utils.loop(iterations, methodBean, maxSimultaneousWorkers, expectedTasksScheduled);
+        CountDownLatch latch = new CountDownLatch(expectedTasksScheduled);
+        Utils.loop(iterations, methodBean, maxSimultaneousWorkers, expectedTasksScheduled, latch );
+        try {
+            latch.await(50000, TimeUnit.MILLISECONDS);
+        }
+        catch (InterruptedException e) {
+            Utils.log(e.getLocalizedMessage());
+        }
         Utils.check();
     }
 
@@ -136,12 +153,12 @@ public class BulkheadAsynchRetryTest extends Arquillian {
 
         boolean tripped;
         try {
-            Utils.loop(iterations, rrMethodBean, maxSimultaneousWorkers);
+            Utils.loop(iterations, rrMethodBean, maxSimultaneousWorkers, 0, null );
             tripped = false;
         }
         catch (BulkheadException bhe) {
             tripped = true;
-            Utils.log("Class Bulkhead que not long enough as expected " + bhe.getMessage());
+            Utils.log("Class Bulkhead queue not long enough as expected " + bhe.getMessage());
         }
         Assert.assertTrue(tripped,
                 "Asynchronous class Bulkead Retry not throwing Bulkhead exception when retry limit just exceeded");
@@ -158,11 +175,10 @@ public class BulkheadAsynchRetryTest extends Arquillian {
     @Test()
     public void testBulkheadMethodAsynchronous55RetryOverload() {
         int iterations = 1000;
-        int expectedTasksScheduled = iterations;
         int maxSimultaneousWorkers = 5;
         boolean blown;
         try {
-            Utils.loop(iterations, rrMethodBean, maxSimultaneousWorkers, expectedTasksScheduled);
+            Utils.loop(iterations, rrMethodBean, maxSimultaneousWorkers, 0, null );
             blown = false;
         }
         catch (BulkheadException bhe) {
@@ -185,7 +201,7 @@ public class BulkheadAsynchRetryTest extends Arquillian {
         int maxSimultaneousWorkers = 5;
         boolean blown;
         try {
-            Utils.loop(iterations, rrClassBean, maxSimultaneousWorkers, expectedTasksScheduled);
+            Utils.loop(iterations, rrClassBean, maxSimultaneousWorkers, expectedTasksScheduled, null);
             blown = false;
         }
         catch (BulkheadException bhe) {
@@ -204,7 +220,14 @@ public class BulkheadAsynchRetryTest extends Arquillian {
     public void testBulkheadPassiveRetryMethodAsynchronous55() {
         int iterations = 10;
         int expectedTasksScheduled = iterations;
-        Utils.loop(iterations, methodBean, 5, expectedTasksScheduled);
+        CountDownLatch latch = new CountDownLatch(expectedTasksScheduled);
+        Utils.loop(iterations, methodBean, 5, expectedTasksScheduled, latch);
+        try {
+            latch.await(50000, TimeUnit.MILLISECONDS);
+        }
+        catch (InterruptedException e) {
+            Utils.log(e.getLocalizedMessage());
+        }
         Utils.check();
     }
 
@@ -218,7 +241,14 @@ public class BulkheadAsynchRetryTest extends Arquillian {
         int iterations = 20;
         int expectedTasksScheduled = iterations;
         int maxSimultaneousWorkers = 5;
-        Utils.loop(iterations, classBean, maxSimultaneousWorkers, expectedTasksScheduled);
+        CountDownLatch latch = new CountDownLatch(expectedTasksScheduled);
+        Utils.loop(iterations, classBean, maxSimultaneousWorkers, expectedTasksScheduled, latch);
+        try {
+            latch.await(50000, TimeUnit.MILLISECONDS);
+        }
+        catch (InterruptedException e) {
+            Utils.log(e.getLocalizedMessage());
+        }
         Utils.check();
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchTest.java
@@ -19,6 +19,7 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.bulkhead;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 
 import javax.inject.Inject;
@@ -33,6 +34,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhe
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadMethodAsynchronousQueueingBean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Checker;
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.TestData;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -40,6 +42,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
+import org.testng.ITestContext;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -89,14 +92,9 @@ public class BulkheadAsynchTest extends Arquillian {
         return war;
     }
 
-    /**
-     * This method is called prior to every test. It waits for all workers to
-     * finish and resets the Checker's state.
-     */
     @BeforeTest
-    public void beforeTest() {
-        Utils.quiesce();
-        Checker.reset();
+    public void beforeTest(final ITestContext testContext) {
+        Utils.log("Testmathod: " + testContext.getName());
     }
 
     /**
@@ -106,65 +104,21 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassAsynchronous10() {
-        loop(10, bhBeanClassAsynchronous10, 10);
-        Utils.check();
-    }
-
-    /**
-     * Run a number of Callable's (usually Asynch's) in a loop on one thread
-     * 
-     * @param number
-     * @param test
-     * @param maxSimultaneousWorkers
-     * @param expectedTasksScheduled
-     */
-    private void loop(int number, BulkheadTestBackend test, int maxSimultaneousWorkers, int expectedTasksScheduled) {
-
-        Checker.setExpectedTasksScheduled(expectedTasksScheduled);
-        loop(number, test, maxSimultaneousWorkers);
-    }
-
-    /**
-     * Run a number of Callable's (usually Asynch's) in a loop on one thread.
-     * Here we do not check that amount that were successfully through the
-     * Bulkhead
-     * 
-     * @param number
-     * @param test
-     * @param maxSimultaneousWorkers
-     */
-    private void loop(int number, BulkheadTestBackend test, int maxSimultaneousWorkers) {
-
-        Checker.setExpectedMaxWorkers(maxSimultaneousWorkers);
-        Checker.setExpectedInstances(number);
-        Checker.setExpectedTasksScheduled(number);
-
-        Future[] results = new Future[number];
-        for (int i = 0; i < number; i++) {
-            Utils.log("synchronous loop() starting test " + i);
-            try {
-                results[i] = test.test(new Checker(5 * 1000));
-            }
-            catch (InterruptedException e1) {
-                Assert.fail("Unexpected interruption", e1);
-            }
-
-        }
-
-        Utils.handleResults(number, results);
+        TestData td = new TestData(new CountDownLatch(10));
+        loop(10, bhBeanClassAsynchronous10, 10, td);
+        td.check();
     }
 
     /**
      * Tests the method asynchronous Bulkhead(10). This test will check that 10
      * and no more than 10 asynchronous calls are allowed into a method that has
-     * an individual
-     * 
-     * @Bulkhead(10) annotation
+     * an individual @Bulkhead(10) annotation
      */
     @Test()
     public void testBulkheadMethodAsynchronous10() {
-        loop(10, bhBeanMethodAsynchronous10, 10);
-        Utils.check();
+        TestData td = new TestData();
+        loop(10, bhBeanMethodAsynchronous10, 10, td);
+        td.check();
     }
 
     /**
@@ -174,8 +128,9 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassAsynchronous3() {
-        loop(10, bhBeanClassAsynchronous3, 3);
-        Utils.check();
+        TestData td = new TestData();
+        loop(10, bhBeanClassAsynchronous3, 3, td);
+        td.check();
     }
 
     /**
@@ -185,8 +140,9 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodAsynchronous3() {
-        loop(10, bhBeanMethodAsynchronous3, 3);
-        Utils.check();
+        TestData td = new TestData();
+        loop(10, bhBeanMethodAsynchronous3, 3, td);
+        td.check();
     }
 
     /**
@@ -196,8 +152,9 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassAsynchronousDefault() {
-        loop(10, bhBeanClassAsynchronousDefault, 10);
-        Utils.check();
+        TestData td = new TestData();
+        loop(10, bhBeanClassAsynchronousDefault, 10, td);
+        td.check();
     }
 
     /**
@@ -207,8 +164,9 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodAsynchronousDefault() {
-        loop(10, bhBeanMethodAsynchronousDefault, 10);
-        Utils.check();
+        TestData td = new TestData();
+        loop(10, bhBeanMethodAsynchronousDefault, 10, td);
+        td.check();
     }
 
     /**
@@ -218,8 +176,9 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassAsynchronousQueueing10() {
-        loop(20, bhBeanClassAsynchronousQueueing, 10, 20);
-        Utils.check();
+        TestData td = new TestData();
+        loop(20, bhBeanClassAsynchronousQueueing, 10, 20, td);
+        td.check();
     }
 
     /**
@@ -229,7 +188,55 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodAsynchronousQueueing10() {
-        loop(20, bhBeanMethodAsynchronousQueueing, 10, 20);
-        Utils.check();
+        TestData td = new TestData();
+        loop(20, bhBeanMethodAsynchronousQueueing, 10, 20, td);
+        td.check();
     }
+
+    /**
+     * Run a number of Callable's (usually Asynch's) in a loop on one thread.
+     * Here we do not check that amount that were successfully through the
+     * Bulkhead
+     * 
+     * @param loops
+     * @param test
+     * @param maxSimultaneousWorkers
+     * @param td
+     */
+    private void loop(int loops, BulkheadTestBackend test, int maxSimultaneousWorkers, TestData td) {
+
+        td.setExpectedMaxSimultaneousWorkers(maxSimultaneousWorkers);
+        td.setExpectedInstances(loops);
+        td.setExpectedTasksScheduled(loops);
+
+        Future[] results = new Future[loops];
+        for (int i = 0; i < loops; i++) {
+            Utils.log("synchronous loop() starting test " + i);
+            try {
+                results[i] = test.test(new Checker(5 * 1000, td));
+            }
+            catch (InterruptedException e1) {
+                Assert.fail("Unexpected interruption", e1);
+            }
+
+        }
+
+        Utils.handleResults(loops, results);
+    }
+
+    /**
+     * Run a number of Callable's (usually Asynch's) in a loop on one thread
+     *
+     * @param number
+     * @param test
+     * @param maxSimultaneousWorkers
+     * @param expectedTasksScheduled
+     * @param td
+     */
+    private void loop(int number, BulkheadTestBackend test, int maxSimultaneousWorkers, int expectedTasksScheduled,
+            TestData td) {
+        td.setExpectedTasksScheduled(expectedTasksScheduled);
+        loop(number, test, maxSimultaneousWorkers, td);
+    }
+
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchTest.java
@@ -116,7 +116,7 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodAsynchronous10() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(10));
         loop(10, bhBeanMethodAsynchronous10, 10, td);
         td.check();
     }
@@ -128,7 +128,7 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassAsynchronous3() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(3));
         loop(10, bhBeanClassAsynchronous3, 3, td);
         td.check();
     }
@@ -140,7 +140,7 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodAsynchronous3() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(3));
         loop(10, bhBeanMethodAsynchronous3, 3, td);
         td.check();
     }
@@ -152,7 +152,7 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassAsynchronousDefault() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(10));
         loop(10, bhBeanClassAsynchronousDefault, 10, td);
         td.check();
     }
@@ -164,7 +164,7 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodAsynchronousDefault() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(10));
         loop(10, bhBeanMethodAsynchronousDefault, 10, td);
         td.check();
     }
@@ -176,7 +176,7 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassAsynchronousQueueing10() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(20));
         loop(20, bhBeanClassAsynchronousQueueing, 10, 20, td);
         td.check();
     }
@@ -188,7 +188,7 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodAsynchronousQueueing10() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(20));
         loop(20, bhBeanMethodAsynchronousQueueing, 10, 20, td);
         td.check();
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchTest.java
@@ -128,7 +128,7 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassAsynchronous3() {
-        TestData td = new TestData(new CountDownLatch(3));
+        TestData td = new TestData(new CountDownLatch(10));
         loop(10, bhBeanClassAsynchronous3, 3, td);
         td.check();
     }
@@ -140,7 +140,7 @@ public class BulkheadAsynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodAsynchronous3() {
-        TestData td = new TestData(new CountDownLatch(3));
+        TestData td = new TestData(new CountDownLatch(10));
         loop(10, bhBeanMethodAsynchronous3, 3, td);
         td.check();
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
@@ -36,6 +36,8 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
+import org.testng.ITestContext;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 /**
@@ -65,6 +67,11 @@ public class BulkheadFutureTest extends Arquillian {
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftBulkheadTest.war").addAsLibrary(testJar);
         return war;
+    }
+
+    @BeforeTest
+    public void beforeTest(final ITestContext testContext) {
+        Utils.log("Testmathod: " + testContext.getName());
     }
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
@@ -47,10 +47,6 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 /**
- * @author Gordon Hutchison
- */
-
-/**
  * This collection of tests tests that failures, particularly Synchronous
  * Bulkhead related failures will cause the Retry annotation logic to work
  * correctly.

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
@@ -206,11 +206,11 @@ public class BulkheadSynchRetryTest extends Arquillian {
 
     /**
      * Test no regression due to passive Retry. The Bulkhead is 5
-     * so the Retry should not come into effect for 10 Tasks.
+     * so the Retry should not come into effect.
      */
     @Test()
     public void testBulkheadPassiveRetryMethodSynchronous55() {
-        int threads = 10;
+        int threads = 5;
         int maxSimultaneousWorkers = 5;
         int expectedTasks = threads;
         TestData td = new TestData(new CountDownLatch(expectedTasks));

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchTest.java
@@ -19,6 +19,7 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.bulkhead;
 
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -105,7 +106,7 @@ public class BulkheadSynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassSemaphore3() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(3));
         threads(20, bhBeanClassSemaphore3, 3, td);
         td.check();
     }
@@ -117,7 +118,7 @@ public class BulkheadSynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassSemaphore10() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(10));
 
         threads(20, bhBeanClassSemaphore10, 10, td);
         td.check();
@@ -133,7 +134,7 @@ public class BulkheadSynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodSemaphore10() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(10));
 
         threads(20, bhBeanMethodSemaphore10, 10, td);
         td.check();
@@ -146,7 +147,7 @@ public class BulkheadSynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodSemaphore3() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(3));
 
         threads(20, bhBeanMethodSemaphore3, 3, td);
         td.check();
@@ -159,7 +160,7 @@ public class BulkheadSynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassSemaphoreDefault() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(10));
 
         threads(20, bhBeanClassSemaphoreDefault, 10, td);
         td.check();
@@ -168,12 +169,12 @@ public class BulkheadSynchTest extends Arquillian {
 
     /**
      * Tests the basic method synchronous Bulkhead with defaulting value
-     * parameter. This will check that more than 1 but less than 10 threads get
+     * parameter. This will check that more than 1 but not more than 10 threads get
      * into the bulkhead at once.
      */
     @Test()
     public void testBulkheadMethodSemaphoreDefault() {
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(10));
 
         threads(20, bhBeanMethodSemaphoreDefault, 10, td);
         td.check();

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchTest.java
@@ -32,8 +32,9 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhe
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadMethodSemaphore3Bean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadMethodSemaphoreDefaultBean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
-import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Checker;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.ParrallelBulkheadTest;
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.TestData;
 import org.jboss.arquillian.container.test.api.Deployment;
 //import org.jboss.arquillian.core.api.Asynchronousing.ExecutorService;
 import org.jboss.arquillian.testng.Arquillian;
@@ -41,6 +42,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.ITestContext;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -91,14 +93,9 @@ public class BulkheadSynchTest extends Arquillian {
         return war;
     }
 
-    /**
-     * This method is called prior to every test. It waits for all workers to
-     * finish and resets the Checker's state.
-     */
     @BeforeTest
-    public void beforeTest() {
-        Utils.quiesce();
-        Checker.reset();
+    public void beforeTest(final ITestContext testContext) {
+        Utils.log("Testmathod: " + testContext.getName());
     }
 
     /**
@@ -108,8 +105,9 @@ public class BulkheadSynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassSemaphore3() {
-        threads(20, bhBeanClassSemaphore3, 3);
-        Utils.check();
+        TestData td = new TestData();
+        threads(20, bhBeanClassSemaphore3, 3, td);
+        td.check();
     }
 
     /**
@@ -119,8 +117,10 @@ public class BulkheadSynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassSemaphore10() {
-        threads(20, bhBeanClassSemaphore10, 10);
-        Utils.check();
+        TestData td = new TestData();
+
+        threads(20, bhBeanClassSemaphore10, 10, td);
+        td.check();
 
     }
 
@@ -133,8 +133,10 @@ public class BulkheadSynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodSemaphore10() {
-        threads(20, bhBeanMethodSemaphore10, 10);
-        Utils.check();
+        TestData td = new TestData();
+
+        threads(20, bhBeanMethodSemaphore10, 10, td);
+        td.check();
     }
 
     /**
@@ -144,8 +146,10 @@ public class BulkheadSynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodSemaphore3() {
-        threads(20, bhBeanMethodSemaphore3, 3);
-        Utils.check();
+        TestData td = new TestData();
+
+        threads(20, bhBeanMethodSemaphore3, 3, td);
+        td.check();
     }
 
     /**
@@ -155,8 +159,10 @@ public class BulkheadSynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadClassSemaphoreDefault() {
-        threads(20, bhBeanClassSemaphoreDefault, 10);
-        Utils.check();
+        TestData td = new TestData();
+
+        threads(20, bhBeanClassSemaphoreDefault, 10, td);
+        td.check();
 
     }
 
@@ -167,8 +173,10 @@ public class BulkheadSynchTest extends Arquillian {
      */
     @Test()
     public void testBulkheadMethodSemaphoreDefault() {
-        threads(20, bhBeanMethodSemaphoreDefault, 10);
-        Utils.check();
+        TestData td = new TestData();
+
+        threads(20, bhBeanMethodSemaphoreDefault, 10, td);
+        td.check();
     }
 
     /**
@@ -178,14 +186,14 @@ public class BulkheadSynchTest extends Arquillian {
      * @param test
      * @param maxSimultaneousWorkers
      */
-    private void threads(int number, BulkheadTestBackend test, int maxSimultaneousWorkers) {
+    private void threads(int number, BulkheadTestBackend test, int maxSimultaneousWorkers, TestData td) {
 
-        Checker.setExpectedMaxWorkers(maxSimultaneousWorkers);
-        Checker.setExpectedInstances(number);
+        td.setExpectedMaxSimultaneousWorkers(maxSimultaneousWorkers);
+        td.setExpectedInstances(number);
         Future[] results = new Future[number];
         for (int i = 0; i < number; i++) {
             Utils.log("Starting test " + i);
-            results[i] = xService.submit(new ParrallelBulkheadTest(test));
+            results[i] = xService.submit(new ParrallelBulkheadTest(test, td));
         }
 
         Utils.handleResults(number, results);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/Utils.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/Utils.java
@@ -77,7 +77,7 @@ public class Utils {
      * @param test
      * @param maxSimultaneousWorkers
      * @param expectedTasksScheduled
-     * @param td 
+     * @param td - used to hold expected results
      */
     public static void loop(int iterations, BulkheadTestBackend test, int maxSimultaneousWorkers, int expectedTasksScheduled, TestData td ) {
 
@@ -104,8 +104,7 @@ public class Utils {
      * A simple local logger. Messages are logged with a prefix of the threadId
      * and the current time.
      * 
-     * @param s
-     *            message
+     * @param s - message
      */
     public static void log(String s) {
         System.out.println(tid() + " " + hms() + ": " + s);
@@ -120,6 +119,9 @@ public class Utils {
         return DateTimeFormatter.ofPattern("HH:mm:ss:SS").format(LocalDateTime.now());
     }
 
+    /**
+     * @param millis
+     */
     public static void sleep(int millis) {
         try {
             Thread.sleep(millis);
@@ -129,6 +131,9 @@ public class Utils {
         }
     }
 
+    /**
+     * Prevent instances being constructed
+     */
     private Utils() {
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/Utils.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/Utils.java
@@ -21,6 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
@@ -97,21 +98,6 @@ public class Utils {
     }
 
     /**
-     * Run a number of Callable's (usually Asynch's) in a loop on one thread
-     * 
-     * @param iterations
-     * @param test
-     * @param maxSimultaneousWorkers
-     * @param expectedTasksScheduled
-     */
-    public static void loop(int iterations, BulkheadTestBackend test, int maxSimultaneousWorkers,
-            int expectedTasksScheduled) {
-
-        Checker.setExpectedTasksScheduled(expectedTasksScheduled);
-        loop(iterations, test, maxSimultaneousWorkers);
-    }
-
-    /**
      * Run a number of Callable's (usually Asynch's) in a loop on one thread.
      * Here we do not check that amount that were successfully through the
      * Bulkhead
@@ -119,12 +105,15 @@ public class Utils {
      * @param iterations
      * @param test
      * @param maxSimultaneousWorkers
+     * @param expectedTasksScheduled
+     * @param latch
      */
-    public static void loop(int iterations, BulkheadTestBackend test, int maxSimultaneousWorkers) {
+    public static void loop(int iterations, BulkheadTestBackend test, int maxSimultaneousWorkers, int expectedTasksScheduled, CountDownLatch latch ) {
 
         Checker.setExpectedMaxWorkers(maxSimultaneousWorkers);
         Checker.setExpectedInstances(iterations);
-        Checker.setExpectedTasksScheduled(iterations);
+        Checker.setExpectedTasksScheduled(expectedTasksScheduled);
+        Checker.setLatch(latch);
 
         Future[] results = new Future[iterations];
         try {
@@ -170,5 +159,6 @@ public class Utils {
     }
 
     private Utils() {
-    };
+    }
+
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/Utils.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/Utils.java
@@ -21,11 +21,11 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Checker;
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.TestData;
 import org.testng.Assert;
 
 public class Utils {
@@ -37,35 +37,6 @@ public class Utils {
      */
     private static long tid() {
         return Thread.currentThread().getId();
-    }
-
-    /**
-     * Wait for the tests to finish and check the results
-     */
-    public static void check() {
-        quiesce();
-        Checker.check();
-    }
-
-    /**
-     * Wait for the tests to finish. We avoid using 'isDone' that passes through
-     * the wrapping Future as we want to test this independently.
-     */
-    static void quiesce() {
-        try {
-            int waits = 0;
-            while (Checker.getWorkers() > 0) {
-                Utils.log("Waiting for " + Checker.getWorkers() + " workers to finish");
-                Thread.sleep(100);
-                if (waits++ > 100) {
-                    break;
-                }
-
-            }
-        }
-        catch (InterruptedException e) {
-            log(e.toString());
-        }
     }
 
     /**
@@ -106,20 +77,20 @@ public class Utils {
      * @param test
      * @param maxSimultaneousWorkers
      * @param expectedTasksScheduled
-     * @param latch
+     * @param td 
      */
-    public static void loop(int iterations, BulkheadTestBackend test, int maxSimultaneousWorkers, int expectedTasksScheduled, CountDownLatch latch ) {
+    public static void loop(int iterations, BulkheadTestBackend test, int maxSimultaneousWorkers, int expectedTasksScheduled, TestData td ) {
 
-        Checker.setExpectedMaxWorkers(maxSimultaneousWorkers);
-        Checker.setExpectedInstances(iterations);
-        Checker.setExpectedTasksScheduled(expectedTasksScheduled);
-        Checker.setLatch(latch);
+        
+        td.setExpectedMaxSimultaneousWorkers(maxSimultaneousWorkers);
+        td.setExpectedInstances(iterations);
+        td.setExpectedTasksScheduled(expectedTasksScheduled);
 
         Future[] results = new Future[iterations];
         try {
             for (int i = 0; i < iterations; i++) {
                 Utils.log("Starting test " + i);
-                results[i] = test.test(new Checker(1 * 1000));
+                results[i] = test.test(new Checker(1 * 1000, td));
             }
         }
         catch (InterruptedException e1) {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55MethodSynchronousRetryBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55MethodSynchronousRetryBean.java
@@ -29,9 +29,8 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 
 /**
  * This tests the class level annotations in Retry that will enable us to submit
- * a set of tasks that will blow the bulkhead and its queue but which will get
- * retried until they are done. Each backend sleeps for one second so we should
- * get done in about 5 seconds as we allow 2 at once.
+ * a set of tasks that will blow the bulkhead which will get
+ * retried until they are done.
  * 
  * @author Gordon Hutchison
  */
@@ -39,9 +38,9 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 public class Bulkhead55MethodSynchronousRetryBean implements BulkheadTestBackend {
 
     @Override
-    @Bulkhead(waitingTaskQueue = 5, value = 5)
+    @Bulkhead(value = 5)
     @Retry(retryOn =
-    { BulkheadException.class }, delay = 1, delayUnit = ChronoUnit.SECONDS, maxRetries = 10)
+    { BulkheadException.class }, delay = 1, delayUnit = ChronoUnit.SECONDS, maxRetries = 20)
     public Future test(BackendTestDelegate action) throws InterruptedException {
         Utils.log("in business method of bean " + this.getClass().getName());
         return action.perform();

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Checker.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Checker.java
@@ -20,14 +20,11 @@
 package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.management.RuntimeErrorException;
 
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
-import org.testng.Assert;
 
 /**
  * A simple sleeping test backend worker. Having this backend as a delegate
@@ -47,18 +44,9 @@ import org.testng.Assert;
  */
 public class Checker implements BackendTestDelegate {
 
-    protected int millis = 1;
+    private int millis = 1;
     private int fails = 0;
-    protected static AtomicInteger workers = new AtomicInteger(0);
-    protected static AtomicInteger maxSimultaneousWorkers = new AtomicInteger(0);
-    protected static AtomicInteger instances = new AtomicInteger(0);
-    protected static AtomicInteger tasksScheduled = new AtomicInteger(0);
-    protected static int expectedInstances;
-    protected static int expectedMaxSimultaneousWorkers;
-    protected static int expectedTasksScheduled;
-    private static boolean maxFill = true;
-    private static CountDownLatch latch = null;
-
+    private TestData td = null;
     /*
      * This string is used for varying substr's barcharts in the log, for
      * example for the number of concurrent workers.
@@ -71,15 +59,17 @@ public class Checker implements BackendTestDelegate {
      * @param i
      *            how long to sleep for in milliseconds
      */
-    public Checker(int sleepMillis) {
-        millis = sleepMillis;
-        instances.incrementAndGet();
+    public Checker(int sleepMillis, TestData td) {
+        this.millis = sleepMillis;
+        this.td = td;
+        this.td.getInstances().incrementAndGet();
     }
 
-    public Checker(int sleepMillis, int fails) {
+    public Checker(int sleepMillis, TestData td, int fails) {
         this.fails = fails;
         this.millis = sleepMillis;
-        instances.incrementAndGet();
+        this.td = td;
+        this.td.getInstances().incrementAndGet();
     }
 
     /*
@@ -92,100 +82,52 @@ public class Checker implements BackendTestDelegate {
     @Override
     public Future<String> perform() throws InterruptedException {
         try {
-            int taskId = tasksScheduled.incrementAndGet();
-            int now = workers.incrementAndGet();
-            int max = maxSimultaneousWorkers.get();
+            int taskId = td.getTasksScheduled().incrementAndGet();
+            int now = td.getWorkers().incrementAndGet();
+            int max = td.getMaxSimultaneousWorkers().get();
 
-            if( latch != null ){
-                latch.countDown();
-            }
+            // if( latch != null ){
+            // latch.countDown();
+            // }
 
-            while ((now > max) && !maxSimultaneousWorkers.compareAndSet(max, now)) {
-                max = maxSimultaneousWorkers.get();
+            while ((now > max) && !td.getMaxSimultaneousWorkers().compareAndSet(max, now)) {
+                max = td.getMaxSimultaneousWorkers().get();
             }
             if (fails > 0) {
-                Thread.sleep(millis/2);
+                Thread.sleep(millis / 2);
                 fails--;
                 RuntimeErrorException e = new RuntimeErrorException(new Error("fake error for Retry Testing"));
                 Utils.log(e.toString());
+                if (td.getLatch() != null) {
+                    td.getLatch().countDown();
+                }
                 throw e;
             }
 
             Utils.log("Task " + taskId + " sleeping for " + millis + " milliseconds. " + now
-                    + " workers inside Bulkhead from " + instances + " instances " + BAR.substring(0, now));
+                    + " workers inside Bulkhead from " + td.getInstances() + " instances " + BAR.substring(0, now));
+
             Thread.sleep(millis);
 
             Utils.log("Task " + taskId + " woke.");
+
+            if (td.getLatch() != null) {
+                td.getLatch().countDown();
+            }
+
         }
         catch (InterruptedException e) {
             Utils.log(e.toString());
         }
         finally {
-            workers.decrementAndGet();
+            td.getWorkers().decrementAndGet();
         }
         CompletableFuture<String> result = new CompletableFuture<>();
-        result.complete("max workers was " + maxSimultaneousWorkers.get());
+        result.complete("max workers was " + td.getMaxSimultaneousWorkers().get());
         return result;
     }
 
-    /**
-     * Prepare the state for the next test
-     */
-    public static void reset() {
-        instances.set(0);
-        workers.set(0);
-        maxSimultaneousWorkers.set(0);
-        tasksScheduled.set(0);
-        maxFill = true;
+    public int getSleep(){
+        return millis;
     }
-
-    /**
-     * Check the test ran successfully
-     */
-    public static void check() {
-        Assert.assertEquals(workers.get(), 0, "Some workers still active. ");
-
-        Assert.assertFalse(expectedInstances != 0 && instances.get() < expectedInstances,
-                " Not all workers launched. " + instances.get() +"/"+expectedInstances );
-
-        Assert.assertTrue(maxSimultaneousWorkers.get() <= expectedMaxSimultaneousWorkers,
-                " Bulkhead appears to have been breeched " + maxSimultaneousWorkers + " workers, expected "
-                        + expectedMaxSimultaneousWorkers + ". ");
-        Assert.assertFalse(expectedMaxSimultaneousWorkers > 1 && maxSimultaneousWorkers.get() == 1,
-                " Workers are not in parrallel. ");
-        Assert.assertTrue(!maxFill || expectedMaxSimultaneousWorkers == maxSimultaneousWorkers.get(),
-                " Work is not being done simultaneously enough, only " + maxSimultaneousWorkers + " "
-                        + " workers at once. Expecting " + expectedMaxSimultaneousWorkers + ". ");
-        Assert.assertFalse(expectedTasksScheduled != 0 && tasksScheduled.get() < expectedTasksScheduled,
-                " Some tasks are missing, expected " + expectedTasksScheduled + " got " + tasksScheduled.get() + ". ");
-
-        Utils.log("Checks passed: " + "tasks: " + tasksScheduled + "/" + expectedTasksScheduled + ", bulkhead: "
-                + maxSimultaneousWorkers + "/" + expectedMaxSimultaneousWorkers);
-    }
-
-    public static int getWorkers() {
-        return workers.get();
-    }
-
-    public static void setExpectedTasksScheduled(int expected) {
-        expectedTasksScheduled = expected;
-    }
-
-    public static void setExpectedInstances(int expectedInstances) {
-        Checker.expectedInstances = expectedInstances;
-    }
-
-    public static void setExpectedMaxWorkers(int expectedMaxWorkers) {
-        Checker.expectedMaxSimultaneousWorkers = expectedMaxWorkers;
-    }
-
-    public static void setExpectedMaxWorkers(int maxSimultaneousWorkers, boolean b) {
-        setExpectedMaxWorkers(maxSimultaneousWorkers);
-        maxFill = b;
-    }
-
-    public static void setLatch(CountDownLatch cdl) {
-        latch = cdl;
-    }
-
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Checker.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Checker.java
@@ -28,17 +28,9 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 
 /**
  * A simple sleeping test backend worker. Having this backend as a delegate
- * means that we can perform more than one kind of test using a common
- * 
+ * means that we can perform more than one kind of test using a common 
  * @Injected object that delegates to one of these that is passed in as a
- *           parameter to the business method.
- * 
- *           There are a number of tests that this backend can perform:
- *           <ul>
- *           <li>expected number of instances created
- *           <li>expected workers started via perform method
- *           <li>max simultaneous workers not exceeded
- *           </ul>
+ * parameter to the business method.
  * 
  * @author Gordon Hutchison
  */
@@ -73,7 +65,7 @@ public class Checker implements BackendTestDelegate {
     }
 
     /*
-     * Work this is the method that simulates the backend work inside the
+     * This is the method that simulates the backend work inside the
      * Bulkhead.
      * 
      * @see org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.
@@ -85,10 +77,6 @@ public class Checker implements BackendTestDelegate {
             int taskId = td.getTasksScheduled().incrementAndGet();
             int now = td.getWorkers().incrementAndGet();
             int max = td.getMaxSimultaneousWorkers().get();
-
-            // if( latch != null ){
-            // latch.countDown();
-            // }
 
             while ((now > max) && !td.getMaxSimultaneousWorkers().compareAndSet(max, now)) {
                 max = td.getMaxSimultaneousWorkers().get();
@@ -127,6 +115,9 @@ public class Checker implements BackendTestDelegate {
         return result;
     }
 
+    /**
+     * @return how long do we sleep for
+     */
     public int getSleep(){
         return millis;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Checker.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Checker.java
@@ -20,6 +20,7 @@
 package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -56,6 +57,7 @@ public class Checker implements BackendTestDelegate {
     protected static int expectedMaxSimultaneousWorkers;
     protected static int expectedTasksScheduled;
     private static boolean maxFill = true;
+    private static CountDownLatch latch = null;
 
     /*
      * This string is used for varying substr's barcharts in the log, for
@@ -94,6 +96,9 @@ public class Checker implements BackendTestDelegate {
             int now = workers.incrementAndGet();
             int max = maxSimultaneousWorkers.get();
 
+            if( latch != null ){
+                latch.countDown();
+            }
 
             while ((now > max) && !maxSimultaneousWorkers.compareAndSet(max, now)) {
                 max = maxSimultaneousWorkers.get();
@@ -177,6 +182,10 @@ public class Checker implements BackendTestDelegate {
     public static void setExpectedMaxWorkers(int maxSimultaneousWorkers, boolean b) {
         setExpectedMaxWorkers(maxSimultaneousWorkers);
         maxFill = b;
+    }
+
+    public static void setLatch(CountDownLatch cdl) {
+        latch = cdl;
     }
 
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/FutureChecker.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/FutureChecker.java
@@ -34,8 +34,12 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
  */
 public class FutureChecker extends Checker {
 
+    public FutureChecker(int sleepMillis, TestData td) {
+        super(sleepMillis, td);
+    }
+
     public FutureChecker(int sleepMillis) {
-        super(sleepMillis);
+        super( sleepMillis, new TestData());
     }
 
     /*
@@ -49,7 +53,7 @@ public class FutureChecker extends Checker {
     @Override
     public Future<String> perform() throws InterruptedException {
         try {
-            int left = millis;
+            int left = getSleep();
             int tick = 250;
             while (left > 0 && !Thread.currentThread().isInterrupted()) {
                 if (left < tick) {
@@ -66,7 +70,7 @@ public class FutureChecker extends Checker {
         }
         catch (InterruptedException e) {
             Utils.log("FutureChecker interrupted " + e.toString());
-            if (millis > 60 * 1000) {
+            if (getSleep() > 60 * 1000) {
                 throw e;
             }
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/FutureChecker.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/FutureChecker.java
@@ -85,9 +85,7 @@ public class FutureChecker extends Checker {
      * underlying method result object apart from the get and get with timeout
      * methods. The semantics are that, for example, isDone()'s result are with
      * respect to the operation of running the method, not as the result would
-     * be if it was delegated to the Future object that the method returns.
-     * 
-     * @author Gordon Hutchison
+     * be if it was delegated to the Future object that the method returns
      *
      */
     public final class TestFuture implements Future<String> {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/ParrallelBulkheadTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/ParrallelBulkheadTest.java
@@ -24,7 +24,7 @@ import java.util.concurrent.Future;
 
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
-import org.junit.Assert;
+import org.testng.Assert;
 
 /**
  * @author Gordon Hutchison
@@ -56,9 +56,9 @@ public class ParrallelBulkheadTest implements Callable<Future> {
      * @param target
      *            the backend bulkheaded test class
      */
-    public ParrallelBulkheadTest(BulkheadTestBackend target) {
+    public ParrallelBulkheadTest(BulkheadTestBackend target, TestData td) {
         this.target = target;
-        this.action = new Checker(1000);
+        this.action = new Checker(1000, td);
     }
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/TestData.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/TestData.java
@@ -1,0 +1,167 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
+import org.testng.Assert;
+
+/**
+ * A class to hold data that is has the scope of a test.
+ * 
+ * @author Gordon Hutchison
+ */
+public class TestData {
+
+    private AtomicInteger workers = new AtomicInteger(0);
+    private AtomicInteger maxSimultaneousWorkers = new AtomicInteger(0);
+    private AtomicInteger instances = new AtomicInteger(0);
+    private AtomicInteger tasksScheduled = new AtomicInteger(0);
+    private int expectedInstances;
+    private int expectedMaxSimultaneousWorkers;
+    private int expectedTasksScheduled;
+    private boolean maxFill = true;
+    private CountDownLatch latch = null;
+
+    public TestData(CountDownLatch countDownLatch) {
+        latch = countDownLatch;
+    }
+
+    public TestData() {
+    }
+
+    public AtomicInteger getWorkers() {
+        return workers;
+    }
+
+    public void setWorkers(AtomicInteger workers) {
+        this.workers = workers;
+    }
+
+    public AtomicInteger getMaxSimultaneousWorkers() {
+        return maxSimultaneousWorkers;
+    }
+
+    public void setMaxSimultaneousWorkers(AtomicInteger maxSimultaneousWorkers) {
+        this.maxSimultaneousWorkers = maxSimultaneousWorkers;
+    }
+
+    public AtomicInteger getInstances() {
+        return instances;
+    }
+
+    public void setInstances(AtomicInteger instances) {
+        this.instances = instances;
+    }
+
+    public AtomicInteger getTasksScheduled() {
+        return tasksScheduled;
+    }
+
+    public void setTasksScheduled(AtomicInteger tasksScheduled) {
+        this.tasksScheduled = tasksScheduled;
+    }
+
+    public int getExpectedInstances() {
+        return expectedInstances;
+    }
+
+    public void setExpectedInstances(int expectedInstances) {
+        this.expectedInstances = expectedInstances;
+    }
+
+    public int getExpectedMaxSimultaneousWorkers() {
+        return expectedMaxSimultaneousWorkers;
+    }
+
+    public void setExpectedMaxSimultaneousWorkers(int expectedMaxSimultaneousWorkers) {
+        this.expectedMaxSimultaneousWorkers = expectedMaxSimultaneousWorkers;
+    }
+
+    public int getExpectedTasksScheduled() {
+        return expectedTasksScheduled;
+    }
+
+    public boolean isMaxFill() {
+        return maxFill;
+    }
+
+    public void setMaxFill(boolean maxFill) {
+        this.maxFill = maxFill;
+    }
+
+    public CountDownLatch getLatch() {
+        return latch;
+    }
+
+    public void setLatch(CountDownLatch latch) {
+        this.latch = latch;
+    }
+
+    public void setExpectedTasksScheduled(int expected) {
+        if (tasksScheduled.get() != 0 && // test being set up
+                expectedTasksScheduled != tasksScheduled.get()) {
+            Utils.log("WARNING: expectedTasksScheduled being set to " + expected + " while tasksScheduled was "
+                    + tasksScheduled.get() + " this will make this check likely to FAIL.");
+        }
+        this.expectedTasksScheduled = expected;
+    }
+
+    /**
+     * Check the test ran successfully
+     */
+    public void check() {
+        
+        if( latch != null ) {
+            try {
+                latch.await(50000, TimeUnit.MILLISECONDS);
+                Assert.assertEquals(getWorkers().get(), 0, "Some workers still active. ");
+            }
+            catch (InterruptedException e) {
+                Utils.log(e.getLocalizedMessage());
+            }
+        }
+        
+
+        Assert.assertFalse(getExpectedInstances() != 0 && getInstances().get() < getExpectedInstances(),
+                " Not all workers launched. " + getInstances().get() + "/" + getExpectedInstances());
+
+        Assert.assertTrue(getMaxSimultaneousWorkers().get() <= getExpectedMaxSimultaneousWorkers(),
+                " Bulkhead appears to have been breeched " + getMaxSimultaneousWorkers() + " workers, expected "
+                        + getExpectedMaxSimultaneousWorkers() + ". ");
+        Assert.assertFalse(getExpectedMaxSimultaneousWorkers() > 1 && getMaxSimultaneousWorkers().get() == 1,
+                " Workers are not in parrallel. ");
+        Assert.assertTrue(
+                !isMaxFill() || getExpectedMaxSimultaneousWorkers() == getMaxSimultaneousWorkers().get(),
+                " Work is not being done simultaneously enough, only " + getMaxSimultaneousWorkers() + " "
+                        + " workers at once. Expecting " + getExpectedMaxSimultaneousWorkers() + ". ");
+        Assert.assertFalse(
+                getExpectedTasksScheduled() != 0 && getTasksScheduled().get() < getExpectedTasksScheduled(),
+                " Some tasks are missing, expected " + getExpectedTasksScheduled() + " got "
+                        + getTasksScheduled().get() + ". ");
+
+        Utils.log("Checks passed: " + "tasks: " + getTasksScheduled() + "/" + getExpectedTasksScheduled()
+                + ", bulkhead: " + getMaxSimultaneousWorkers() + "/" + getExpectedMaxSimultaneousWorkers());
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/TestData.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/TestData.java
@@ -27,7 +27,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.testng.Assert;
 
 /**
- * A class to hold data that is has the scope of a test.
+ * A class to hold a set of data that is has the scope of a test.
  * 
  * @author Gordon Hutchison
  */


### PR DESCRIPTION
Here are some test improvements. Adding the use of a CountDownLatch and removing the reusing of static data between tests to make the tests more reliable.