### PR TITLE
Metrics add fallback counter

### DIFF
--- a/spec/src/main/asciidoc/metrics.asciidoc
+++ b/spec/src/main/asciidoc/metrics.asciidoc
@@ -21,14 +21,14 @@
 == Integration with Microprofile Metrics
 
 When Microprofile Fault Tolerance and Microprofile Metrics are used together, metrics are automatically added for each of
-the methods annotated with a `@Retry`, `@Timeout`, `@CircuitBreaker` or `@Bulkhead` annotation.
+the methods annotated with a `@Retry`, `@Timeout`, `@CircuitBreaker`, `@Bulkhead` or `@Fallback` annotation.
 
 === Names
 
 The automatically added metrics follow a consistent pattern which includes the fully qualified name of the annotated method.
 In the tables below, the placeholder `<name>` should be replaced by the fully qualified method name.
 
-=== Metrics added for `@Retry`, `@Timeout`, `@CircuitBreaker` and `@Bulkhead`
+=== Metrics added for `@Retry`, `@Timeout`, `@CircuitBreaker`, `@Bulkhead` and `@Fallback`
 
 Implementations must ensure that if any of these annotations are present on a method, then the following metrics are added only once for that method.
 
@@ -163,6 +163,19 @@ Similarly, the sum of `ft.<name>.circuitbreaker.open.total`, `ft.<name>.circuitb
 |===
 
 *Only added if the method is also annotated with `@Asynchronous`
+
+
+=== Metrics added for `@Fallback`
+
+[cols="8,3,4,9"]
+|===
+| Name | Type | Unit | Description
+
+|`ft.<name>.fallback.calls.total`
+| Gauge<Long> | None
+| Number of times the fallback handler or method was called
+|===
+
 
 == Notes
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsTest.java
@@ -82,13 +82,16 @@ public class AllMetricsTest extends Arquillian {
         assertThat("circuitbreaker open time", m.getCircuitBreakerTimeOpenDelta(), is(0L));
         assertThat("circuitbreaker times opened", m.getCircuitBreakerOpenedDelta(), is(0L));
         
-        // Bulkhead
+        // Bulkhead metrics
         assertThat("bulkhead concurrent executions", m.getBulkheadConcurrentExecutions().get(), is(0L));
         assertThat("bulkhead accepted calls", m.getBulkheadCallsAcceptedDelta(), is(1L));
         assertThat("bulkhead rejected calls", m.getBulkheadCallsRejectedDelta(), is(0L));
         assertThat("bulkhead duration histogram present", m.getBulkheadExecutionDuration().isPresent(), is(true));
         assertThat("bulkhead queue population present", m.getBulkheadQueuePopulation().isPresent(), is(true));
         assertThat("bulkhead queue wait time histogram present", m.getBulkheadWaitTime().isPresent(), is(true));
+        
+        // Fallback metrics
+        assertThat("fallback calls", m.getFallbackCallsDelta(), is(0L));
     }
     
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricBean.java
@@ -53,10 +53,27 @@ public class FallbackMetricBean {
         }
     }
     
+    @Fallback(FallbackMetricHandler.class)
+    public Void doWorkWithHandler(Action action) {
+        if (action == Action.PASS) {
+            return null;
+        }
+        else {
+            throw new TestException();
+        }
+    }
+    
     /**
-     * Set whether the fallback method should pass or throw an exception 
+     * Set whether the fallback method and handler should pass or throw an exception 
      */
     public void setFallbackAction(Action action) {
         this.fallbackAction = action;
+    }
+    
+    /**
+     * Get whether the fallback method and handler should pass or throw an exception 
+     */
+    public Action getFallbackAction() {
+        return fallbackAction;
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricHandler.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricHandler.java
@@ -1,0 +1,45 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.metrics;
+
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricBean.Action;
+import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.TestException;
+import org.eclipse.microprofile.faulttolerance.ExecutionContext;
+import org.eclipse.microprofile.faulttolerance.FallbackHandler;
+
+@Dependent
+public class FallbackMetricHandler implements FallbackHandler<Void> {
+    
+    @Inject private FallbackMetricBean fallbackBean;
+    
+    @Override
+    public Void handle(ExecutionContext context) {
+        if (fallbackBean.getFallbackAction() == Action.PASS) {
+            return null;
+        }
+        else {
+            throw new TestException();
+        }
+    }
+    
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricTest.java
@@ -1,0 +1,73 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.metrics;
+
+import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectTestException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricBean.Action;
+import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+public class FallbackMetricTest extends Arquillian {
+
+    @Deployment
+    public static WebArchive deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricFallback.war")
+                .addClasses(FallbackMetricBean.class)
+                .addPackage(MetricGetter.class.getPackage());
+        return war;
+    }
+    
+    @Inject private FallbackMetricBean fallbackBean;
+    
+    @Test
+    public void fallbackMetricTest() {
+        MetricGetter m = new MetricGetter(FallbackMetricBean.class, "doWork");
+        m.baselineCounters();
+        
+        fallbackBean.setFallbackAction(Action.PASS);
+        fallbackBean.doWork(Action.PASS);
+        
+        assertThat("fallback calls", m.getFallbackCallsDelta(), is(0L));
+        assertThat("invocations", m.getInvocationsDelta(), is(1L));
+        assertThat("failed invocations", m.getInvocationsFailedDelta(), is(0L));
+        
+        fallbackBean.doWork(Action.FAIL);
+        
+        assertThat("fallback calls", m.getFallbackCallsDelta(), is(1L));
+        assertThat("invocations", m.getInvocationsDelta(), is(2L));
+        assertThat("failed invocations", m.getInvocationsFailedDelta(), is(0L));
+        
+        fallbackBean.setFallbackAction(Action.FAIL);
+        expectTestException(() -> fallbackBean.doWork(Action.FAIL));
+        
+        assertThat("fallback calls", m.getFallbackCallsDelta(), is(2L));
+        assertThat("invocations", m.getInvocationsDelta(), is(3L));
+        assertThat("failed invocations", m.getInvocationsFailedDelta(), is(1L));
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/MetricsDisabledTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/MetricsDisabledTest.java
@@ -90,6 +90,9 @@ public class MetricsDisabledTest extends Arquillian {
         assertThat("bulkhead duration histogram present", m.getBulkheadExecutionDuration().isPresent(), is(false));
         assertThat("bulkhead queue population present", m.getBulkheadQueuePopulation().isPresent(), is(false));
         assertThat("bulkhead queue wait time histogram present", m.getBulkheadWaitTime().isPresent(), is(false));
+        
+        // Fallback metrics
+        assertThat("fallback calls", m.getFallbackCallsDelta(), is(0L));
     }
 
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/util/MetricGetter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/util/MetricGetter.java
@@ -82,6 +82,9 @@ public class MetricGetter {
     private long bulkheadCallsAcceptedBaseline;
     private long bulkheadCallsRejectedBaseline;
     
+    // Fallback
+    private long fallbackCallsBaseline;
+    
     public MetricGetter(Class<?> clazz, String methodName) {
         validateClassAndMethodName(clazz, methodName);
         prefix = "ft." + clazz.getCanonicalName() + "." + methodName;
@@ -119,6 +122,9 @@ public class MetricGetter {
         // Bulkhead
         bulkheadCallsAcceptedBaseline = getBulkheadCallsAcceptedTotal();
         bulkheadCallsRejectedBaseline = getBulkheadCallsRejectedTotal();
+        
+        // Fallback
+        fallbackCallsBaseline = getFallbackCallsTotal();
     }
     
     // ----------------------
@@ -262,7 +268,7 @@ public class MetricGetter {
     }
     
     // -----------------------
-    // Circuit Breaker Metrics
+    // Bulkhead Metrics
     // -----------------------
     
     public Optional<Long> getBulkheadConcurrentExecutions() {
@@ -295,6 +301,18 @@ public class MetricGetter {
     
     public Optional<Histogram> getBulkheadWaitTime() {
         return getMetric(prefix + ".bulkhead.waiting.duration", Histogram.class);
+    }
+    
+    // -----------------------
+    // Fallback Metrics
+    // -----------------------
+    
+    public long getFallbackCallsTotal() {
+        return getCounterValue(prefix + ".fallback.calls.total");
+    }
+    
+    public long getFallbackCallsDelta() {
+        return getFallbackCallsTotal() - fallbackCallsBaseline;
     }
     
     // -----------------------


### PR DESCRIPTION
Add a new counter named `ft.<name>.fallback.calls.total` for how many times a fallback method or handler is called.

Currently, there's no way to find this out. Also, with the way `ft.<name>.invocations.failed.total` is specified, that counter will only increment for a method annotated with `@Fallback` if the fallback method also throws an exception.

This metric gives you a better idea of how often your main logic fails, as well as allowing you to see if your fallback itself is failing.

For #234