### PR TITLE
The CDI scope annotation was added to the BulkHead test clients that …

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead10ClassAsynchronousBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead10ClassAsynchronousBean.java
@@ -21,6 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -30,7 +32,7 @@ import org.eclipse.microprofile.faulttolerance.Bulkhead;
  *
  * @author Gordon Hutchison
  */
-@Bulkhead(10) @Asynchronous
+@Bulkhead(10) @Asynchronous @ApplicationScoped
 public class Bulkhead10ClassAsynchronousBean implements BulkheadTestBackend {
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead10ClassSemaphoreBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead10ClassSemaphoreBean.java
@@ -21,6 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 
@@ -29,6 +31,7 @@ import org.eclipse.microprofile.faulttolerance.Bulkhead;
  * 
  * @author Gordon Hutchison
  */
+@ApplicationScoped
 @Bulkhead(10)
 public class Bulkhead10ClassSemaphoreBean implements BulkheadTestBackend {
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead10MethodAsynchronousBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead10MethodAsynchronousBean.java
@@ -21,6 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -30,7 +32,7 @@ import org.eclipse.microprofile.faulttolerance.Bulkhead;
  *
  * @author Gordon Hutchison
  */
-
+@ApplicationScoped
 public class Bulkhead10MethodAsynchronousBean implements BulkheadTestBackend {
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead10MethodSemaphoreBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead10MethodSemaphoreBean.java
@@ -21,6 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 
@@ -29,7 +31,7 @@ import org.eclipse.microprofile.faulttolerance.Bulkhead;
  * 
  * @author Gordon Hutchison
  */
-
+@ApplicationScoped
 public class Bulkhead10MethodSemaphoreBean implements BulkheadTestBackend {
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55ClassAsynchronousRetry1Bean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55ClassAsynchronousRetry1Bean.java
@@ -21,6 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -32,6 +34,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  * 
  * @author Gordon Hutchison
  */
+@ApplicationScoped
 @Bulkhead(waitingTaskQueue = 5, value = 5)
 @Asynchronous
 @Retry(retryOn =

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55ClassAsynchronousRetryBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55ClassAsynchronousRetryBean.java
@@ -22,6 +22,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -33,6 +35,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  *
  * @author Gordon Hutchison
  */
+@ApplicationScoped
 @Bulkhead(waitingTaskQueue = 5, value = 5)
 @Asynchronous
 @Retry(retryOn =

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55MethodAsynchronousRetryBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55MethodAsynchronousRetryBean.java
@@ -22,6 +22,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -36,7 +38,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  * 
  * @author Gordon Hutchison
  */
-
+@ApplicationScoped
 public class Bulkhead55MethodAsynchronousRetryBean implements BulkheadTestBackend {
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10ClassAsynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10ClassAsynchBean.java
@@ -22,6 +22,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -33,6 +35,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  *
  * @author Gordon Hutchison
  */
+@ApplicationScoped
 @Bulkhead(waitingTaskQueue = 5, value = 5)
 @Asynchronous
 @Retry(retryOn =

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10ClassSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10ClassSynchBean.java
@@ -22,6 +22,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
@@ -32,6 +34,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  *
  * @author Gordon Hutchison
  */
+@ApplicationScoped
 @Bulkhead(waitingTaskQueue = 5, value = 5)
 @Retry(retryOn =
 { BulkheadException.class }, delay = 1, delayUnit = ChronoUnit.MICROS, maxRetries = 10, maxDuration=999999)

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10MethodAsynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10MethodAsynchBean.java
@@ -22,6 +22,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -33,7 +35,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  *
  * @author Gordon Hutchison
  */
-
+@ApplicationScoped
 public class Bulkhead55RapidRetry10MethodAsynchBean implements BulkheadTestBackend {
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10MethodSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10MethodSynchBean.java
@@ -22,6 +22,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
@@ -32,7 +34,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  *
  * @author Gordon Hutchison
  */
-
+@ApplicationScoped
 public class Bulkhead55RapidRetry10MethodSynchBean implements BulkheadTestBackend {
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead5ClassSynchronousRetry1Bean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead5ClassSynchronousRetry1Bean.java
@@ -21,6 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
@@ -31,6 +33,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  * 
  * @author Gordon Hutchison
  */
+@ApplicationScoped
 @Bulkhead(value = 5)
 @Retry(retryOn =
 { BulkheadException.class, InterruptedException.class, RuntimeException.class }, maxRetries = 1, maxDuration=999999)

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead5MethodSynchronousRetry20Bean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead5MethodSynchronousRetry20Bean.java
@@ -22,6 +22,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
@@ -34,7 +36,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  * 
  * @author Gordon Hutchison
  */
-
+@ApplicationScoped
 public class Bulkhead5MethodSynchronousRetry20Bean implements BulkheadTestBackend {
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead5RapidRetry0MethodSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead5RapidRetry0MethodSynchBean.java
@@ -22,6 +22,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
@@ -32,7 +34,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  *
  * @author Gordon Hutchison
  */
-
+@ApplicationScoped
 public class Bulkhead5RapidRetry0MethodSynchBean implements BulkheadTestBackend {
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead5RapidRetry12MethodSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead5RapidRetry12MethodSynchBean.java
@@ -21,6 +21,9 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
@@ -32,6 +35,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  * 
  * @author Andrew Pielage
  */
+@ApplicationScoped
 public class Bulkhead5RapidRetry12MethodSynchBean implements BulkheadTestBackend {
     
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadClassAsynchronousDefaultBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadClassAsynchronousDefaultBean.java
@@ -21,6 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -30,6 +32,7 @@ import org.eclipse.microprofile.faulttolerance.Bulkhead;
  *
  * @author Gordon Hutchison
  */
+@ApplicationScoped
 @Bulkhead
 @Asynchronous
 public class BulkheadClassAsynchronousDefaultBean implements BulkheadTestBackend {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadClassAsynchronousQueueingBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadClassAsynchronousQueueingBean.java
@@ -21,6 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -30,6 +32,7 @@ import org.eclipse.microprofile.faulttolerance.Bulkhead;
  * 
  * @author Gordon Hutchison
  */
+@ApplicationScoped
 @Bulkhead(value = 10, waitingTaskQueue = 10)
 @Asynchronous
 public class BulkheadClassAsynchronousQueueingBean implements BulkheadTestBackend {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadClassSemaphoreDefaultBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadClassSemaphoreDefaultBean.java
@@ -21,6 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 
@@ -29,6 +31,7 @@ import org.eclipse.microprofile.faulttolerance.Bulkhead;
  *
  * @author Gordon Hutchison
  */
+@ApplicationScoped
 @Bulkhead
 public class BulkheadClassSemaphoreDefaultBean implements BulkheadTestBackend {
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadMethodAsynchronousDefaultBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadMethodAsynchronousDefaultBean.java
@@ -21,6 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -30,7 +32,7 @@ import org.eclipse.microprofile.faulttolerance.Bulkhead;
  *
  * @author Gordon Hutchison
  */
-
+@ApplicationScoped
 public class BulkheadMethodAsynchronousDefaultBean implements BulkheadTestBackend {
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadMethodAsynchronousQueueingBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadMethodAsynchronousQueueingBean.java
@@ -21,6 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -30,7 +32,7 @@ import org.eclipse.microprofile.faulttolerance.Bulkhead;
  *
  * @author Gordon Hutchison
  */
-
+@ApplicationScoped
 public class BulkheadMethodAsynchronousQueueingBean implements BulkheadTestBackend {
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadMethodSemaphoreDefaultBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadMethodSemaphoreDefaultBean.java
@@ -21,6 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.ApplicationScoped;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 
@@ -29,7 +31,7 @@ import org.eclipse.microprofile.faulttolerance.Bulkhead;
  *
  * @author Gordon Hutchison
  */
-
+@ApplicationScoped
 public class BulkheadMethodSemaphoreDefaultBean implements BulkheadTestBackend {
 
     @Override


### PR DESCRIPTION
…wasn't have it, to avoid incompatibilities with the CDI implmentation on SE and JEE regarding the arquilian deployment made it for the BulkHead test that generates an empty beans.xml file that is valid for JEE for initiate the CDI activation on Java Web EE apps but not for SE apps that  can easily access using y Annotation-based injection method.

github issue url
https://github.com/eclipse/microprofile-fault-tolerance/issues/179