### PR TITLE
Check Style external configuration to avoid issues with the .editorconfig file…

### DIFF
--- a/microprofile_checks.xml
+++ b/microprofile_checks.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+	<module name="SuppressionCommentFilter" />
+	<module name="FileLength">
+		<property name="max" value="3500" />
+		<property name="fileExtensions" value="java" />
+	</module>
+	<module name="FileTabCharacter" />
+	<module name="TreeWalker">
+		<module name="FileContentsHolder" />
+		<module name="ConstantName">
+			<property name="format" value="^(([A-Z][A-Z0-9]*(_[A-Z0-9]+)*))$" />
+		</module>
+		<module name="LocalVariableName" />
+		<module name="MethodName">
+			<property name="format" value="${checkstyle.methodNameFormat}" />
+		</module>
+		<module name="PackageName" />
+		<module name="LocalFinalVariableName" />
+		<module name="ParameterName" />
+		<module name="StaticVariableName" />
+
+		<module name="TypeName">
+			<property name="format" value="^_?[A-Z][a-zA-Z0-9]*$|packageinfo" />
+		</module>
+		<module name="AvoidStarImport">
+			<property name="excludes"
+				value="java.io,java.net,java.util,javax.enterprise.inject.spi,javax.enterprise.context" />
+		</module>
+		<module name="IllegalImport" />
+		<module name="RedundantImport" />
+		<module name="UnusedImports" />
+		<module name="LineLength">
+			<property name="max" value="150" />
+			<property name="ignorePattern" value="@version|@see" />
+		</module>
+		<module name="MethodLength">
+			<property name="max" value="250" />
+		</module>
+		<module name="ParameterNumber">
+			<property name="max" value="11" />
+		</module>
+		<module name="EmptyBlock">
+			<property name="option" value="text" />
+		</module>
+		<module name="NeedBraces" />
+		<module name="LeftCurly">
+			<property name="option" value="EOL" />
+		</module>
+		<module name="RightCurly">
+			<property name="option" value="ALONE" />
+		</module>
+		<module name="EmptyStatement" />
+		<module name="EqualsHashCode" />
+		<module name="DefaultComesLast" />
+		<module name="MissingSwitchDefault" />
+		<module name="FallThrough" />
+		<module name="MultipleVariableDeclarations" />
+		<module
+			name="com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck">
+			<property name="severity" value="ignore" />
+		</module>
+		<module name="HideUtilityClassConstructor" />
+		<module
+			name="com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck">
+			<property name="packageAllowed" value="false" />
+			<property name="protectedAllowed" value="true" />
+			<property name="publicMemberPattern" value="^serialVersionUID" />
+			<property name="severity" value="warning" />
+		</module>
+		<module name="UpperEll" />
+	</module>
+</module>
+          


### PR DESCRIPTION
i suggest use the plugin that exists for intellij

https://plugins.jetbrains.com/plugin/1065-checkstyle-idea

and for eclipse
https://checkstyle.github.io/eclipse-cs/

and use the microprofile_checks.xml file with the configuration and rules that are already present on the maven check style plugin and adding to the plugin the check style property checkstyle.methodNameFormat with the value that is already defined on the microprofile-fault-tolerance-parent pom.xml  ^_?[a-z][a-zA-Z0-9]*$

to allow to the developers use the plugin that validates the check style rules at compilation time, just importing use the microprofile_checks.xml file

using the plugin, the IDE will start to show the warnings and errors base on the rules imported on the xml file.

Signed-off-by: carlos.delarosa <kusanagi12002@gmail.com>