### PR TITLE
make failureRatio work into requestVolumeThreshold consecutive window calls

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerTest.java
@@ -89,23 +89,26 @@ public class CircuitBreakerTest extends Arquillian {
      */
     @Test
     public void testCircuitClosedThenOpen() {
-        for (int i = 0; i < 7; i++) {
+        for (int i = 1; i < 8; i++) {
 
             try {
                 clientForCBWithDelay.serviceA();
 
-                if (i < 4) {
+                if (i < 5) {
                     Assert.fail("serviceA should throw an Exception in testCircuitClosedThenOpen on iteration " + i);
                 }
             }
             catch (CircuitBreakerOpenException cboe) {
-                // Expected on iteration 4
-                if (i < 4) {
+                // Expected on iteration 5
+                if (i < 5) {
                     Assert.fail("serviceA should throw a RuntimeException in testCircuitClosedThenOpen on iteration " + i);
                 }
             }
             catch (RuntimeException ex) {
                 // Expected
+                if (!contains(new int[]{1, 2, 3, 4}, i)) {
+                    Assert.fail("serviceA should not throw a RuntimeException on iteration " + i);
+                }
             }
             catch (Exception ex) {
                 // Not Expected
@@ -137,13 +140,11 @@ public class CircuitBreakerTest extends Arquillian {
      */
     @Test
     public void testCircuitReClose() {
-        for (int i = 0; i < 7; i++) {
+        for (int i = 1; i < 8; i++) {
             try {
-                // Pause to allow the circuit breaker to half-open on iteration
-                // 4
-                // This is conservative when the circuit breaker has a minimal
-                // delay.
-                if (i == 4) {
+                // Pause to allow the circuit breaker to half-open on iteration 5
+                // This is conservative when the circuit breaker has a minimal delay.
+                if (i == 5) {
                     try {
                         Thread.sleep(500);
                     }
@@ -152,7 +153,7 @@ public class CircuitBreakerTest extends Arquillian {
                     }
                 }
                 clientForCBNoDelay.serviceA();
-                if (i < 4) {
+                if (i < 5) {
                     Assert.fail("serviceA should throw an Exception in testCircuitReClose on iteration " + i);
                 }
             }
@@ -164,6 +165,9 @@ public class CircuitBreakerTest extends Arquillian {
             }
             catch (RuntimeException ex) {
                 // Expected
+                if (!contains(new int[]{1, 2, 3, 4}, i)) {
+                    Assert.fail("serviceA should not throw a RuntimeException on iteration " + i);
+                }
             }
             catch (Exception ex) {
                 // Not Expected
@@ -190,7 +194,7 @@ public class CircuitBreakerTest extends Arquillian {
      * 4         RunTimeException
      * 5         CircuitBreakerOpenException
      * Pause for longer than CircuitBreaker delay, so that it transitions to half-open
-     * 6         SUCCEED (CircuitBreaker will be re-closed as successThreshold is 2)
+     * 6         SUCCEED (CircuitBreaker will be re-closed as successThreshold is 1)
      * 7         RunTimeException
      * 8         RunTimeException
      * 9         RunTimeException
@@ -326,24 +330,27 @@ public class CircuitBreakerTest extends Arquillian {
      */
     @Test
     public void testClassLevelCircuitBase() {
-        for (int i = 0; i < 7; i++) {
+        for (int i = 1; i < 8; i++) {
 
             try {
                 clientForClassLevelCBWithDelay.serviceA();
 
-                if (i < 4) {
+                if (i < 5) {
                     Assert.fail("serviceA should throw an Exception in testClassLevelCircuitBase");
                 }
             }
             catch (CircuitBreakerOpenException cboe) {
-                // Expected on iteration 4
+                // Expected on iteration 5
 
-                if (i < 4) {
+                if (i < 5) {
                     Assert.fail("serviceA should throw a RuntimeException in testClassLevelCircuitBase on iteration " + i);
                 }
             }
             catch (RuntimeException ex) {
                 // Expected
+                if (!contains(new int[]{1, 2, 3, 4}, i)) {
+                    Assert.fail("serviceA should not throw a RuntimeException on iteration " + i);
+                }
             }
             catch (Exception ex) {
                 // Not Expected
@@ -375,22 +382,25 @@ public class CircuitBreakerTest extends Arquillian {
      */
     @Test
     public void testClassLevelCircuitOverride() {
-        for (int i = 0; i < 7; i++) {
+        for (int i = 1; i < 8; i++) {
             try {
                 clientForClassLevelCBWithDelay.serviceC();
 
-                if (i < 2) {
+                if (i < 3) {
                     Assert.fail("serviceC should throw an Exception in testClassLevelCircuitOverride on iteration " + i);
                 }
             }
             catch (CircuitBreakerOpenException cboe) {
-                // Expected on iteration 4
-                if (i < 2) {
+                // Expected starting from iteration 3
+                if (i < 3) {
                     Assert.fail("serviceC should throw a RuntimeException in testClassLevelCircuitOverride on iteration " + i);
                 }
             }
             catch (RuntimeException ex) {
                 // Expected
+                if (!contains(new int[]{1, 2}, i)) {
+                    Assert.fail("serviceC should not throw a RuntimeException on iteration " + i);
+                }
             }
             catch (Exception ex) {
                 // Not Expected
@@ -424,13 +434,12 @@ public class CircuitBreakerTest extends Arquillian {
      */
     @Test
     public void testClassLevelCircuitOverrideNoDelay() {
-        for (int i = 0; i < 7; i++) {
+        for (int i = 1; i < 8; i++) {
             try {
-                // Pause to allow the circuit breaker to half-open on iteration
-                // 4
+                // Pause to allow the circuit breaker to half-open on iteration 5
                 // This is conservative when the circuit breaker has a minimal
                 // delay.
-                if (i == 4) {
+                if (i == 5) {
                     try {
                         Thread.sleep(500);
                     }
@@ -439,7 +448,7 @@ public class CircuitBreakerTest extends Arquillian {
                     }
                 }
                 clientForClassLevelCBWithDelay.serviceD();
-                if (i < 4) {
+                if (i < 5) {
                     Assert.fail("serviceA should throw an Exception in testClassLevelCircuitOverrideNoDelay on iteration " + i);
                 }
             }
@@ -451,6 +460,9 @@ public class CircuitBreakerTest extends Arquillian {
             }
             catch (RuntimeException ex) {
                 // Expected
+                if (!contains(new int[]{1, 2, 3, 4}, i)) {
+                    Assert.fail("serviceD should not throw a RuntimeException on iteration " + i);
+                }
             }
             catch (Exception ex) {
                 // Not Expected

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/Misc.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/Misc.java
@@ -1,0 +1,53 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck;
+
+/**
+ * Simple utility class.
+ */
+public abstract class Misc {
+    public abstract static class Ints {
+        /**
+         * Search for the existence of an int value in a given int array.
+         * @param data the int data to search into
+         * @param value the value to search
+         * @return true if the data array contains at least once the expected value, false otherwise
+         */
+        public static boolean contains(int[] data, int value) {
+            for (int i = 0; i < data.length; i++) {
+                if (value == data[i]) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        /*
+         * prevent instanciation
+         */
+        private Ints() {
+        }
+    }
+    /*
+     * prevent instanciation
+     */
+    private Misc() {
+    }
+}


### PR DESCRIPTION
> :warning: __by correcting the behavior of tests this commit introduces changes compared to initial TCK version__ :warning: 

as discussed in #188 & #136 the status change of a circuit into OPEN state should work in a window of `requestVolumeThreshold` calls and should match `failureRatio`. There's no need to wait for `requestVolumeThreshold` failed calls.

I separated the PR in 2 commits. The first one adresses really the issue, the second one clarifies & unifies a bit some expectations on the test file I worked on so by being more consistent it is easier to read/understand the tests.

I can of course squash/rebase both commits or remove the latest one if required.