### PR TITLE
State what happens when metric names clash

### DIFF
--- a/spec/src/main/asciidoc/metrics.asciidoc
+++ b/spec/src/main/asciidoc/metrics.asciidoc
@@ -28,6 +28,9 @@ the methods annotated with a `@Retry`, `@Timeout`, `@CircuitBreaker`, `@Bulkhead
 The automatically added metrics follow a consistent pattern which includes the fully qualified name of the annotated method.
 In the tables below, the placeholder `<name>` should be replaced by the fully qualified method name.
 
+If two methods have the same fully qualified name then the metrics for those methods will be combined. The result of this combination
+is non-portable and may vary between implementations. For portable behavior, monitored methods in the same class should have unique names.
+
 === Metrics added for `@Retry`, `@Timeout`, `@CircuitBreaker`, `@Bulkhead` and `@Fallback`
 
 Implementations must ensure that if any of these annotations are present on a method, then the following metrics are added only once for that method.

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClashingNameBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClashingNameBean.java
@@ -1,0 +1,66 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.metrics;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+@ApplicationScoped
+public class ClashingNameBean {
+
+    @Retry(maxRetries = 5)
+    @Bulkhead(3)
+    @Timeout(value = 1000, unit = ChronoUnit.MILLIS)
+    @CircuitBreaker(failureRatio = 1.0, requestVolumeThreshold = 20)
+    @Fallback(fallbackMethod = "doFallback")
+    @Asynchronous
+    public Future<Void> doWork() {
+        return CompletableFuture.completedFuture(null);
+    }
+    
+    @Retry(maxRetries = 5)
+    @Bulkhead(3)
+    @Timeout(value = 1000, unit = ChronoUnit.MILLIS)
+    @CircuitBreaker(failureRatio = 1.0, requestVolumeThreshold = 20)
+    @Fallback(fallbackMethod = "doFallback")
+    @Asynchronous
+    public Future<Void> doWork(String dummy) {
+        return CompletableFuture.completedFuture(null);
+    }
+    
+    public Future<Void> doFallback() {
+        return CompletableFuture.completedFuture(null);
+    }
+    
+    public Future<Void> doFallback(String dummy) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClashingNameTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClashingNameTest.java
@@ -1,0 +1,60 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.metrics;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+public class ClashingNameTest extends Arquillian {
+
+    @Deployment
+    public static WebArchive deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricClash.war")
+                .addClasses(ClashingNameBean.class)
+                .addPackage(MetricGetter.class.getPackage());
+        
+        return war;
+    }
+    
+    @Inject
+    private ClashingNameBean clashingNameBean;
+    
+    @Test
+    public void testClashingName() {
+        MetricGetter m = new MetricGetter(ClashingNameBean.class, "doWork");
+        m.baselineCounters();
+        
+        clashingNameBean.doWork();
+        clashingNameBean.doWork("dummy");
+        
+        assertThat("invocations", m.getInvocationsDelta(), is(greaterThan(0L)));
+    }
+
+}


### PR DESCRIPTION
I'm not sure how specific we should be here.

We could go all the way and explain how each metric type should be combined - in most cases this is a simple sum. We could then add tests to ensure that metrics are combined correctly in all cases.

From an implementation point of view, this isn't too arduous, though some additional work would be required to combine gauges.

However, I'm not sure how valuable combining metrics is for the user. Essentially we're just trying to do something sensible if this situation happens so for the moment, I've just added a simple test which ensures that the implementation doesn't throw an exception and increments the basic invocation metric.