### PR TITLE
Remove @Asynchronous annotation from sync tests

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
@@ -237,7 +237,7 @@ public class BulkheadSynchRetryTest extends Arquillian {
     public void testNoRetriesBulkhead() {
         int threads = 30;
         int maxSimultaneousWorkers = 5;
-        int expectedTasks = 10;
+        int expectedTasks = 5;
         TestData td = new TestData(new CountDownLatch(expectedTasks));
         threads(threads, zeroRetryBean, maxSimultaneousWorkers, expectedTasks, td);
         td.check();

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BackendTestDelegate;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhead55ClassSynchronousRetryBean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhead55MethodSynchronousRetryBean;
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadRapidRetry50MethodSynchBean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadRapidRetry550MethodSynchBean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadRapidRetry55ClassSynchBean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadRapidRetry55MethodSynchBean;
@@ -82,7 +83,10 @@ public class BulkheadSynchRetryTest extends Arquillian {
     private BulkheadRapidRetry55MethodSynchBean rrMethodBean;
 
     @Inject
-    private BulkheadRapidRetry550MethodSynchBean zeroRetryBean;
+    private BulkheadRapidRetry50MethodSynchBean zeroRetryBean;
+    
+    @Inject
+    private BulkheadRapidRetry550MethodSynchBean zeroRetryWaitingQueueBean;
 
     /**
      * This is the Arquillian deploy method that controls the contents of the
@@ -240,6 +244,21 @@ public class BulkheadSynchRetryTest extends Arquillian {
         int expectedTasks = 5;
         TestData td = new TestData(new CountDownLatch(expectedTasks));
         threads(threads, zeroRetryBean, maxSimultaneousWorkers, expectedTasks, td);
+        td.check();
+    }
+    
+    /**
+     * Test that that the waitingTaskQueue parameter is ignored due to the absence of 
+     * the Asynchronous annotation. Only 5 tasks should go through, as the waiting
+     * queue size should be ignored.
+     */
+    @Test()
+    public void testIgnoreWaitingTaskQueueBulkhead() {
+        int threads = 30;
+        int maxSimultaneousWorkers = 5;
+        int expectedTasks = 5;
+        TestData td = new TestData(new CountDownLatch(expectedTasks));
+        threads(threads, zeroRetryWaitingQueueBean, maxSimultaneousWorkers, expectedTasks, td);
         td.check();
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55ClassSynchronousRetryBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55ClassSynchronousRetryBean.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Future;
 import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
-import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
@@ -36,7 +35,6 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  */
 @ApplicationScoped
 @Bulkhead(waitingTaskQueue = 5, value = 5)
-@Asynchronous
 @Retry(retryOn =
 { BulkheadException.class }, delay = 500, delayUnit = ChronoUnit.MILLIS, maxRetries = 12, maxDuration=999999)
 public class Bulkhead55ClassSynchronousRetryBean implements BulkheadTestBackend {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55ClassSynchronousRetryBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55ClassSynchronousRetryBean.java
@@ -30,7 +30,7 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 
 /**
- * A simple method level Synchronous @Bulkhead bean that has a retry option.
+ * A simple class level Synchronous @Bulkhead bean that has a retry option.
  * @author Gordon Hutchison
  */
 @ApplicationScoped

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry50MethodSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry50MethodSynchBean.java
@@ -21,23 +21,25 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Future;
+
 import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 
 /**
- * A simple method level synchronous @Bulkhead bean that has a retry option, 
- * with a waitingTaskQueue value that should be ignored.
- * 
- * @author Andrew Pielage
+ * A simple method level synchronous @Bulkhead bean that has a retry option.
+ *
+ * @author Gordon Hutchison
  */
-public class BulkheadRapidRetry550MethodSynchBean implements BulkheadTestBackend {
-    
+
+public class BulkheadRapidRetry50MethodSynchBean implements BulkheadTestBackend {
+
     @Override
     @ApplicationScoped
-    @Bulkhead(value = 5, waitingTaskQueue = 5)
+    @Bulkhead(value = 5)
     @Retry(retryOn =
      { BulkheadException.class }, delay = 1, delayUnit = ChronoUnit.MICROS,
      maxRetries = 0, maxDuration=999999 )
@@ -45,4 +47,5 @@ public class BulkheadRapidRetry550MethodSynchBean implements BulkheadTestBackend
         Utils.log("in business method of bean " + this.getClass().getName());
         return action.perform();
     }
-}
+
+};

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry550MethodSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry550MethodSynchBean.java
@@ -30,7 +30,7 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 
 /**
- * A simple method level Asynchronous @Bulkhead bean that has a retry option.
+ * A simple method level synchronous @Bulkhead bean that has a retry option.
  *
  * @author Gordon Hutchison
  */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry550MethodSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry550MethodSynchBean.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Future;
 import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
-import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
@@ -41,7 +40,6 @@ public class BulkheadRapidRetry550MethodSynchBean implements BulkheadTestBackend
     @Override
     @ApplicationScoped
     @Bulkhead(waitingTaskQueue = 5, value = 5)
-    @Asynchronous
     @Retry(retryOn =
      { BulkheadException.class }, delay = 1, delayUnit = ChronoUnit.MICROS,
      maxRetries = 0, maxDuration=999999 )

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry550MethodSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry550MethodSynchBean.java
@@ -39,7 +39,7 @@ public class BulkheadRapidRetry550MethodSynchBean implements BulkheadTestBackend
 
     @Override
     @ApplicationScoped
-    @Bulkhead(waitingTaskQueue = 5, value = 5)
+    @Bulkhead(value = 5)
     @Retry(retryOn =
      { BulkheadException.class }, delay = 1, delayUnit = ChronoUnit.MICROS,
      maxRetries = 0, maxDuration=999999 )

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry55ClassSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry55ClassSynchBean.java
@@ -23,7 +23,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Future;
 
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
-import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
@@ -34,7 +33,6 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  * @author Gordon Hutchison
  */
 @Bulkhead(waitingTaskQueue = 5, value = 5)
-@Asynchronous
 @Retry(retryOn =
 { BulkheadException.class }, delay = 1, delayUnit = ChronoUnit.MICROS, maxRetries = 10, maxDuration=999999)
 public class BulkheadRapidRetry55ClassSynchBean implements BulkheadTestBackend {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry55ClassSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry55ClassSynchBean.java
@@ -28,7 +28,7 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 
 /**
- * A simple method level Asynchronous @Bulkhead bean that has a retry option.
+ * A simple class level synchronous @Bulkhead bean that has a retry option.
  *
  * @author Gordon Hutchison
  */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry55MethodSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry55MethodSynchBean.java
@@ -30,7 +30,7 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 
 /**
- * A simple method level Asynchronous @Bulkhead bean that has a retry option.
+ * A simple method level synchronous @Bulkhead bean that has a retry option.
  *
  * @author Gordon Hutchison
  */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry55MethodSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRapidRetry55MethodSynchBean.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Future;
 import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
-import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
@@ -41,7 +40,6 @@ public class BulkheadRapidRetry55MethodSynchBean implements BulkheadTestBackend 
     @Override
     @ApplicationScoped
     @Bulkhead(waitingTaskQueue = 5, value = 5)
-    @Asynchronous
     @Retry(retryOn =
     { BulkheadException.class }, delay = 1, delayUnit = ChronoUnit.MILLIS, maxRetries = 10, maxDuration=999999)
     public Future test(BackendTestDelegate action) throws InterruptedException {


### PR DESCRIPTION
Some of the synchronous tests are annotated with `@Asynchronous`, making them, well, not synchronous.

These tests also already submit themselves to an executor to simulate multiple simultaneous calls, so with this annotation present the tests are being submitted to an executor, to be then be submitted to a second executor.