### PR TITLE
Fix wrong assumption in Bulkhead Future tests

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchRetryTest.java
@@ -91,7 +91,7 @@ public class BulkheadAsynchRetryTest extends Arquillian {
 
     @BeforeTest
     public void beforeTest(final ITestContext testContext) {
-        Utils.log("Testmathod: " + testContext.getName());
+        Utils.log("Testmethod: " + testContext.getName());
     }
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchTest.java
@@ -94,7 +94,7 @@ public class BulkheadAsynchTest extends Arquillian {
 
     @BeforeTest
     public void beforeTest(final ITestContext testContext) {
-        Utils.log("Testmathod: " + testContext.getName());
+        Utils.log("Testmethod: " + testContext.getName());
     }
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
@@ -43,18 +43,14 @@ import org.testng.annotations.Test;
 /**
  * This set of tests will test correct operation on the relevant methods of the
  * Future object that is returned from the business method of a Asynchronous
- * Method or Class. Note that this is not the same as the Future object that the
- * users called method (which runs on the new thread) returns. So, for example,
- * calls to 'isDone' will be done with respect to the users 'get' method having
- * been completed and not delegated to the user's 'Future.isDone'
- * implementation.
+ * Method or Class.
  * 
  * @author Gordon Hutchison
  */
 public class BulkheadFutureTest extends Arquillian {
 
     private static final int SHORT_TIME = 100;
-    private static final int VERY_LONG_TIME = 300000;
+    private static final int LONG_TIME = 3000;
     @Inject
     private BulkheadMethodAsynchronousDefaultBean bhBeanMethodAsynchronousDefault;
     @Inject
@@ -71,7 +67,7 @@ public class BulkheadFutureTest extends Arquillian {
 
     @BeforeTest
     public void beforeTest(final ITestContext testContext) {
-        Utils.log("Testmathod: " + testContext.getName());
+        Utils.log("Testmethod: " + testContext.getName());
     }
 
     /**
@@ -82,7 +78,7 @@ public class BulkheadFutureTest extends Arquillian {
     public void testBulkheadMethodAsynchFutureCancel() {
 
         // We want a long running backend that we can cancel
-        Checker fc = new FutureChecker(VERY_LONG_TIME);
+        Checker fc = new FutureChecker(LONG_TIME);
 
         Future<String> result = null;
         try {
@@ -178,7 +174,7 @@ public class BulkheadFutureTest extends Arquillian {
     @Test()
     public void testBulkheadClassAsynchFutureCancel() {
 
-        Checker fc = new FutureChecker(VERY_LONG_TIME);
+        Checker fc = new FutureChecker(LONG_TIME);
         Future<String> result = null;
         try {
             result = bhBeanClassAsynchronousDefault.test(fc);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.bulkhead;
 
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -68,46 +67,6 @@ public class BulkheadFutureTest extends Arquillian {
     @BeforeTest
     public void beforeTest(final ITestContext testContext) {
         Utils.log("Testmethod: " + testContext.getName());
-    }
-
-    /**
-     * Tests that the Future that is returned from a asynchronous bulkhead
-     * method can be cancelled OK and that isCancelled works correctly.
-     */
-    @Test()
-    public void testBulkheadMethodAsynchFutureCancel() {
-
-        // We want a long running backend that we can cancel
-        Checker fc = new FutureChecker(LONG_TIME);
-
-        Future<String> result = null;
-        try {
-            result = bhBeanMethodAsynchronousDefault.test(fc);
-        }
-        catch (InterruptedException e1) {
-            Assert.fail("Unexpected interruption", e1);
-        }
-
-        Assert.assertFalse(result.isDone(), "Future reporting Done when not");
-        Assert.assertFalse(result.isCancelled(), "Future reporting Canceled when not");
-
-        result.cancel(true);
-
-        Utils.sleep(SHORT_TIME);
-
-        Assert.assertTrue(result.isDone(), "Future reporting Done when not");
-        Assert.assertTrue(result.isCancelled(), "Future reporting not Cancelled when Cancelled");
-
-        try {
-            String rc = result.get();
-            Assert.assertNull(rc, "We should have gotten a CancelationException as cancelled");
-        }
-        catch (Throwable t) {
-            Assert.assertTrue(t instanceof CancellationException);
-        }
-        Assert.assertTrue(result.isCancelled(), "Future cancel not reporting Cancelled after get");
-        Assert.assertTrue(result.isDone(), "Future not reporting Done when canceled after get");
-
     }
 
     /**
@@ -165,50 +124,7 @@ public class BulkheadFutureTest extends Arquillian {
         }
         Assert.assertTrue(result.isDone(), "Future done not reporting true");
     }
-
-    /**
-     * Tests that the Future that is returned from a asynchronous bulkhead can
-     * be canceled OK and that isCancelled works correctly on a method in an
-     * asynchronous bulkhead annotated class
-     */
-    @Test()
-    public void testBulkheadClassAsynchFutureCancel() {
-
-        Checker fc = new FutureChecker(LONG_TIME);
-        Future<String> result = null;
-        try {
-            result = bhBeanClassAsynchronousDefault.test(fc);
-        }
-        catch (InterruptedException e1) {
-            Assert.fail("Unexpected interruption", e1);
-        }
-
-        Assert.assertFalse(result.isDone(), "Future reporting Done when not");
-        Assert.assertFalse(result.isCancelled(), "Future reporting Canceled when not");
-
-        result.cancel(true);
-
-        try {
-            Thread.sleep(SHORT_TIME);
-        }
-        catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-        Assert.assertTrue(result.isDone(), "Future reporting not Done when Done");
-        Assert.assertTrue(result.isCancelled(), "Future reporting not Cancelled when Cancelled");
-
-        try {
-            String rc = result.get();
-            Assert.assertNull(rc, "We should have got a CancelationException");
-        }
-        catch (Throwable t) {
-            Assert.assertTrue(t instanceof CancellationException);
-        }
-        Assert.assertTrue(result.isCancelled(), "Future isCancelled not reporting true when called after cancel,get");
-        Assert.assertTrue(result.isDone(), "Future not reporting Done when called after cancel,get");
-
-    }
-
+  
     /**
      * Tests that the Future that is returned from a asynchronous bulkhead can
      * be queried for Done OK after a goodpath get with timeout and also

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
@@ -101,7 +101,7 @@ public class BulkheadSynchRetryTest extends Arquillian {
 
     @BeforeTest
     public void beforeTest(final ITestContext testContext) {
-        Utils.log("Testmathod: " + testContext.getName());
+        Utils.log("Testmethod: " + testContext.getName());
     }
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchTest.java
@@ -96,7 +96,7 @@ public class BulkheadSynchTest extends Arquillian {
 
     @BeforeTest
     public void beforeTest(final ITestContext testContext) {
-        Utils.log("Testmathod: " + testContext.getName());
+        Utils.log("Testmethod: " + testContext.getName());
     }
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/FutureChecker.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/FutureChecker.java
@@ -28,7 +28,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 
 /**
  * A backend that is used in the tests of the operations on the Future returned
- * by the user (only get() should be called).
+ * by the user.
  * 
  * @author Gordon Hutchison
  */
@@ -39,13 +39,12 @@ public class FutureChecker extends Checker {
     }
 
     public FutureChecker(int sleepMillis) {
-        super( sleepMillis, new TestData());
+        super(sleepMillis, new TestData());
     }
 
     /*
      * This method is the one called from the business method of the injected
-     * object that has the annotations. In this class we just wait to be told
-     * what to do.
+     * object that has the annotations.
      * 
      * @see org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.
      * BulkheadTestAction#perform()
@@ -77,35 +76,30 @@ public class FutureChecker extends Checker {
         return new TestFuture();
     }
 
-    /**
-     * This test backend delegate does nothing except to complain with
-     * UnsupportedOperation exceptions if methods that are not expected to be
-     * called are called...The Future returned from a annotated method or class
-     * to a client is not expected to pass on any method calls to the users
-     * underlying method result object apart from the get and get with timeout
-     * methods. The semantics are that, for example, isDone()'s result are with
-     * respect to the operation of running the method, not as the result would
-     * be if it was delegated to the Future object that the method returns
-     *
-     */
     public final class TestFuture implements Future<String> {
 
         private AtomicBoolean done = new AtomicBoolean(false);
         private String result = "";
+        private boolean isCancelCalled;
+        private boolean isDoneCalled;
+        private boolean isIsCancelledCalled;
 
         @Override
         public boolean cancel(boolean mayInterruptIfRunning) {
-            throw new UnsupportedOperationException();
+            isCancelCalled = true;
+            return true;
         }
 
         @Override
         public boolean isCancelled() {
-            throw new UnsupportedOperationException();
+            isIsCancelledCalled = true;
+            return isCancelCalled;
         }
 
         @Override
         public boolean isDone() {
-            throw new UnsupportedOperationException();
+            isDoneCalled = true;
+            return true;
         }
 
         /*


### PR DESCRIPTION
Signed-off-by: Gordon Hutchison <Gordon.Hutchison@gmail.com>
The tests were throwing errors if an application level Future had methods other than the
gets called - this was wrong.