### PR TITLE
Fix BulkheadAsynchRetryTest#testBulkheadMethodAsynchronousRetry55Trip()

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchRetryTest.java
@@ -86,7 +86,7 @@ public class BulkheadAsynchRetryTest extends Arquillian {
     /**
      * This is the Arquillian deploy method that controls the contents of the
      * war that contains all the tests.
-     * 
+     *
      * @return the test war "ftBulkheadAsynchTest.war"
      */
     @Deployment
@@ -137,14 +137,14 @@ public class BulkheadAsynchRetryTest extends Arquillian {
      * a method level test. The bean here does not delay its retries so there is
      * not enough time for the first generation of workers and queued workers to
      * progress.
-     * 
+     *
      * @throws InterruptedException when interrupted
      */
     @Test()
     public void testBulkheadMethodAsynchronousRetry55Trip() throws InterruptedException {
         int iterations = 11;
         int maxSimultaneousWorkers = 5;
-        TestData td = new TestData();
+        TestData td = new TestData(new CountDownLatch(10));
 
         boolean tripped;
         try {
@@ -166,7 +166,7 @@ public class BulkheadAsynchRetryTest extends Arquillian {
     /**
      * Tests overloading the Retries by firing lots of work at a full Method
      * bulkhead
-     * 
+     *
      * @throws InterruptedException when interrupted
      */
     @Test()
@@ -188,7 +188,7 @@ public class BulkheadAsynchRetryTest extends Arquillian {
     }
 
     /**
-     * 
+     *
      * Tests overloading the Retries by firing lots of work at a full Class
      * bulkhead
      */
@@ -239,7 +239,7 @@ public class BulkheadAsynchRetryTest extends Arquillian {
         Utils.loop(iterations, classBean, maxSimultaneousWorkers, expectedTasksScheduled, td);
         td.check();
     }
-    
+
     /**
      * Check we do not loose anything from the queue due to exceptions covered
      * by Retry at the class level. The Checker backends will throw an exception
@@ -273,6 +273,5 @@ public class BulkheadAsynchRetryTest extends Arquillian {
         td.check();
         Utils.handleResults(threads, results);
     }
-    
 
 }


### PR DESCRIPTION
- TestData.check() must not be invoked before async wrappers are executed
- resolves #232