### PR TITLE
Fix to race condition in TCK bulkhead Checker

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/TestData.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/TestData.java
@@ -128,7 +128,10 @@ public class TestData {
     }
 
     /**
-     * Check the test ran successfully
+     * Check the test ran successfully.
+     * Note: It is not safe to have checks of actual results here as they are RETURNED
+     * from the workers 'perform' methods and these decrement the latch used below
+     * just BEFORE returning.
      */
     public void check() {
         


### PR DESCRIPTION
fixes #227 

Moved the latch decrement to the finally and after the worker count decrement
in the worker class Checker:

```
finally {
            // We want to decrement this before the latch
            td.getWorkers().decrementAndGet();
            CountDownLatch latch = td.getLatch();
            if (latch != null ) {
                latch.countDown();
            }
        }
```
Signed-off-by: Gordon Hutchison <Gordon.Hutchison@gmail.com>
