### PR TITLE
update arquillian-core & support testable when ShouldThrowException is used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,13 +104,6 @@
                 <artifactId>cdi-api</artifactId>
                 <version>1.2</version>
             </dependency>
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>1.1.13.Final</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -28,7 +28,7 @@
     <version>1.1-SNAPSHOT</version>
 
     <properties>
-        <arquillian.version>1.1.13.Final</arquillian.version>
+        <arquillian.version>1.1.14.Final</arquillian.version>
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9_]*$</checkstyle.methodNameFormat>
     </properties>
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodTest.java
@@ -37,7 +37,7 @@ public class IncompatibleFallbackMethodTest extends Arquillian {
     FallbackMethodClient fallbackMethodClient;
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deployAnotherApp() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalid.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodWithArgsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodWithArgsTest.java
@@ -37,7 +37,7 @@ public class IncompatibleFallbackMethodWithArgsTest extends Arquillian {
     FallbackMethodWithArgsClient fallbackMethodClient;
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deployAnotherApp() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalid.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackPolicies.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackPolicies.java
@@ -37,7 +37,7 @@ public class IncompatibleFallbackPolicies extends Arquillian {
     FallbackClient fallbackClient;
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalid.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackTest.java
@@ -37,7 +37,7 @@ public class IncompatibleFallbackTest extends Arquillian {
     FallbackClient fallbackClient;
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalid.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadAsynchQueueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadAsynchQueueTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidBulkheadAsynchQueueTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidBulkhead3.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadValueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadValueTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidBulkheadValueTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidBulkhead1.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerDelayTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerDelayTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerDelayTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB1.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioNegTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureRatioNegTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB3.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioPosTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioPosTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureRatioPosTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB2.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVol0Test.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVol0Test.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureReqVol0Test extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB4.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVolNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVolNegTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureReqVolNegTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB5.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccess0Test.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccess0Test.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureSuccess0Test extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB6.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccessNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccessNegTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureSuccessNegTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB7.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayDurationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayDurationTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidRetryDelayDurationTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy2() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidRetry3.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidRetryDelayTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidRetry1.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryJitterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryJitterTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidRetryJitterTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidRetry4.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryMaxRetriesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryMaxRetriesTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidRetryMaxRetriesTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidRetry2.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidTimeoutValueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidTimeoutValueTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidTimeoutValueTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(DefinitionException.class)
+    @ShouldThrowException(value = DefinitionException.class, testable = true)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidTimeout.jar")


### PR DESCRIPTION
as explained in the gitter & in [google groups](https://groups.google.com/forum/#!topic/microprofile/HI0NgS4A5Ag), to let all container a chance to run the tests that expect `@ShouldThrowException` a move to _arquillian-core-1.1.14.Final_ is required together with an enhancement of all tests using `@ShouldThrowException`.
This PR should not hurt (but it is to be verified) the embedded arquillian containers, still offering a chance to the remote ones to support the `@ShouldThrowException` tests.

Issues references:
- fault-tolerance issue: #200
- arquillian-core new feature: arquillian/arquillian-core#135
- enhancement in wildfly-arquillian: wildfly/wildfly-arquillian#116