### PR TITLE
263 Add Connection to disableEnv test jars

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationGloballyTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationGloballyTest.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.asynchronous.AsyncClient;
 import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.StringFallbackHandler;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Connection;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -55,7 +56,7 @@ public class DisableAnnotationGloballyTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftDisableGlobally.jar")
-            .addClasses(DisableClient.class, StringFallbackHandler.class, AsyncClient.class)
+            .addClasses(DisableClient.class, StringFallbackHandler.class, AsyncClient.class, Connection.class)
             .addAsManifestResource(new StringAsset("Retry/enabled=false\n" +
                                                        "Fallback/enabled=false\n" +
                                                        "CircuitBreaker/enabled=false\n" +

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnClassTest.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.asynchronous.AsyncClient;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Connection;
 import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.StringFallbackHandler;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -55,7 +56,7 @@ public class DisableAnnotationOnClassTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftDisableClass.jar")
-            .addClasses(DisableClient.class, StringFallbackHandler.class, AsyncClient.class)
+            .addClasses(DisableClient.class, StringFallbackHandler.class, AsyncClient.class, Connection.class)
             .addAsManifestResource(new StringAsset(
               "org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableClient/Retry/enabled=false\n" +
               "org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableClient/Fallback/enabled=false\n" +

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnMethodsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnMethodsTest.java
@@ -23,6 +23,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.asynchronous.AsyncClient;
 import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.StringFallbackHandler;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Connection;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -55,7 +56,7 @@ public class DisableAnnotationOnMethodsTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftDisableMethods.jar")
-            .addClasses(DisableClient.class, StringFallbackHandler.class, AsyncClient.class)
+            .addClasses(DisableClient.class, StringFallbackHandler.class, AsyncClient.class, Connection.class)
             .addAsManifestResource(new StringAsset(
               "org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableClient/serviceA/Retry/enabled=false\n" +
               "org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableClient/serviceB/Fallback/enabled=false\n" +


### PR DESCRIPTION
The connection class is used by AsyncClient in the tests in the disableEnv package. Without it the test fails with an injection error. 