### PR TITLE
[Do not merge] open tck for extensions, use junit instead of testng

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>microprofile-fault-tolerance-parent</artifactId>
     <version>1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-    
+
     <name>MicroProfile Fault Tolerance</name>
     <description>Eclipse MicroProfile Fault Tolerance Feature</description>
 
@@ -275,6 +275,7 @@
                 </executions>
                 <configuration>
                     <excludes>
+                        <exclude>src/main/resources/META-INF/services/org.eclipse.microprofile.fault.tolerance.tck.TckArchiveProvider</exclude>
                         <exclude>.travis.yml.*</exclude>
                         <exclude>bnd.bnd</exclude>
                         <exclude>*.log</exclude>
@@ -287,7 +288,7 @@
 
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>release</id>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -78,14 +78,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <version>6.9.9</version>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.testng</groupId>
-            <artifactId>arquillian-testng-container</artifactId>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
             <version>${arquillian.version}</version>
         </dependency>
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
@@ -21,17 +21,18 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClassLevelClientWithRetry;
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientWithRetry;
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testng.Assert;
-import org.testng.annotations.Test;
 
 /**
  * Test CircuitBreaker Thresholds and delays with Retries.
@@ -40,7 +41,8 @@ import org.testng.annotations.Test;
  *
  */
 
-public class CircuitBreakerRetryTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class CircuitBreakerRetryTest {
 
     private @Inject CircuitBreakerClientWithRetry clientForCBWithRetry;
     private @Inject CircuitBreakerClassLevelClientWithRetry clientForClassLevelCBWithRetry;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
 
 /**
  * Test CircuitBreaker Thresholds and delays with Retries.
- * 
+ *
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
  *
  */
@@ -54,7 +54,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftCircuitBreakerRetry.war")
                         .addAsLibrary(testJar);
-        return war;
+        return TckAdditions.decorate(war);
     }
 
     /**
@@ -133,7 +133,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
     }
 
     /**
-     * Analogous to testCircuitOpenWithMoreRetries with Class level @CircuitBreaker and @Retry annotations 
+     * Analogous to testCircuitOpenWithMoreRetries with Class level @CircuitBreaker and @Retry annotations
      * that are inherited by serviceA
      */
     @Test
@@ -167,7 +167,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
     }
 
     /**
-     * Analogous to testCircuitOpenWithFewRetries with Class level @CircuitBreaker and @Retry annotations 
+     * Analogous to testCircuitOpenWithFewRetries with Class level @CircuitBreaker and @Retry annotations
      * that are overridden by serviceB.
      */
     @Test
@@ -206,7 +206,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         invokeCounter = clientForClassLevelCBWithRetry.getCounterForInvokingServiceB();
         Assert.assertEquals(invokeCounter, 3, "The number of executions should be 3");
     }
-    
+
     /**
      * Analagous to testCircuitOpenWithMoreRetries but execution failures are caused by timeouts.
      */
@@ -215,7 +215,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         int invokeCounter = 0;
         try {
             clientForCBWithRetry.serviceC(1000);
-            
+
             invokeCounter = clientForCBWithRetry.getCounterForInvokingServiceA();
             if (invokeCounter < 4) {
                 Assert.fail("serviceC should retry in testCircuitOpenWithMoreRetries on iteration "
@@ -224,7 +224,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         }
         catch (CircuitBreakerOpenException cboe) {
             // Expected on iteration 4
-            
+
             invokeCounter = clientForCBWithRetry.getCounterForInvokingServiceC();
             if (invokeCounter < 4) {
                 Assert.fail("serviceC should retry in testCircuitOpenWithMoreRetries on iteration "

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerTest.java
@@ -21,20 +21,21 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClassLevelClientWithDelay;
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientDefaultSuccessThreshold;
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientHigherSuccessThreshold;
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientNoDelay;
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientWithDelay;
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testng.Assert;
-import org.testng.annotations.Test;
 
 /**
  * Test CircuitBreaker Thresholds and delays.
@@ -43,7 +44,8 @@ import org.testng.annotations.Test;
  *
  */
 
-public class CircuitBreakerTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class CircuitBreakerTest {
 
     private @Inject CircuitBreakerClientWithDelay clientForCBWithDelay;
     private @Inject CircuitBreakerClassLevelClientWithDelay clientForClassLevelCBWithDelay;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 
 /**
  * Test CircuitBreaker Thresholds and delays.
- * 
+ *
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
  *
  */
@@ -64,24 +64,24 @@ public class CircuitBreakerTest extends Arquillian {
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftCircuitBreaker.war")
                         .addAsLibrary(testJar);
-        return war;
+        return TckAdditions.decorate(war);
     }
 
     /**
      * A test to exercise Circuit Breaker thresholds, with a default
      * SuccessThreshold
-     * 
+     *
      * With requestVolumeThreshold = 4, failureRatio=0.75, successThreshold = 2,
      * delay = 50000 the expected behaviour is,
-     * 
-     * Execution Behaviour 
-     * ========= ========= 
-     * 1         RunTimeException 
-     * 2         RunTimeException 
-     * 3         RunTimeException  
-     * 4         RunTimeException 
-     * 5         CircuitBreakerOpenException 
-     * 6         CircuitBreakerOpenException 
+     *
+     * Execution Behaviour
+     * ========= =========
+     * 1         RunTimeException
+     * 2         RunTimeException
+     * 3         RunTimeException
+     * 4         RunTimeException
+     * 5         CircuitBreakerOpenException
+     * 6         CircuitBreakerOpenException
      * 7         CircuitBreakerOpenException
      */
     @Test
@@ -117,18 +117,18 @@ public class CircuitBreakerTest extends Arquillian {
     /**
      * A test to exercise Circuit Breaker thresholds, with a SuccessThreshold of
      * 2
-     * 
+     *
      * With requestVolumeThreshold = 4, failureRatio=0.75 and successThreshold =
      * 2 the expected behaviour is,
-     * 
-     * Execution Behaviour 
-     * ========= ========= 
-     * 1         RunTimeException 
-     * 2         RunTimeException 
-     * 3         RunTimeException  
+     *
+     * Execution Behaviour
+     * ========= =========
+     * 1         RunTimeException
+     * 2         RunTimeException
+     * 3         RunTimeException
      * 4         RunTimeException
      * Pause for longer than CircuitBreaker delay, so that it transitions to half-open
-     * 5         SUCCEED 
+     * 5         SUCCEED
      * 6         SUCCEED (CircuitBreaker will be re-closed as successThreshold is 2)
      * 7         SUCCEED
      */
@@ -175,15 +175,15 @@ public class CircuitBreakerTest extends Arquillian {
     /**
      * A test to exercise Circuit Breaker thresholds, with a default
      * SuccessThreshold
-     * 
-     * With requestVolumeThreshold = 4, failureRatio=0.75 and successThreshold = 1 
+     *
+     * With requestVolumeThreshold = 4, failureRatio=0.75 and successThreshold = 1
      * the expected behaviour is,
      *
-     * Execution Behaviour 
-     * ========= ========= 
-     * 1         RunTimeException 
-     * 2         RunTimeException 
-     * 3         RunTimeException  
+     * Execution Behaviour
+     * ========= =========
+     * 1         RunTimeException
+     * 2         RunTimeException
+     * 3         RunTimeException
      * 4         RunTimeException
      * 5         CircuitBreakerOpenException
      * Pause for longer than CircuitBreaker delay, so that it transitions to half-open
@@ -239,19 +239,19 @@ public class CircuitBreakerTest extends Arquillian {
     /**
      * A test to exercise Circuit Breaker thresholds, with a default
      * SuccessThreshold
-     * 
+     *
      * With requestVolumeThreshold = 4, failureRatio=0.75 and successThreshold = 3
      * the expected behaviour is,
-     * 
-     * Execution Behaviour 
-     * ========= ========= 
-     * 1         RunTimeException 
-     * 2         RunTimeException 
-     * 3         RunTimeException  
+     *
+     * Execution Behaviour
+     * ========= =========
+     * 1         RunTimeException
+     * 2         RunTimeException
+     * 3         RunTimeException
      * 4         RunTimeException
      * 5         CircuitBreakerOpenException
      * Pause for longer than CircuitBreaker delay, so that it transitions to half-open
-     * 6         SUCCEED 
+     * 6         SUCCEED
      * 7         SUCCEED
      * 8         RunTimeException (CircuitBreaker will be re-opened)
      * 9         CircuitBreakerOpenException
@@ -300,18 +300,18 @@ public class CircuitBreakerTest extends Arquillian {
     /**
      * Analogous to testCircuitClosedThenOpen but using a Class level rather
      * than method level annotation.
-     * 
+     *
      * With requestVolumeThreshold = 4, failureRatio=0.75, successThreshold = 2
      * , delay = 50000 the expected behaviour is,
-     * 
-     * Execution Behaviour 
-     * ========= ========= 
-     * 1         RunTimeException 
-     * 2         RunTimeException 
-     * 3         RunTimeException  
-     * 4         RunTimeException 
-     * 5         CircuitBreakerOpenException 
-     * 6         CircuitBreakerOpenException 
+     *
+     * Execution Behaviour
+     * ========= =========
+     * 1         RunTimeException
+     * 2         RunTimeException
+     * 3         RunTimeException
+     * 4         RunTimeException
+     * 5         CircuitBreakerOpenException
+     * 6         CircuitBreakerOpenException
      * 7         CircuitBreakerOpenException
      */
     @Test
@@ -349,18 +349,18 @@ public class CircuitBreakerTest extends Arquillian {
     /**
      * Analogous to testCircuitClosedThenOpen but with a Class level annotation
      * specified that is overridden by a Method level annotation on serviceC.
-     * 
+     *
      * With successThreshold = 2, requestVolumeThreshold = 2, failureRatio=1,
      * delay = 50000 the expected behaviour is,
-     * 
-     * Execution Behaviour 
-     * ========= ========= 
-     * 1         RunTimeException 
-     * 2         RunTimeException 
-     * 3         CircuitBreakerOpenException  
-     * 4         CircuitBreakerOpenException 
-     * 5         CircuitBreakerOpenException 
-     * 6         CircuitBreakerOpenException 
+     *
+     * Execution Behaviour
+     * ========= =========
+     * 1         RunTimeException
+     * 2         RunTimeException
+     * 3         CircuitBreakerOpenException
+     * 4         CircuitBreakerOpenException
+     * 5         CircuitBreakerOpenException
+     * 6         CircuitBreakerOpenException
      * 7         CircuitBreakerOpenException
      */
     @Test
@@ -397,18 +397,18 @@ public class CircuitBreakerTest extends Arquillian {
     /**
      * Analogous to testCircuitReClose but with a Class level annotation
      * specified that is overridden by a Method level annotation on serviceD.
-     * 
+     *
      * With successThreshold = 2, requestVolumeThreshold = 4, failureRatio=0.75,
      * delay = 1 the expected behaviour is,
-     * 
-     * Execution Behaviour 
-     * ========= ========= 
-     * 1         RunTimeException 
-     * 2         RunTimeException 
-     * 3         RunTimeException  
+     *
+     * Execution Behaviour
+     * ========= =========
+     * 1         RunTimeException
+     * 2         RunTimeException
+     * 3         RunTimeException
      * 4         RunTimeException
      * Pause for longer than CircuitBreaker delay, so that it transitions to half-open
-     * 5         SUCCEED 
+     * 5         SUCCEED
      * 6         SUCCEED (CircuitBreaker will be re-closed as successThreshold is 2)
      * 7         SUCCEED
      */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ConfigTest.java
@@ -35,10 +35,10 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 /**
  * Test that Fault Tolerance values configured through annotations can be overridden by configuration properties.
- *  
+ *
  * The test assumes that the container supports both the MicroProfile Configuration API and the MicroProfile
  * Fault Tolerance API. Configuration Properties are provided in the manifest of the deployed application.
- * 
+ *
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
  *
  */
@@ -47,7 +47,7 @@ public class ConfigTest extends Arquillian {
     private @Inject ConfigClient clientForConfig;
     private @Inject ConfigClassLevelClient clientForClassLevelConfig;
     private @Inject ConfigClassLevelMaxDurationClient clientForClassLevelMaxDurationConfig;
-    
+
     @Deployment
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
@@ -65,15 +65,15 @@ public class ConfigTest extends Arquillian {
         WebArchive war = ShrinkWrap
                 .create(WebArchive.class, "ftConfig.war")
                 .addAsLibrary(testJar);
-        return war;
+        return TckAdditions.decorate(war);
     }
 
     /**
-     * Test the configuration of maxRetries on a specific method. 
-     * 
+     * Test the configuration of maxRetries on a specific method.
+     *
      * The serviceA is annotated with maxRetries = 5, but a configuration property overrides it with a value of 3,
      * so serviceA should be executed 4 times.
-     * 
+     *
      * The test assumes that the container has been configured with the property,
      * org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClient/serviceA/Retry/maxRetries=3
      */
@@ -81,7 +81,7 @@ public class ConfigTest extends Arquillian {
     public void testConfigMaxRetries() {
         try {
             clientForConfig.serviceA();
-            
+
             Assert.fail("serviceA should throw a RuntimeException in testConfigMaxRetries");
         }
         catch(RuntimeException ex) {
@@ -90,13 +90,13 @@ public class ConfigTest extends Arquillian {
         int count = clientForConfig.getCounterForInvokingConnectionService();
         Assert.assertEquals(count, 4, "The max number of execution should be 4");
     }
-    
+
     /**
-     * Test the configuration of maxRetries on a class. 
-     * 
+     * Test the configuration of maxRetries on a class.
+     *
      * The class is annotated with maxRetries = 5, but a configuration property overrides it with a value of 3,
      * so serviceA should be executed 4 times.
-     * 
+     *
      * The test assumes that the container has been configured with the property,
      * org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClassLevelClient/Retry/maxRetries=3
      */
@@ -104,7 +104,7 @@ public class ConfigTest extends Arquillian {
     public void testClassLevelConfigMaxRetries() {
         try {
             clientForClassLevelConfig.serviceA();
-            
+
             Assert.fail("serviceA should throw a RuntimeException in testClassLevelConfigMaxRetries");
         }
         catch(RuntimeException ex) {
@@ -113,13 +113,13 @@ public class ConfigTest extends Arquillian {
         int count = clientForClassLevelConfig.getCounterForInvokingConnectionService();
         Assert.assertEquals(count, 4, "The max number of execution should be 4");
     }
-    
+
     /**
-     * Test the configuration of maxRetries on a class. 
-     * 
+     * Test the configuration of maxRetries on a class.
+     *
      * The class is annotated with maxRetries = 5. A configuration property overrides it with a value of 3 but serviceB
      * has its own annotation and should be executed 2 times.
-     * 
+     *
      * The test assumes that the container has been configured with the property,
      * org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClassLevelClient/Retry/maxRetries=3
      */
@@ -127,7 +127,7 @@ public class ConfigTest extends Arquillian {
     public void testClassLevelConfigMethodOverrideMaxRetries() {
         try {
             clientForClassLevelConfig.serviceB();
-            
+
             Assert.fail("serviceB should throw a RuntimeException in testClassLevelConfigMethodOverrideMaxRetries");
         }
         catch(RuntimeException ex) {
@@ -138,11 +138,11 @@ public class ConfigTest extends Arquillian {
     }
 
     /**
-     * Test the configuration of maxDuration on a specific method. 
-     * 
+     * Test the configuration of maxDuration on a specific method.
+     *
      * The serviceA is annotated with maxDuration=3000 but a configuration property overrides it with a value of 1000,
      * so serviceA should be executed less than 11 times.
-     * 
+     *
      * The test assumes that the container has been configured with the property,
      * org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClient/serviceC/Retry/maxDuration=1000
      */
@@ -156,18 +156,18 @@ public class ConfigTest extends Arquillian {
             // Expected
         }
 
-        //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms, 
+        //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms,
         //the max invocation should be less than 10
         int count = clientForConfig.getRetryCountForWritingService();
         Assert.assertTrue(count< 11, "The max retry counter should be less than 11");
     }
 
     /**
-     * Test the configuration of maxDuration on a class. 
-     * 
+     * Test the configuration of maxDuration on a class.
+     *
      * The class is annotated with maxDuration=3000 but a configuration property overrides it with a value of 1000
      * so serviceA should be executed less than 11 times.
-     * 
+     *
      * The test assumes that the container has been configured with the property,
      * org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClassLevelMaxDurationClient/Retry/maxDuration=1000
      */
@@ -181,9 +181,9 @@ public class ConfigTest extends Arquillian {
             // Expected
         }
 
-        //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms, 
+        //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms,
         //the max invocation should be less than 10
-        int retryCountforWritingService = clientForClassLevelMaxDurationConfig.getRetryCountForWritingService();        
+        int retryCountforWritingService = clientForClassLevelMaxDurationConfig.getRetryCountForWritingService();
         Assert.assertTrue(retryCountforWritingService< 11, "The max retry counter should be less than 11");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ConfigTest.java
@@ -25,14 +25,15 @@ import org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigCl
 import org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClassLevelMaxDurationClient;
 import org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClient;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testng.Assert;
-import org.testng.annotations.Test;
 /**
  * Test that Fault Tolerance values configured through annotations can be overridden by configuration properties.
  *
@@ -42,7 +43,8 @@ import org.testng.annotations.Test;
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
  *
  */
-public class ConfigTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class ConfigTest {
 
     private @Inject ConfigClient clientForConfig;
     private @Inject ConfigClassLevelClient clientForClassLevelConfig;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/FallbackTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/FallbackTest.java
@@ -40,7 +40,7 @@ import org.testng.annotations.Test;
 
 /**
  * Test fallback was invoked correctly; fallback handler supporting CDI injection; type safety on fallback class.
- * 
+ *
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
  *
  */
@@ -62,13 +62,13 @@ public class FallbackTest extends Arquillian {
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftFallback.war")
                         .addAsLibrary(testJar);
-        return war;
+        return TckAdditions.decorate(war);
     }
 
     /**
      * Test that a Fallback service is driven after the specified number of retries are executed.
-     * 
-     * Each of serviceA and serviceB specify the same FallbackHandler. The test checks that the 
+     *
+     * Each of serviceA and serviceB specify the same FallbackHandler. The test checks that the
      * handler has been driven in the correct ExecutionContext and that the Service has been
      * executed the correct number of times.
      */
@@ -97,8 +97,8 @@ public class FallbackTest extends Arquillian {
 
     /**
      * A refinement on testFallbackSuccess to test that a bean may be injected in the FallbackHandler.
-     * 
-     * Each of serviceA and serviceB specify the same FallbackHandler. The test checks that the 
+     *
+     * Each of serviceA and serviceB specify the same FallbackHandler. The test checks that the
      * handler has been driven in the correct ExecutionContext and that the Service has been
      * executed the correct number of times.
      */
@@ -121,7 +121,7 @@ public class FallbackTest extends Arquillian {
             String result = fallbackWithBeanClient.serviceB();
             Assert.assertTrue(result.contains("serviceB"),
                             "The message should be \"fallback for serviceB\"");
-            //MyBean should be injected to the fallbackA, MyBean is application scoped, 
+            //MyBean should be injected to the fallbackA, MyBean is application scoped,
             //so the same instance should be injected to the fallback handler
             Assert.assertTrue(result.contains("35"),
                             "The message should be \"fallback for serviceB myBean.getCount()=35\"");
@@ -134,7 +134,7 @@ public class FallbackTest extends Arquillian {
 
     /**
      * Analogous to testFallbackSuccess with Class level annotations that are inherited by serviceA
-     * but overridden by serviceB. 
+     * but overridden by serviceB.
      */
     @Test
     public void testClassLevelFallbackSuccess() {
@@ -158,10 +158,10 @@ public class FallbackTest extends Arquillian {
         }
         Assert.assertEquals(fallbackClassLevelClient.getCounterForInvokingServiceB(), 3, "The execution count should be 3 (2 retries + 1)");
     }
-    
+
     /**
      * Test that a Fallback service is driven after the specified number of retries are executed.
-     * 
+     *
      * A timeout is configured for serviceC but the service should fail before the timeout is reached
      * and generate a RuntimeException. After a retry the Fallback will be executed.
      */
@@ -171,22 +171,22 @@ public class FallbackTest extends Arquillian {
             String result = fallbackClient.serviceC(10);
             Assert.assertTrue(result.contains("serviceC"),
                             "The message should be \"fallback for serviceC\"");
-        } 
+        }
         catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceC should not throw a TimeoutException in testFallbacktNoTimeout");
-        } 
+        }
         catch (RuntimeException ex) {
             // Not expected
             Assert.fail("serviceC should not throw a RuntimeException in testFallbacktNoTimeout");
-        }        
+        }
 
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceC(), 2, "The execution count should be 2 (1 retry + 1)");
     }
-    
+
     /**
      * Test that a Fallback service is driven after the specified number of retries are executed.
-     * 
+     *
      * A timeout is configured for serviceC and in this case the service should generate Timeout exceptions.
      * After a retry the Fallback will be executed.
      */
@@ -196,23 +196,23 @@ public class FallbackTest extends Arquillian {
             String result = fallbackClient.serviceC(1000);
             Assert.assertTrue(result.contains("serviceC"),
                             "The message should be \"fallback for serviceC\"");
-        } 
+        }
         catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceC should not throw a TimeoutException in testFallbackTimeout");
-        } 
+        }
         catch (RuntimeException ex) {
             // Not Expected
             Assert.fail("serviceC should not throw a RuntimeException in testFallbackTimeout");
         }
-        
+
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceC(), 2, "The execution count should be 2 (1 retry + 1)");
     }
-    
+
     /**
      * Test that a method in a Fallback service is driven after the specified number of retries are executed.
-     * 
-     * ServiceD specifies a method on a FallbackHandler. The test checks that the FallbackHandler method 
+     *
+     * ServiceD specifies a method on a FallbackHandler. The test checks that the FallbackHandler method
      * has been driven and that the Service has been executed the correct number of times.
      */
     @Test
@@ -227,13 +227,13 @@ public class FallbackTest extends Arquillian {
             Assert.fail("serviceD should not throw a RuntimeException in testFallbackMethodSuccess");
         }
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceD(), 2, "The execution count should be 2 (1 retry + 1)");
-        
+
     }
 
     /**
      * Analogous to testFallbackMethodSuccess but serviceE has a pair of parameters.
-     * 
-     * ServiceE specifies a method on a FallbackHandler. The test checks that the FallbackHandler method 
+     *
+     * ServiceE specifies a method on a FallbackHandler. The test checks that the FallbackHandler method
      * has been driven and that the Service has been executed the correct number of times.
      */
     @Test
@@ -248,6 +248,6 @@ public class FallbackTest extends Arquillian {
             Assert.fail("serviceE should not throw a RuntimeException in testFallbackMethodWithArgsSuccess");
         }
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceE(), 2, "The execution count should be 2 (1 retry + 1)");
-        
+
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/FallbackTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/FallbackTest.java
@@ -30,13 +30,14 @@ import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.String
 import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.StringFallbackHandlerWithBean;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testng.Assert;
-import org.testng.annotations.Test;
 
 /**
  * Test fallback was invoked correctly; fallback handler supporting CDI injection; type safety on fallback class.
@@ -44,7 +45,8 @@ import org.testng.annotations.Test;
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
  *
  */
-public class FallbackTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class FallbackTest {
 
     private @Inject FallbackClient fallbackClient;
     private @Inject FallbackWithBeanClient fallbackWithBeanClient;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
@@ -26,13 +26,14 @@ import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClas
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientAbortOn;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientRetryOn;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testng.Assert;
-import org.testng.annotations.Test;
 /**
  * Test the retryOn and abortOn conditions.
  * If retryOn condition is not met, no retry will be performed.
@@ -40,7 +41,8 @@ import org.testng.annotations.Test;
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  *
  */
-public class RetryConditionTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class RetryConditionTest {
 
     private @Inject RetryClientRetryOn clientForRetryOn;
     private @Inject RetryClientAbortOn clientForAbortOn;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
@@ -46,7 +46,7 @@ public class RetryConditionTest extends Arquillian {
     private @Inject RetryClientAbortOn clientForAbortOn;
     private @Inject RetryClassLevelClientRetryOn clientForClassLevelRetryOn;
     private @Inject RetryClassLevelClientAbortOn clientForClassLevelAbortOn;
-    
+
     @Deployment
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftRetryCondition.jar")
@@ -59,12 +59,12 @@ public class RetryConditionTest extends Arquillian {
         WebArchive war = ShrinkWrap
                 .create(WebArchive.class, "ftRetryCondition.war")
                 .addAsLibrary(testJar);
-        return war;
+        return TckAdditions.decorate(war);
     }
 
     /**
      * Test that retries are executed where a failure declared as "retry on" in the {@code @Retry} annotation is encountered.
-     *  
+     *
      * serviceA is configured to retry on a RuntimeException. The service should be retried 3 times.
      */
     @Test
@@ -82,9 +82,9 @@ public class RetryConditionTest extends Arquillian {
     /**
      * Test that no retries are executed where a failure declared as "retry on" in the {@code @Retry} annotation
      * is NOT encountered.
-     *  
+     *
      * serviceB is configured to retry on an IOException. In practice the only exception that the service
-     * will throw is a RuntimeException, therefore no retries should be executed. 
+     * will throw is a RuntimeException, therefore no retries should be executed.
      */
     @Test
     public void testRetryOnFalse() {
@@ -102,9 +102,9 @@ public class RetryConditionTest extends Arquillian {
     /**
      * Test that the default number of retries are executed where a failure declared as "abort on" in the {@code @Retry} annotation
      * is NOT encountered.
-     *  
+     *
      * serviceA is configured to abort on an IOException. In practice the only exception that the service
-     * will throw is a RuntimeException, therefore the default number of 3 retries should be executed. 
+     * will throw is a RuntimeException, therefore the default number of 3 retries should be executed.
      */
     @Test
     public void testRetryWithAbortOnFalse() {
@@ -121,7 +121,7 @@ public class RetryConditionTest extends Arquillian {
     /**
      * Test that no retries are executed where a failure declared as "abort on" in the {@code @Retry} annotation
      * is encountered.
-     *  
+     *
      * serviceB is configured to abort on a RuntimeException. The service should not be retried.
      */
     @Test
@@ -139,7 +139,7 @@ public class RetryConditionTest extends Arquillian {
 
     /**
      * Analogous to testRetryOnTrue but using a Class level rather than method level annotation.
-     * 
+     *
      * serviceA is configured to retry on a RuntimeException. The service should be retried 3 times.
      */
     @Test
@@ -153,13 +153,13 @@ public class RetryConditionTest extends Arquillian {
         }
         Assert.assertEquals(clientForClassLevelRetryOn.getRetryCountForConnectionService(), 4, "The execution count should be 4 (3 retries + 1)");
     }
-    
+
     /**
      * Analogous to testRetryonFalse, testing whether the {@code @Retry} annotation on method serviceB overrides the Class level
      * {@code @Retry} annotation.
-     *  
+     *
      * serviceB is configured to retry on an IOException. In practice the only exception that the service
-     * will throw is a RuntimeException, therefore no retries should be executed. 
+     * will throw is a RuntimeException, therefore no retries should be executed.
      */
     @Test
     public void testClassLevelRetryOnFalse() {
@@ -173,14 +173,14 @@ public class RetryConditionTest extends Arquillian {
         Assert.assertEquals(clientForClassLevelRetryOn.getRetryCountForWritingService(), 1,
             "The execution count should be 1 as the retry condition is false");
     }
-    
+
     /**
      * Analogous to testRetryWithAbortOnFalse but using a Class level rather than method level {@code @Retry} annotation.
      * Test that the default number of retries are executed where a failure declared as "abort on" in the {@code @Retry} annotation
      * is NOT encountered.
-     *  
+     *
      * The Class, and therefore serviceA, is configured to abort on an IOException. In practice the only exception that the service
-     * will throw is a RuntimeException, therefore the default number of 3 retries should be executed. 
+     * will throw is a RuntimeException, therefore the default number of 3 retries should be executed.
      */
     @Test
     public void testClassLevelRetryWithAbortOnFalse() {
@@ -197,10 +197,10 @@ public class RetryConditionTest extends Arquillian {
     /**
      * Analogous to testRetryWithAbortOnTrue, testing whether the {@code @Retry} annotation on method serviceB overrides the Class level
      * {@code @Retry} annotation.
-     * 
+     *
      * Test that no retries are executed where a failure declared as "abort on" in the {@code @Retry} annotation
      * is encountered.
-     *  
+     *
      * serviceB is configured to abort on a RuntimeException. The service should not be retried.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
@@ -25,13 +25,14 @@ import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClas
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientForMaxRetries;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientWithDelay;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testng.Assert;
-import org.testng.annotations.Test;
 /**
  * Test when maxDuration is reached, no more retries will be perfomed.
  * Test the delay and jitter were taken into consideration.
@@ -39,7 +40,8 @@ import org.testng.annotations.Test;
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  *
  */
-public class RetryTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class RetryTest {
 
     private @Inject RetryClientForMaxRetries clientForMaxRetry;
     private @Inject RetryClientWithDelay clientForDelay;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
 /**
  * Test when maxDuration is reached, no more retries will be perfomed.
  * Test the delay and jitter were taken into consideration.
- * 
+ *
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  *
  */
@@ -44,7 +44,7 @@ public class RetryTest extends Arquillian {
     private @Inject RetryClientForMaxRetries clientForMaxRetry;
     private @Inject RetryClientWithDelay clientForDelay;
     private @Inject RetryClassLevelClientForMaxRetries clientForClassLevelMaxRetry;
-    
+
     @Deployment
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
@@ -56,12 +56,12 @@ public class RetryTest extends Arquillian {
         WebArchive war = ShrinkWrap
                 .create(WebArchive.class, "ftRetry.war")
                 .addAsLibrary(testJar);
-        return war;
+        return TckAdditions.decorate(war);
     }
 
     /**
-     * Test maxRetries. 
-     * 
+     * Test maxRetries.
+     *
      * As serviceA is annotated with maxRetries = 5, serviceA should be executed 6 times.
      */
     @Test
@@ -75,7 +75,7 @@ public class RetryTest extends Arquillian {
         }
         Assert.assertEquals(clientForMaxRetry.getRetryCountForConnectionService(), 6, "The max number of execution should be 6");
     }
-    
+
     @Test
     public void testRetryMaxDuration() {
         try {
@@ -86,7 +86,7 @@ public class RetryTest extends Arquillian {
             // Expected
         }
 
-        //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms, 
+        //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms,
         //the max invocation should be less than 10
         Assert.assertTrue(clientForMaxRetry.getRetryCountForWritingService()< 11, "The max retry counter should be less than 11");
     }
@@ -101,11 +101,11 @@ public class RetryTest extends Arquillian {
             // Expected
         }
 
-        //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms, 
+        //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms,
         //the max invocation should be less than 10
         Assert.assertTrue(clientForMaxRetry.getRetryCountForWritingService()< 11, "The max retry counter should be less than 11");
     }
-    
+
     @Test
     public void testRetryWithDelay() {
         try {
@@ -123,7 +123,7 @@ public class RetryTest extends Arquillian {
     /**
      * Analogous to testRetryMaxRetries but using a Class level rather
      * than method level annotation.
-     * 
+     *
      * With maxRetries = 2, serviceA should be executed 3 times.
      */
     @Test
@@ -141,7 +141,7 @@ public class RetryTest extends Arquillian {
     /**
      * Analogous to testRetryMaxDuration, testing whether the {@code @Retry} annotation on method serviceB overrides the Class level
      * {@code @Retry} annotation.
-     * 
+     *
      * Ensure that serviceB is executed more than the maxRetries of 2 specified at the Class level.
      */
     @Test
@@ -154,19 +154,19 @@ public class RetryTest extends Arquillian {
             // Expected
         }
 
-        //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms, 
+        //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms,
         //the max invocation should be less than 10
-        int retryCountforWritingService = clientForClassLevelMaxRetry.getRetryCountForWritingService();        
+        int retryCountforWritingService = clientForClassLevelMaxRetry.getRetryCountForWritingService();
         Assert.assertTrue(retryCountforWritingService< 11, "The max retry counter should be less than 11");
-        
+
         // Further test that we have retried more than the maximum number of retries specified in the Class level {@code @Retry} annotation
-        Assert.assertTrue(retryCountforWritingService> 3, "The max retry counter should be greater than 3");      
+        Assert.assertTrue(retryCountforWritingService> 3, "The max retry counter should be greater than 3");
     }
 
     /**
      * Analogous to testRetryMaxDurationSeconds, testing whether the {@code @Retry} annotation on method serviceB overrides the Class level
      * {@code @Retry} annotation.
-     * 
+     *
      * Ensure that serviceB is executed more than the maxRetries of 2 specified at the Class level.
      */
     @Test
@@ -179,7 +179,7 @@ public class RetryTest extends Arquillian {
             // Expected
         }
 
-        //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms, 
+        //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms,
         //the max invocation should be less than 10
         Assert.assertTrue(clientForClassLevelMaxRetry.getRetryCountForWritingService()< 11, "The max retry counter should be less than 11");
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTimeoutTest.java
@@ -24,20 +24,22 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.fault.tolerance.tck.retrytimeout.clientserver.RetryTimeoutClient;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testng.Assert;
-import org.testng.annotations.Test;
 /**
  * Test the combination of the @Retry and @Timeout annotations.
  *
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  *
  */
-public class RetryTimeoutTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class RetryTimeoutTest {
 
     private @Inject RetryTimeoutClient clientForRetryTimeout;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTimeoutTest.java
@@ -33,14 +33,14 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 /**
  * Test the combination of the @Retry and @Timeout annotations.
- * 
+ *
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  *
  */
 public class RetryTimeoutTest extends Arquillian {
 
     private @Inject RetryTimeoutClient clientForRetryTimeout;
-    
+
     @Deployment
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
@@ -52,52 +52,52 @@ public class RetryTimeoutTest extends Arquillian {
         WebArchive war = ShrinkWrap
                 .create(WebArchive.class, "ftRetryTimeout.war")
                 .addAsLibrary(testJar);
-        return war;
+        return TckAdditions.decorate(war);
     }
-   
+
     /**
      * Test that a Service is retried the expected number of times.
-     * 
+     *
      * A timeout is configured for serviceA and in this case the service should generate Timeout exceptions.
-     * 
+     *
      * The service should be retried.
      */
     @Test
     public void testRetryTimeout() {
         try {
             String result = clientForRetryTimeout.serviceA(1000);
-        } 
+        }
         catch (TimeoutException ex) {
             // Expected
-        } 
+        }
         catch (RuntimeException ex) {
             // Not Expected
             Assert.fail("serviceA should not throw a RuntimeException in testRetryTimeout");
         }
-        
+
         Assert.assertEquals(clientForRetryTimeout.getCounterForInvokingServiceA(), 2, "The execution count should be 2 (1 retry + 1)");
     }
-    
+
     /**
      * Test that a Service is retried the expected number of times.
-     * 
+     *
      * A timeout is configured for serviceA but the service should fail before the timeout is reached
-     * and generate a RuntimeException.  
-     * 
+     * and generate a RuntimeException.
+     *
      * The service should be retried.
      */
     @Test
     public void testRetryNoTimeout() {
         try {
             String result = clientForRetryTimeout.serviceA(10);
-        } 
+        }
         catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceA should not throw a TimeoutException in testRetrytNoTimeout");
-        } 
+        }
         catch (RuntimeException ex) {
             // Expected
-        }        
+        }
 
         Assert.assertEquals(clientForRetryTimeout.getCounterForInvokingServiceA(), 2, "The execution count should be 2 (1 retry + 1)");
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TckAdditions.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TckAdditions.java
@@ -1,0 +1,42 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck;
+
+import java.util.ServiceLoader;
+
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class TckAdditions {
+    private TckAdditions() {
+        // ignore
+    }
+
+    /**
+     * Loads via {@link ServiceLoader} additional archive producers. Delegate to each of them the addition of an archive
+     * to the @{@link org.jboss.arquillian.container.test.api.Deployment} under test.
+     * @param web the Arquillian {@link WebArchive} to enhance with additional libraries
+     * @return the modified {@link WebArchive}
+     */
+    public static WebArchive decorate(WebArchive web) {
+        ServiceLoader<TckArchiveProvider> providers = ServiceLoader.load(TckArchiveProvider.class);
+        providers.forEach(p -> web.addAsLibrary(p.additional()));
+        return web;
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TckArchiveProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TckArchiveProvider.java
@@ -1,0 +1,31 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck;
+
+import org.jboss.shrinkwrap.api.Archive;
+
+/**
+ * Simple producer to provide additional archive to be included in tck webapp tests.
+ * Producers implementing this interface will be called via {@link java.util.ServiceLoader} during initialization
+ * of Arquillian tests to be integrated into the @{@link org.jboss.arquillian.container.test.api.Deployment} under test.
+ */
+public interface TckArchiveProvider {
+    Archive<?> additional();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutTest.java
@@ -26,13 +26,14 @@ import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.Shorter
 import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.TimeoutClient;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testng.Assert;
-import org.testng.annotations.Test;
 
 /**
  * Tests to exercise Fault Tolerance Timeouts.
@@ -40,7 +41,8 @@ import org.testng.annotations.Test;
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
  *
  */
-public class TimeoutTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class TimeoutTest {
 
     private @Inject TimeoutClient clientForTimeout;
     private @Inject DefaultTimeoutClient clientForDefaultTimeout;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutTest.java
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
 
 /**
  * Tests to exercise Fault Tolerance Timeouts.
- * 
+ *
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
  *
  */
@@ -54,24 +54,24 @@ public class TimeoutTest extends Arquillian {
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftTimeout.war").addAsLibrary(testJar);
-        return war;
+        return TckAdditions.decorate(war);
     }
 
     /**
      * A test to exercise the default timeout. The default Fault Tolerance
      * timeout is 1 second but serviceA will attempt to sleep for 20 seconds, so
      * should throw a TimeoutException.
-     * 
+     *
      */
     @Test
     public void testTimeout() {
         try {
             clientForTimeout.serviceA(20000);
             Assert.fail("serviceA should throw a TimeoutException in testTimeout");
-        } 
+        }
         catch (TimeoutException ex) {
             // Expected
-        } 
+        }
         catch (RuntimeException ex) {
             // Not Expected
             Assert.fail("serviceA should throw a TimeoutException in testTimeout not a RuntimeException");
@@ -82,25 +82,25 @@ public class TimeoutTest extends Arquillian {
      * A test that should not time out. The default Fault Tolerance timeout is 1
      * second but serviceA will attempt to sleep for only 10 milliseconds before
      * throwing a RuntimeException. There should be no Timeout.
-     * 
+     *
      */
     @Test
     public void testNoTimeout() {
         try {
             clientForTimeout.serviceA(10);
             Assert.fail("serviceB should throw a RuntimeException in testNoTimeout");
-        } 
+        }
         catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceB should throw a RuntimeException in testNoTimeout not a TimeoutException");
-        } 
+        }
         catch (RuntimeException ex) {
             // Expected
         }
     }
-    
+
     /**
-     * A test that should time out. The Fault Tolerance timeout is set to a (non-default) 2 seconds but serviceB 
+     * A test that should time out. The Fault Tolerance timeout is set to a (non-default) 2 seconds but serviceB
      * will attempt to sleep for 2.5 seconds - so longer than a  default timeout.
      */
     @Test
@@ -108,40 +108,40 @@ public class TimeoutTest extends Arquillian {
         try {
             clientForTimeout.serviceB(2500);
             Assert.fail("serviceB should throw a TimeoutException in testGTDefaultTimeout");
-        } 
+        }
         catch (TimeoutException ex) {
             // Expected
-        } 
+        }
         catch (RuntimeException ex) {
             // Not Expected
             Assert.fail("serviceB should throw a TimeoutException in testGTDefaultTimeout not a RuntimeException");
         }
     }
-    
+
     /**
      * A test that should not time out. The Fault Tolerance timeout is set to 2
      * seconds but serviceB will attempt to sleep for 1.5 seconds - so longer than a  default
-     * timeout but shorter than the timeout that has been configured, before throwing a 
+     * timeout but shorter than the timeout that has been configured, before throwing a
      * RuntimeException. There should be no Timeout.
-     * 
+     *
      */
     @Test
     public void testGTDefaultNoTimeout() {
         try {
             clientForTimeout.serviceB(1500);
             Assert.fail("serviceB should throw a RuntimeException in testGTDefaultNoTimeout");
-        } 
+        }
         catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceB should throw a RuntimeException in testGTDefaultNoTimeout not a TimeoutException");
-        } 
+        }
         catch (RuntimeException ex) {
             // Expected
         }
     }
-    
+
     /**
-     * A test that should time out. The Fault Tolerance timeout is set to a (non-default) 0.5 seconds but serviceC 
+     * A test that should time out. The Fault Tolerance timeout is set to a (non-default) 0.5 seconds but serviceC
      * will attempt to sleep for 1 second - so longer than a  default timeout.
      */
     @Test
@@ -149,39 +149,39 @@ public class TimeoutTest extends Arquillian {
         try {
             clientForTimeout.serviceC(1000);
             Assert.fail("serviceC should throw a TimeoutException in testLTDefaultTimeout");
-        } 
+        }
         catch (TimeoutException ex) {
             // Expected
-        } 
+        }
         catch (RuntimeException ex) {
             // Not Expected
             Assert.fail("serviceC should throw a TimeoutException in testLTDefaultTimeout not a RuntimeException");
         }
     }
-    
+
     /**
      * A test that should not time out. The Fault Tolerance timeout is set to a (non-default) 0.5
      * seconds but serviceC will attempt to sleep for only 10 milliseconds before
      * throwing a RuntimeException. There should be no Timeout.
-     * 
+     *
      */
     @Test
     public void testLTDefaultNoTimeout() {
         try {
             clientForTimeout.serviceC(10);
             Assert.fail("serviceC should throw a RuntimeException in testLTDefaultNoTimeout");
-        } 
+        }
         catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceC should throw a RuntimeException in testLTDefaultNoTimeout not a TimeoutException");
-        } 
+        }
         catch (RuntimeException ex) {
             // Expected
         }
     }
-    
+
     /**
-     * A test that should time out. The Fault Tolerance timeout is set to a (non-default) 2 seconds but serviceD 
+     * A test that should time out. The Fault Tolerance timeout is set to a (non-default) 2 seconds but serviceD
      * will attempt to sleep for 2.5 seconds - so longer than a  default timeout. serviceD specifies its timeout
      * in Seconds rather than milliseconds.
      */
@@ -190,53 +190,53 @@ public class TimeoutTest extends Arquillian {
         try {
             clientForTimeout.serviceD(2500);
             Assert.fail("serviceD should throw a TimeoutException in testSecondsTimeout");
-        } 
+        }
         catch (TimeoutException ex) {
             // Expected
-        } 
+        }
         catch (RuntimeException ex) {
             // Not Expected
             Assert.fail("serviceD should throw a TimeoutException in testSecondsTimeout not a RuntimeException");
         }
     }
-    
+
     /**
      * A test that should not time out. The Fault Tolerance timeout is set to 2
      * seconds but serviceD will attempt to sleep for 1.5 seconds - so longer than a  default
-     * timeout but shorter than the timeout that has been configured, before throwing a 
+     * timeout but shorter than the timeout that has been configured, before throwing a
      * RuntimeException. There should be no Timeout.
-     * 
+     *
      */
     @Test
     public void testSecondsNoTimeout() {
         try {
             clientForTimeout.serviceD(1500);
             Assert.fail("serviceD should throw a RuntimeException in testSecondsNoTimeout");
-        } 
+        }
         catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceD should throw a RuntimeException in testSecondsNoTimeout not a TimeoutException");
-        } 
+        }
         catch (RuntimeException ex) {
             // Expected
         }
     }
-    
+
     /**
      * A parallel test to testTimeout with class level annotation. The default Fault Tolerance
      * timeout is 1 second but serviceA will attempt to sleep for 20 seconds, so
      * should throw a TimeoutException.
-     * 
+     *
      */
     @Test
     public void testTimeoutClassLevel() {
         try {
             clientForDefaultTimeout.serviceA(20000);
             Assert.fail("serviceA should throw a TimeoutException in testTimeout");
-        } 
+        }
         catch (TimeoutException ex) {
             // Expected
-        } 
+        }
         catch (RuntimeException ex) {
             // Not Expected
             Assert.fail("serviceA should throw a TimeoutException in testTimeout not a RuntimeException");
@@ -244,29 +244,29 @@ public class TimeoutTest extends Arquillian {
     }
 
     /**
-     * A parallel test to testNoTimeout with class level annotation. The default Fault 
-     * Tolerance timeout is 1 second but serviceA will attempt to sleep for only 10 milliseconds 
+     * A parallel test to testNoTimeout with class level annotation. The default Fault
+     * Tolerance timeout is 1 second but serviceA will attempt to sleep for only 10 milliseconds
      * before throwing a RuntimeException. There should be no Timeout.
-     * 
+     *
      */
     @Test
     public void testNoTimeoutClassLevel() {
         try {
             clientForDefaultTimeout.serviceA(10);
             Assert.fail("serviceB should throw a RuntimeException in testNoTimeoutClassLevel");
-        } 
+        }
         catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceB should throw a RuntimeException in testNoTimeoutClassLevel not a TimeoutException");
-        } 
+        }
         catch (RuntimeException ex) {
             // Expected
         }
     }
-    
+
     /**
-     * A parallel test to testGTDefaultTimeout where the method level Timeout annotation overrides 
-     * the class level annotation. The Fault Tolerance timeout is set to a (non-default) 2 seconds but 
+     * A parallel test to testGTDefaultTimeout where the method level Timeout annotation overrides
+     * the class level annotation. The Fault Tolerance timeout is set to a (non-default) 2 seconds but
      * serviceB will attempt to sleep for 2.5 seconds - so longer than a  default timeout.
      */
     @Test
@@ -274,20 +274,20 @@ public class TimeoutTest extends Arquillian {
         try {
             clientForDefaultTimeout.serviceB(2500);
             Assert.fail("serviceB should throw a TimeoutException in testGTDefaultTimeout");
-        } 
+        }
         catch (TimeoutException ex) {
             // Expected
-        } 
+        }
         catch (RuntimeException ex) {
             // Not Expected
             Assert.fail("serviceB should throw a TimeoutException in testGTDefaultTimeout not a RuntimeException");
         }
     }
-    
+
     /**
-     * A parallel test to testGTDefaultNoTimeout where the method level Timeout annotation overrides 
-     * the class level annotation. The Fault Tolerance timeout is set to 2 seconds but serviceB will attempt 
-     * to sleep for 1.5 seconds - so longer than a  default timeout but shorter than the timeout that has been 
+     * A parallel test to testGTDefaultNoTimeout where the method level Timeout annotation overrides
+     * the class level annotation. The Fault Tolerance timeout is set to 2 seconds but serviceB will attempt
+     * to sleep for 1.5 seconds - so longer than a  default timeout but shorter than the timeout that has been
      * configured, before throwing a RuntimeException. There should be no Timeout.
      */
     @Test
@@ -295,18 +295,18 @@ public class TimeoutTest extends Arquillian {
         try {
             clientForDefaultTimeout.serviceB(1500);
             Assert.fail("serviceB should throw a RuntimeException in testGTDefaultNoTimeout");
-        } 
+        }
         catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceB should throw a RuntimeException in testGTDefaultNoTimeout not a TimeoutException");
-        } 
+        }
         catch (RuntimeException ex) {
             // Expected
         }
     }
-    
+
     /**
-     * A parallel test to testLTDefaultTimeout with class level annotation. The Fault Tolerance timeout is set 
+     * A parallel test to testLTDefaultTimeout with class level annotation. The Fault Tolerance timeout is set
      * to a (non-default) 0.5 seconds but serviceA will attempt to sleep for 1 second - so longer than a  default timeout.
      */
     @Test
@@ -314,19 +314,19 @@ public class TimeoutTest extends Arquillian {
         try {
             clientForShorterTimeout.serviceA(1000);
             Assert.fail("serviceA should throw a TimeoutException in testLTDefaultTimeoutClassLevel");
-        } 
+        }
         catch (TimeoutException ex) {
             // Expected
-        } 
+        }
         catch (RuntimeException ex) {
             // Not Expected
             Assert.fail("serviceA should throw a TimeoutException in testLTDefaultTimeoutClassLevel not a RuntimeException");
         }
     }
-    
+
     /**
-     * A parallel test to testLTDefaultNoTimeout with class level annotation. The Fault Tolerance timeout is set 
-     * to a (non-default) 0.5 seconds but serviceC will attempt to sleep for only 10 milliseconds before throwing a 
+     * A parallel test to testLTDefaultNoTimeout with class level annotation. The Fault Tolerance timeout is set
+     * to a (non-default) 0.5 seconds but serviceC will attempt to sleep for only 10 milliseconds before throwing a
      * RuntimeException. There should be no Timeout.
      */
     @Test
@@ -334,19 +334,19 @@ public class TimeoutTest extends Arquillian {
         try {
             clientForShorterTimeout.serviceA(10);
             Assert.fail("serviceA should throw a RuntimeException in testLTDefaultNoTimeoutClassLevel");
-        } 
+        }
         catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceA should throw a RuntimeException in testLTDefaultNoTimeoutClassLevel not a TimeoutException");
-        } 
+        }
         catch (RuntimeException ex) {
             // Expected
         }
     }
 
     /**
-     * A parallel test to testGTDefaultTimeout where the method level Timeout annotation overrides 
-     * the class level annotation. The Fault Tolerance timeout is set to a (non-default) 2 seconds but 
+     * A parallel test to testGTDefaultTimeout where the method level Timeout annotation overrides
+     * the class level annotation. The Fault Tolerance timeout is set to a (non-default) 2 seconds but
      * serviceB will attempt to sleep for 2.5 seconds - so longer than a  default timeout.
      */
     @Test
@@ -354,20 +354,20 @@ public class TimeoutTest extends Arquillian {
         try {
             clientForShorterTimeout.serviceB(2500);
             Assert.fail("serviceB should throw a TimeoutException in testGTShorterTimeoutOverride");
-        } 
+        }
         catch (TimeoutException ex) {
             // Expected
-        } 
+        }
         catch (RuntimeException ex) {
             // Not Expected
             Assert.fail("serviceB should throw a TimeoutException in testGTShorterTimeoutOverride not a RuntimeException");
         }
     }
-    
+
     /**
-     * A parallel test to testGTDefaultNoTimeout where the method level Timeout annotation overrides 
-     * the class level annotation. The Fault Tolerance timeout is set to 2 seconds but serviceB will attempt 
-     * to sleep for 1.5 seconds - so longer than a  default timeout but shorter than the timeout that has been 
+     * A parallel test to testGTDefaultNoTimeout where the method level Timeout annotation overrides
+     * the class level annotation. The Fault Tolerance timeout is set to 2 seconds but serviceB will attempt
+     * to sleep for 1.5 seconds - so longer than a  default timeout but shorter than the timeout that has been
      * configured, before throwing a RuntimeException. There should be no Timeout.
      */
     @Test
@@ -375,14 +375,14 @@ public class TimeoutTest extends Arquillian {
         try {
             clientForShorterTimeout.serviceB(1500);
             Assert.fail("serviceB should throw a RuntimeException in testGTShorterNoTimeoutOverride");
-        } 
+        }
         catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceB should throw a RuntimeException in testGTShorterNoTimeoutOverride not a TimeoutException");
-        } 
+        }
         catch (RuntimeException ex) {
             // Expected
         }
     }
-    
+
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchRetryTest.java
@@ -30,15 +30,14 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhe
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.TestData;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testng.Assert;
-import org.testng.ITestContext;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 
 /**
  * @author Gordon Hutchison
@@ -52,7 +51,8 @@ import org.testng.annotations.Test;
  * @author Gordon Hutchison
  *
  */
-public class BulkheadAsynchRetryTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class BulkheadAsynchRetryTest {
 
     /*
      * As the FaultTolerance annotation only works on business methods of
@@ -77,7 +77,7 @@ public class BulkheadAsynchRetryTest extends Arquillian {
     /**
      * This is the Arquillian deploy method that controls the contents of the
      * war that contains all the tests.
-     * 
+     *
      * @return the test war "ftBulkheadAsynchTest.war"
      */
     @Deployment
@@ -87,11 +87,6 @@ public class BulkheadAsynchRetryTest extends Arquillian {
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftBulkheadAsynchRetryTest.war").addAsLibrary(testJar);
         return war;
-    }
-
-    @BeforeTest
-    public void beforeTest(final ITestContext testContext) {
-        Utils.log("Testmethod: " + testContext.getName());
     }
 
     /**
@@ -128,7 +123,7 @@ public class BulkheadAsynchRetryTest extends Arquillian {
      * a method level test. The bean here does not delay its retries so there is
      * not enough time for the first generation of workers and queued workers to
      * progress.
-     * 
+     *
      * @throws InterruptedException when interrupted
      */
     @Test()
@@ -157,7 +152,7 @@ public class BulkheadAsynchRetryTest extends Arquillian {
     /**
      * Tests overloading the Retries by firing lots of work at a full Method
      * bulkhead
-     * 
+     *
      * @throws InterruptedException when interrupted
      */
     @Test()
@@ -179,7 +174,7 @@ public class BulkheadAsynchRetryTest extends Arquillian {
     }
 
     /**
-     * 
+     *
      * Tests overloading the Retries by firing lots of work at a full Class
      * bulkhead
      */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchTest.java
@@ -36,21 +36,21 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhe
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Checker;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.TestData;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testng.Assert;
-import org.testng.ITestContext;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 
 /**
  * @author Gordon Hutchison
  */
 
-public class BulkheadAsynchTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class BulkheadAsynchTest {
 
     /*
      * As the FaultTolerance annotation only work on business methods of
@@ -80,7 +80,7 @@ public class BulkheadAsynchTest extends Arquillian {
     /**
      * This is the Arquillian deploy method that controls the contents of the
      * war that contains all the tests.
-     * 
+     *
      * @return the test war "ftBulkheadAsynchTest.war"
      */
     @Deployment
@@ -90,11 +90,6 @@ public class BulkheadAsynchTest extends Arquillian {
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftBulkheadAsynchTest.war").addAsLibrary(testJar);
         return war;
-    }
-
-    @BeforeTest
-    public void beforeTest(final ITestContext testContext) {
-        Utils.log("Testmethod: " + testContext.getName());
     }
 
     /**
@@ -197,7 +192,7 @@ public class BulkheadAsynchTest extends Arquillian {
      * Run a number of Callable's (usually Asynch's) in a loop on one thread.
      * Here we do not check that amount that were successfully through the
      * Bulkhead
-     * 
+     *
      * @param loops
      * @param test
      * @param maxSimultaneousWorkers

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
@@ -29,24 +29,24 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhe
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Checker;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.FutureChecker;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testng.Assert;
-import org.testng.ITestContext;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 
 /**
  * This set of tests will test correct operation on the relevant methods of the
  * Future object that is returned from the business method of a Asynchronous
  * Method or Class.
- * 
+ *
  * @author Gordon Hutchison
  */
-public class BulkheadFutureTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class BulkheadFutureTest {
 
     private static final int SHORT_TIME = 100;
     private static final int LONG_TIME = 3000;
@@ -62,11 +62,6 @@ public class BulkheadFutureTest extends Arquillian {
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftBulkheadTest.war").addAsLibrary(testJar);
         return war;
-    }
-
-    @BeforeTest
-    public void beforeTest(final ITestContext testContext) {
-        Utils.log("Testmethod: " + testContext.getName());
     }
 
     /**
@@ -124,7 +119,7 @@ public class BulkheadFutureTest extends Arquillian {
         }
         Assert.assertTrue(result.isDone(), "Future done not reporting true");
     }
-  
+
     /**
      * Tests that the Future that is returned from a asynchronous bulkhead can
      * be queried for Done OK after a goodpath get with timeout and also

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
@@ -37,14 +37,13 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Checke
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.ParrallelBulkheadTest;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.TestData;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.ITestContext;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * This collection of tests tests that failures, particularly Synchronous
@@ -54,7 +53,8 @@ import org.testng.annotations.Test;
  * @author Gordon Hutchison
  *
  */
-public class BulkheadSynchRetryTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class BulkheadSynchRetryTest {
 
     private static final int DONT_CHECK = 0;
     /*
@@ -87,7 +87,7 @@ public class BulkheadSynchRetryTest extends Arquillian {
     /**
      * This is the Arquillian deploy method that controls the contents of the
      * war that contains all the tests.
-     * 
+     *
      * @return the test war "ftBulkheadSynchRetryTest.war"
      */
     @Deployment
@@ -97,11 +97,6 @@ public class BulkheadSynchRetryTest extends Arquillian {
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftBulkheadSynchRetryTest.war").addAsLibrary(testJar);
         return war;
-    }
-
-    @BeforeTest
-    public void beforeTest(final ITestContext testContext) {
-        Utils.log("Testmethod: " + testContext.getName());
     }
 
     /**
@@ -245,7 +240,7 @@ public class BulkheadSynchRetryTest extends Arquillian {
 
     /**
      * Run a number of Callable's in parallel
-     * 
+     *
      * @param number
      * @param test
      * @param maxSimultaneousWorkers

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchTest.java
@@ -33,24 +33,24 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhe
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadMethodSemaphore3Bean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadMethodSemaphoreDefaultBean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
-
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.ParrallelBulkheadTest;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.TestData;
 import org.jboss.arquillian.container.test.api.Deployment;
-//import org.jboss.arquillian.core.api.Asynchronousing.ExecutorService;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.ITestContext;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+//import org.jboss.arquillian.core.api.Asynchronousing.ExecutorService;
 
 /**
  * @author Gordon Hutchison
  */
-public class BulkheadSynchTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class BulkheadSynchTest {
 
     /*
      * We use an executer service to simulate the parallelism of multiple
@@ -82,7 +82,7 @@ public class BulkheadSynchTest extends Arquillian {
     /**
      * This is the Arquillian deploy method that controls the contents of the
      * war that contains all the tests.
-     * 
+     *
      * @return the test war "ftBulkheadSynchTest.war"
      */
     @Deployment
@@ -92,11 +92,6 @@ public class BulkheadSynchTest extends Arquillian {
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftBulkheadSynchTest.war").addAsLibrary(testJar);
         return war;
-    }
-
-    @BeforeTest
-    public void beforeTest(final ITestContext testContext) {
-        Utils.log("Testmethod: " + testContext.getName());
     }
 
     /**
@@ -129,7 +124,7 @@ public class BulkheadSynchTest extends Arquillian {
      * Tests the method synchronous Bulkhead10. This test will check that 10 and
      * no more than 10 parallel synchronous calls are allowed into a method that
      * has an individual
-     * 
+     *
      * {@code @Bulkhead(10)} annotation
      */
     @Test()
@@ -182,7 +177,7 @@ public class BulkheadSynchTest extends Arquillian {
 
     /**
      * Run a number of Callable's in parallel
-     * 
+     *
      * @param number
      * @param test
      * @param maxSimultaneousWorkers

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableTest.java
@@ -24,29 +24,31 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.StringFallbackHandler;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.testng.Assert;
-import org.testng.annotations.Test;
 
 /**
  * Test the impact of the MP_Fault_Tolerance_NonFallback_Enabled environment variable.
- * 
+ *
  * The test assumes that the container supports both the MicroProfile Configuration API and the MicroProfile
- * Fault Tolerance API. The MP_Fault_Tolerance_NonFallback_Enabled Variable is set to "false" in the manifest 
+ * Fault Tolerance API. The MP_Fault_Tolerance_NonFallback_Enabled Variable is set to "false" in the manifest
  * of the deployed application.
- * 
+ *
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
  *
  */
-public class DisableTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class DisableTest {
 
     private @Inject DisableClient disableClient;
-    
+
     @Deployment
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
@@ -62,11 +64,11 @@ public class DisableTest extends Arquillian {
                 .addAsLibrary(testJar);
         return war;
     }
-    
+
     /**
-     * Test maxRetries on @Retry. 
-     * 
-     * ServiceA is annotated with maxRetries = 1 so serviceA is expected to execute 2 times but if MP_Fault_Tolerance_NonFallback_Enabled 
+     * Test maxRetries on @Retry.
+     *
+     * ServiceA is annotated with maxRetries = 1 so serviceA is expected to execute 2 times but if MP_Fault_Tolerance_NonFallback_Enabled
      * is set to false in the Container environment, then no retries should be attempted.
      */
     @Test
@@ -83,8 +85,8 @@ public class DisableTest extends Arquillian {
 
     /**
      * Test that a Fallback service is driven when a Service fails.
-     *  
-     * ServiceB is annotated with maxRetries = 1 so serviceB is expected to execute 2 times but if MP_Fault_Tolerance_NonFallback_Enabled 
+     *
+     * ServiceB is annotated with maxRetries = 1 so serviceB is expected to execute 2 times but if MP_Fault_Tolerance_NonFallback_Enabled
      * is set to false in the Container environment, then no retries should be attempted HOWEVER the Fallback should still be driven
      * successfully, so the test checks that a Fallback was driven after serviceB fails.
      */
@@ -103,11 +105,11 @@ public class DisableTest extends Arquillian {
         Assert.assertEquals(disableClient.getCounterForInvokingServiceB(), 1, "The execution count should be 1 (0 retries + 1)");
 
     }
-    
+
     /**
      * A test to exercise Circuit Breaker thresholds, with a default SuccessThreshold
-     * 
-     * If MP_Fault_Tolerance_NonFallback_Enabled is set to false in the Container environment, then the CircuitBreaker 
+     *
+     * If MP_Fault_Tolerance_NonFallback_Enabled is set to false in the Container environment, then the CircuitBreaker
      * will not operate, no CircuitBreakerOpenExceptions will be thrown and execution will fail 7 times.
      */
     @Test
@@ -122,7 +124,7 @@ public class DisableTest extends Arquillian {
             }
             catch (Exception ex) {
                 // Not Expected
-                Assert.fail("serviceC should throw a RuntimeException in testCircuitClosedThenOpen on iteration " + i + 
+                Assert.fail("serviceC should throw a RuntimeException in testCircuitClosedThenOpen on iteration " + i +
                                 " but caught exception " + ex);
             }
         }
@@ -130,27 +132,27 @@ public class DisableTest extends Arquillian {
 
         Assert.assertEquals(serviceCExecutions, 7, "The number of executions should be 7");
     }
-    
+
     /**
-     * A test to exercise the default timeout. 
-     * 
+     * A test to exercise the default timeout.
+     *
      * In normal operation, the default Fault Tolerance timeout is 1 second but serviceD will attempt to sleep for 3 seconds, so
-     * would be expected to throw a TimeoutException. However, if MP_Fault_Tolerance_NonFallback_Enabled is set to false in the Container 
+     * would be expected to throw a TimeoutException. However, if MP_Fault_Tolerance_NonFallback_Enabled is set to false in the Container
      * environment, then no Timeout will occur and a RuntimeException will be thrown after 3 seconds.
-     * 
+     *
      */
     @Test
     public void testTimeout() {
         try {
             disableClient.serviceD(3000);
             Assert.fail("serviceD should throw a TimeoutException in testTimeout");
-        } 
+        }
         catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceD should throw a RuntimeException in testTimeout not a TimeoutException");
-        } 
+        }
         catch (RuntimeException ex) {
-            // Expected       
+            // Expected
         }
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodTest.java
@@ -24,14 +24,16 @@ import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-public class IncompatibleFallbackMethodTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class IncompatibleFallbackMethodTest {
     private
     @Inject
     FallbackMethodClient fallbackMethodClient;
@@ -53,12 +55,12 @@ public class IncompatibleFallbackMethodTest extends Arquillian {
 
     /**
      * Test that the deployment of a FallbackHandler with an invalid Fallback Method leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with the IncompatibleFallbackMethodHandler. While the Service returns an
      * Integer, the IncompatibleFallbackMethodHandler's Fallback Method returns a String.
      */
     @Test
     public void test() {
-       
+
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodWithArgsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodWithArgsTest.java
@@ -24,14 +24,16 @@ import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-public class IncompatibleFallbackMethodWithArgsTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class IncompatibleFallbackMethodWithArgsTest {
     private
     @Inject
     FallbackMethodWithArgsClient fallbackMethodClient;
@@ -53,7 +55,7 @@ public class IncompatibleFallbackMethodWithArgsTest extends Arquillian {
 
     /**
      * Test that the deployment of a FallbackHandler with an invalid Fallback Method leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with the IncompatibleFallbackMethodHandler. While the Service returns an
      * Integer, the IncompatibleFallbackMethodHandler's Fallback Method returns a String.
      */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackPolicies.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackPolicies.java
@@ -24,14 +24,16 @@ import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-public class IncompatibleFallbackPolicies extends Arquillian {
+@RunWith(Arquillian.class)
+public class IncompatibleFallbackPolicies {
     private
     @Inject
     FallbackClient fallbackClient;
@@ -52,9 +54,9 @@ public class IncompatibleFallbackPolicies extends Arquillian {
 
     /**
      * Test that the deployment of specifying both handler and fallback method causing deployment failure.
-     * 
-     * A service in FallbackClientWithBothFallbacks has specified both fallback handler and fallback method. 
-     * 
+     *
+     * A service in FallbackClientWithBothFallbacks has specified both fallback handler and fallback method.
+     *
      */
     @Test
     public void test() {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackTest.java
@@ -24,14 +24,16 @@ import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.Test;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-public class IncompatibleFallbackTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class IncompatibleFallbackTest {
     private
     @Inject
     FallbackClient fallbackClient;
@@ -52,7 +54,7 @@ public class IncompatibleFallbackTest extends Arquillian {
 
     /**
      * Test that the deployment of an invalid FallbackHandler leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with the IncompatibleFallbackHandler. While the Service returns an
      * Integer, the IncompatibleFallbackHandler returns a String.
      */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadAsynchQueueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadAsynchQueueTest.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidBulkheadAsynchQueueTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidBulkheadAsynchQueueTest {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -45,10 +47,10 @@ public class InvalidBulkheadAsynchQueueTest extends Arquillian {
             .create(WebArchive.class, "ftInvalidBulkhead3.war")
             .addAsLibrary(testJar);
     }
-    
+
     /**
      * Test that the deployment of an invalid @Bulkhead parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Bulkhead annotation with a negative waitingTaskQueue attribute.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadValueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadValueTest.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidBulkheadValueTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidBulkheadValueTest {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -45,10 +47,10 @@ public class InvalidBulkheadValueTest extends Arquillian {
             .create(WebArchive.class, "ftInvalidBulkhead1.war")
             .addAsLibrary(testJar);
     }
-    
+
     /**
      * Test that the deployment of an invalid @Bulkhead parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Bulkhead annotation with a negative value.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerDelayTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerDelayTest.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidCircuitBreakerDelayTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidCircuitBreakerDelayTest {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -47,7 +49,7 @@ public class InvalidCircuitBreakerDelayTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a negative delay.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioNegTest.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidCircuitBreakerFailureRatioNegTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidCircuitBreakerFailureRatioNegTest {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -47,7 +49,7 @@ public class InvalidCircuitBreakerFailureRatioNegTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a negative failureRatio.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioPosTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioPosTest.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidCircuitBreakerFailureRatioPosTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidCircuitBreakerFailureRatioPosTest {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -47,7 +49,7 @@ public class InvalidCircuitBreakerFailureRatioPosTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a failureRatio greater than 1.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVol0Test.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVol0Test.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidCircuitBreakerFailureReqVol0Test extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidCircuitBreakerFailureReqVol0Test {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -47,7 +49,7 @@ public class InvalidCircuitBreakerFailureReqVol0Test extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a requestVolumeThreshold of 0.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVolNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVolNegTest.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidCircuitBreakerFailureReqVolNegTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidCircuitBreakerFailureReqVolNegTest {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -47,7 +49,7 @@ public class InvalidCircuitBreakerFailureReqVolNegTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a negative requestVolumeThreshold.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccess0Test.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccess0Test.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidCircuitBreakerFailureSuccess0Test extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidCircuitBreakerFailureSuccess0Test {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -47,7 +49,7 @@ public class InvalidCircuitBreakerFailureSuccess0Test extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a successThreshold of 0.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccessNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccessNegTest.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidCircuitBreakerFailureSuccessNegTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidCircuitBreakerFailureSuccessNegTest {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -47,7 +49,7 @@ public class InvalidCircuitBreakerFailureSuccessNegTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @CircuitBreaker parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @CircuitBreaker annotation with a negative successThreshold.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayDurationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayDurationTest.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidRetryDelayDurationTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidRetryDelayDurationTest {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -45,10 +47,10 @@ public class InvalidRetryDelayDurationTest extends Arquillian {
             .create(WebArchive.class, "ftInvalidRetry3.war")
             .addAsLibrary(testJar);
     }
-    
+
     /**
      * Test that the deployment of an invalid @Retry parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Retry annotation with a maxDuration that is less than the delay.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayTest.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidRetryDelayTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidRetryDelayTest {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -47,7 +49,7 @@ public class InvalidRetryDelayTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @Retry parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Retry annotation with a negative delay.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryJitterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryJitterTest.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidRetryJitterTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidRetryJitterTest {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -47,7 +49,7 @@ public class InvalidRetryJitterTest extends Arquillian {
     }
     /**
      * Test that the deployment of an invalid @Retry parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Retry annotation with a negative jitter.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryMaxRetriesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryMaxRetriesTest.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidRetryMaxRetriesTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidRetryMaxRetriesTest {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -45,10 +47,10 @@ public class InvalidRetryMaxRetriesTest extends Arquillian {
             .create(WebArchive.class, "ftInvalidRetry2.war")
             .addAsLibrary(testJar);
     }
-    
+
     /**
      * Test that the deployment of an invalid @Retry parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Retry annotation with a negative maxRetries.
      */
     @Test

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidTimeoutValueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidTimeoutValueTest.java
@@ -20,17 +20,19 @@
 package org.eclipse.microprofile.fault.tolerance.tck.invalidParameters;
 
 import javax.enterprise.inject.spi.DefinitionException;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.ShouldThrowException;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import org.testng.annotations.Test;
-
-public class InvalidTimeoutValueTest extends Arquillian {
+@RunWith(Arquillian.class)
+public class InvalidTimeoutValueTest {
 
     @Deployment
     @ShouldThrowException(DefinitionException.class)
@@ -45,10 +47,10 @@ public class InvalidTimeoutValueTest extends Arquillian {
             .create(WebArchive.class, "ftInvalidTimeout.war")
             .addAsLibrary(testJar);
     }
-    
+
     /**
      * Test that the deployment of an invalid @Timeout parameter leads to a DeploymentException.
-     * 
+     *
      * A Service is annotated with a @Timeout annotation with a negative value.
      */
     @Test

--- a/tck/src/main/java/org/testng/ArquillianTestNGArchiveProvider.java
+++ b/tck/src/main/java/org/testng/ArquillianTestNGArchiveProvider.java
@@ -17,19 +17,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-package org.eclipse.microprofile.fault.tolerance.tck;
+package org.testng;
 
+import org.eclipse.microprofile.fault.tolerance.tck.TckArchiveProvider;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
 /**
- * Verify the asynchronous invocation
- *
- *
+ * Self provided TckArchiveProvider adding the wrapper org.testng.Assert class to artifact under test.
+ * This must be removed once full move to junit is done.
  */
-public class AsynchronousInvocation {
-
-    /**
-     * @Todo test the asynchronous behaviour
-     *
-     */
-
+public class ArquillianTestNGArchiveProvider implements TckArchiveProvider {
+    @Override
+    public Archive<?> additional() {
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class);
+        archive.addClass(Assert.class);
+        return archive;
+    }
 }

--- a/tck/src/main/java/org/testng/Assert.java
+++ b/tck/src/main/java/org/testng/Assert.java
@@ -35,7 +35,7 @@ public class Assert {
         org.junit.Assert.fail(message);
     }
 
-    public static void assertEquals(int expected, int actual, String message) {
+    public static void assertEquals(int actual, int expected, String message) {
         org.junit.Assert.assertEquals(message, expected, actual);
     }
 

--- a/tck/src/main/java/org/testng/Assert.java
+++ b/tck/src/main/java/org/testng/Assert.java
@@ -17,19 +17,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-package org.eclipse.microprofile.fault.tolerance.tck;
-
+package org.testng;
 
 /**
- * Verify the asynchronous invocation
- *
- *
+ * @deprecated only for temporary switch to junit
  */
-public class AsynchronousInvocation {
+@Deprecated
+public class Assert {
+    private Assert() {
+        // ignore
+    }
+    public static void fail(String message) {
+        org.junit.Assert.fail(message);
+    }
 
-    /**
-     * @Todo test the asynchronous behaviour
-     *
-     */
+    public static void fail(String message, Throwable ignore) {
+        org.junit.Assert.fail(message);
+    }
 
+    public static void assertEquals(int expected, int actual, String message) {
+        org.junit.Assert.assertEquals(message, expected, actual);
+    }
+
+    public static void assertTrue(boolean condition, String message) {
+        org.junit.Assert.assertTrue(message, condition);
+    }
+
+    public static void assertFalse(boolean condition, String message) {
+        org.junit.Assert.assertFalse(message, condition);
+    }
+
+    public static void assertNull(Object o) {
+        org.junit.Assert.assertNull(o);
+    }
 }

--- a/tck/src/main/resources/META-INF/services/org.eclipse.microprofile.fault.tolerance.tck.TckArchiveProvider
+++ b/tck/src/main/resources/META-INF/services/org.eclipse.microprofile.fault.tolerance.tck.TckArchiveProvider
@@ -1,0 +1,1 @@
+org.testng.ArquillianTestNGArchiveProvider


### PR DESCRIPTION
As expressed in #165 I want to be able to run mpft tck (arquillian based) on a jee standard platform.

This PR introduces 2 changes allowing the tck to be run at least on wildfly:
- junit instead of testng
- extension point to ShrinkWrap web archives under tests in the tck

The extension point would allow third parties to enhance the archives under tests with additionnal stuff including, but not limited to, their implementation _(CDI extensions, interceptors, ...)_.

This PR is provided as a discussion entry point for the 2 topics above. The junit move, as provided in the PR, is only a transitional step. I didn't wanted upfront to reimplement fully the tests (without knowing if you would accept that) using junit so I created the `org.testng.Assert` facade class.

With this PR, you can run a demo project running tck on jee (wildfly) using arquillian: https://github.com/McFoggy/mpft-jee-tck.