### PR TITLE
Allow annotations to be explicitly enabled via config

### DIFF
--- a/spec/src/main/asciidoc/configuration.asciidoc
+++ b/spec/src/main/asciidoc/configuration.asciidoc
@@ -114,10 +114,10 @@ Similarly, the property `com.acme.ClassA/Retry/maxRetries` will be ignored if `@
 === Disabled Fault Tolerance policies with configuration
 
 Fault Tolerance policies can be disabled with configuration at method level, class level or globally for all deployment. If multiple configurations are specified, method-level configuration overrides class-level configuration, which then overrides global configuration. e.g.
-* `com.acme.test.MyClient/methodA/CircuitBreaker/enabled=true`
-* `com.acme.test.MyClient/CircuitBreaker/enabled=false`
+* `com.acme.test.MyClient/methodA/CircuitBreaker/enabled=false`
+* `com.acme.test.MyClient/CircuitBreaker/enabled=true`
 * `CircuitBreaker/enabled=false`
-For the above scenario, all occurrence of `CircuitBreaker` for the application is disabled except the method `methodA` on the class `com.acme.test.MyClient`.
+For the above scenario, all occurrences of `CircuitBreaker` for the application are disabled except for those on the class `com.acme.test.MyClient`. All occurrences of `CircuitBreaker` on `com.acme.test.MyClient` are enabled, except for the one on `methodA` which is disabled.
 
 
 Each policy can be disabled by using its annotation name.
@@ -158,13 +158,4 @@ For instance the following config will disable bulkhead policy globally:
 
 Policy will be disabled everywhere ignoring existing policy annotations on methods and classes.
 
-If the above configurations patterns are used with another value than `true` or `false` (i.e. `<classname>/<methodname>/<annotation>/enabled=whatever`) non-portable behaviour results.
-
-=== Configuring Metrics Integration
-
-The integration with MicroProfile Metrics can be disabled by setting a config property named `MP_Fault_Tolerance_Metrics_Enabled` to the value `false`.
-If this property is absent or set to `true` then the integration with MicroProfile Metrics will be enabled and the metrics listed earlier in this specification
-will be added automatically for every method annotated with a `@Retry`, `@Timeout`, `@CircuitBreaker` or `@Bulkhead` annotation.
-
-In order to prevent from any unexpected behaviours, the property `MP_Fault_Tolerance_Metrics_Enabled` will only be read when the application starts.
-Any dynamic changes afterwards will be ignored until the application is restarted.
+If the above configurations patterns are used with a value other than `true` or `false` (i.e. `<classname>/<methodname>/<annotation>/enabled=whatever`) non-portable behaviour results.

--- a/spec/src/main/asciidoc/configuration.asciidoc
+++ b/spec/src/main/asciidoc/configuration.asciidoc
@@ -113,7 +113,12 @@ Similarly, the property `com.acme.ClassA/Retry/maxRetries` will be ignored if `@
 
 === Disabled Fault Tolerance policies with configuration
 
-Fault Tolerance policies can be disabled with configuration at method level, class level or globally for all deployment.
+Fault Tolerance policies can be disabled with configuration at method level, class level or globally for all deployment. If multiple configurations are specified, method-level configuration overrides class-level configuration, which then overrides global configuration. e.g.
+* `com.acme.test.MyClient/methodA/CircuitBreaker/enabled=true`
+* `com.acme.test.MyClient/CircuitBreaker/enabled=false`
+* `CircuitBreaker/enabled=false`
+For the above scenario, all occurrence of `CircuitBreaker` for the application is disabled except the method `methodA` on the class `com.acme.test.MyClient`.
+
 
 Each policy can be disabled by using its annotation name.
 
@@ -153,7 +158,7 @@ For instance the following config will disable bulkhead policy globally:
 
 Policy will be disabled everywhere ignoring existing policy annotations on methods and classes.
 
-If the above configurations patterns are used with another value than `false` (i.e. `<classname>/<methodname>/<annotation>/enabled=whatever`) non-portable behaviour results.
+If the above configurations patterns are used with another value than `true` or `false` (i.e. `<classname>/<methodname>/<annotation>/enabled=whatever`) non-portable behaviour results.
 
 === Configuring Metrics Integration
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationClient.java
@@ -1,0 +1,162 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.fault.tolerance.tck.util.ConcurrentExecutionTracker;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+
+/**
+ * A client to determine the impact of disabling annotations via config
+ * <p>
+ * Each method has an easy test to determine whether it's annotations are active or not.
+ * 
+ * @author <a href="mailto:anrouse@uk.ibm.com">Andrew Rouse</a>
+ *
+ */
+@ApplicationScoped
+public class DisableAnnotationClient {
+
+    private int failAndRetryOnceCounter = 0;
+    private int failRetryOnceThenFallbackCounter = 0;
+    
+    @Inject private ConcurrentExecutionTracker tracker;
+
+    /**
+     * Always throws {@link TestException}, should increment counter by two if Retry is enabled, or one if it is not
+     */
+    @Retry(maxRetries = 1)
+    public void failAndRetryOnce() {
+        failAndRetryOnceCounter++;
+        throw new TestException();
+    }
+    
+    /**
+     * Returns the number of times that {@link #failAndRetryOnce()} has been executed
+     */
+    public int getFailAndRetryOnceCounter() {
+        return failAndRetryOnceCounter;
+    }
+    
+    /**
+     * Should return normally if Fallback is enabled or throw TestException if not
+     * <p>
+     * Should increment counter by two if Retry is enabled or one if it is not
+     */
+    @Retry(maxRetries = 1)
+    @Fallback(fallbackMethod = "fallback")
+    public String failRetryOnceThenFallback() {
+        failRetryOnceThenFallbackCounter++;
+        throw new TestException();
+    }
+    
+    /**
+     * Returns the number of times that {@link #failRetryOnceThenFallback()} has been executed
+     */
+    public int getFailRetryOnceThenFallbackCounter() {
+        return failRetryOnceThenFallbackCounter;
+    }
+    
+    public String fallback() {
+        return "OK";
+    }
+    
+    /**
+     * Always throws TestException on first invocation, throws {@link org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException}
+     * on second if CircuitBreaker is enabled
+     * <p>
+     * Throw test exception on second invocation if CircuitBreaker is disabled
+     */
+    @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 1, failureRatio = 1, delay = 50000)
+    public void failWithCircuitBreaker() {
+        throw new TestException();
+    }
+    
+    /**
+     * Throws {@link org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException} if Timeout is enabled or TestException otherwise
+     */
+    @Timeout(500)
+    public void failWithTimeout() {
+        try {
+            Thread.sleep(2000);
+            throw new TestException();
+        }
+        catch (InterruptedException e) {
+            //expected
+        }
+    }
+    
+    /**
+     * Blocks waiting for {@code waitingFuture} to complete
+     * <p>
+     * If passed an already completed {@link Future}, this method will return immediately.
+     * <p>
+     * Should permit two simultaneous calls if bulkhead enabled, or more if bulkhead disabled.
+     * 
+     * @param waitingFuture the future to wait for
+     */
+    @Bulkhead(2)
+    public void waitWithBulkhead(Future<?> waitingFuture) {
+        try {
+            tracker.executionStarted();
+            waitingFuture.get();
+        }
+        catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+        finally {
+            tracker.executionEnded();
+        }
+    }
+    
+    /**
+     * Wait for {@code count} executions of {@link #waitWithBulkhead(Future)} to be in progress.
+     */
+    public void waitForBulkheadExecutions(int count) {
+        tracker.waitForRunningExecutions(count);
+    }
+    
+    /**
+     * Returns a future which will be complete on method return if Asynchronous is disabled, or incomplete if Asynchronous is enabled. 
+     */
+    @Asynchronous
+    public Future<String> asyncWaitThenReturn() {
+        try {
+            Thread.sleep(2000);
+            return CompletableFuture.completedFuture("OK");
+        }
+        catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationGloballyEnableOnClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationGloballyEnableOnClassTest.java
@@ -35,6 +35,9 @@ import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -46,32 +49,35 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
- * Test the impact of policies disabling through config.
- *
- * The test assumes that the container supports both the MicroProfile Configuration API and the MicroProfile
- * Fault Tolerance API. Some Fault tolerance policies are disabled through configuration on DisabledClient methods.
- *
+ * Test that annotations can be disabled globally and then re-enabled at the class level
+ * 
  * @author <a href="mailto:antoine@sabot-durand.net">Antoine Sabot-Durand</a>
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
  * @author <a href="mailto:anrouse@uk.ibm.com">Andrew Rouse</a>
  */
-public class DisableAnnotationOnMethodsTest extends Arquillian {
+public class DisableAnnotationGloballyEnableOnClassTest extends Arquillian {
 
     @Inject
     private DisableAnnotationClient disableClient;
 
     @Deployment
     public static WebArchive deploy() {
-        Asset config = new DisableConfigAsset()
-                .disable(DisableAnnotationClient.class, "failAndRetryOnce", Retry.class)
-                .disable(DisableAnnotationClient.class, "failRetryOnceThenFallback", Fallback.class)
-                .disable(DisableAnnotationClient.class, "failWithCircuitBreaker", CircuitBreaker.class)
-                .disable(DisableAnnotationClient.class, "failWithTimeout", Timeout.class)
-                .disable(DisableAnnotationClient.class, "asyncWaitThenReturn", Asynchronous.class)
-                .disable(DisableAnnotationClient.class, "waitWithBulkhead", Bulkhead.class);
+       Asset config = new DisableConfigAsset()
+               .disable(Retry.class)
+               .disable(CircuitBreaker.class)
+               .disable(Timeout.class)
+               .disable(Asynchronous.class)
+               .disable(Fallback.class)
+               .disable(Bulkhead.class)
+               .enable(DisableAnnotationClient.class, Retry.class)
+               .enable(DisableAnnotationClient.class, CircuitBreaker.class)
+               .enable(DisableAnnotationClient.class, Timeout.class)
+               .enable(DisableAnnotationClient.class, Asynchronous.class)
+               .enable(DisableAnnotationClient.class, Fallback.class)
+               .enable(DisableAnnotationClient.class, Bulkhead.class);
         
         JavaArchive testJar = ShrinkWrap
-            .create(JavaArchive.class, "ftDisableMethods.jar")
+            .create(JavaArchive.class, "ftDisableGlobalEnableClass.jar")
             .addClasses(DisableAnnotationClient.class)
             .addPackage(Packages.UTILS)
             .addAsManifestResource(config, "microprofile-config.properties")
@@ -79,65 +85,63 @@ public class DisableAnnotationOnMethodsTest extends Arquillian {
             .as(JavaArchive.class);
 
         WebArchive war = ShrinkWrap
-            .create(WebArchive.class, "ftDisableMethods.war")
+            .create(WebArchive.class, "ftDisableGlobalEnableClass.war")
             .addAsLibrary(testJar);
         return war;
     }
 
     /**
-     * failAndRetryOnce is annotated with maxRetries = 1 so it is expected to execute 2 times but as Retry is disabled,
-     * then no retries should be attempted.
+     * failAndRetryOnce is annotated with maxRetries = 1 so it is expected to execute 2 times.
      */
     @Test
-    public void testRetryDisabled() {
+    public void testRetryEnabled() {
+        // Always get a TestException
         Assert.assertThrows(TestException.class, () -> disableClient.failAndRetryOnce());
-        Assert.assertEquals(disableClient.getFailAndRetryOnceCounter(), 1, "Retry disabled - should be 1 exection");
+        // Should get two attempts if retry is enabled
+        Assert.assertEquals(disableClient.getFailAndRetryOnceCounter(), 2, "Retry enabled - should be 2 exections");
     }
 
     /**
-     * Test that a Fallback service is ignored when service fails.
+     * Test that a Fallback service is used when service fails.
      *
-     * ServiceB is annotated with maxRetries = 1 so serviceB is expected to execute 2 times (Retry is not disabled on the method)
+     * Retry is also enabled so there should be two executions
      */
     @Test
-    public void testFallbackDisabled() {
-        // Throw TestException because Fallback is disabled
-        Assert.assertThrows(TestException.class, () -> disableClient.failRetryOnceThenFallback());
-        // One execution because Retry is still enabled on this method
+    public void testFallbackEnabled() {
+        // Expect no exception because fallback is enabled
+        disableClient.failRetryOnceThenFallback();
+        // Two executions because Retry is enabled
         Assert.assertEquals(disableClient.getFailRetryOnceThenFallbackCounter(), 2, "Retry enabled - should be 2 executions");
     }
 
     /**
-     * CircuitBreaker policy being disabled the policy shouldn't be applied
+     * CircuitBreaker is enabled on the method so the policy should be applied
      */
     @Test
-    public void testCircuitClosedThenOpen() {
+    public void testCircuitBreaker() {
         // Always get TestException on first execution
         Assert.assertThrows(TestException.class, () -> disableClient.failWithCircuitBreaker());
-        // Should get TestException on second execution because CircuitBreaker is disabled
-        Assert.assertThrows(TestException.class, () -> disableClient.failWithCircuitBreaker());
+        // Should get CircuitBreakerOpenException on second execution because CircuitBreaker is enabled
+        Assert.assertThrows(CircuitBreakerOpenException.class, () -> disableClient.failWithCircuitBreaker());
     }
 
     /**
-     * Test Timeout is disabled, should wait two seconds and then get a TestException
+     * Test Timeout is enabled, should fail with a timeout exception
      */
     @Test
     public void testTimeout() {
-        // Expect TestException because Timeout is disabled and will not fire
-        Assert.assertThrows(TestException.class, () -> disableClient.failWithTimeout());
+        // Expect TimeoutException because Timeout is enabled and method will time out
+        Assert.assertThrows(TimeoutException.class, () -> disableClient.failWithTimeout());
     }
 
     /**
-     * A test to check that asynchronous is disabled
-     *
-     * In normal operation, asyncClient.asyncWaitThenReturn() is launched asynchronously. As Asynchronous operation was disabled via config,
-     * test is expecting a synchronous operation.
+     * A test to check that asynchronous is enabled
      */
     @Test
     public void testAsync() throws InterruptedException, ExecutionException {
         Future<?> result = disableClient.asyncWaitThenReturn();
         try {
-            Assert.assertTrue(result.isDone(), "Returned future.isDone() expected true because Async disabled");
+            Assert.assertFalse(result.isDone(), "Returned future.isDone() expected false because Async enabled");
         }
         finally {
             result.get(); // Success or failure, don't leave the future lying around
@@ -160,8 +164,8 @@ public class DisableAnnotationOnMethodsTest extends Arquillian {
             disableClient.waitForBulkheadExecutions(2);
             
             // Try to start a third execution. This would throw a BulkheadException if Bulkhead is enabled.
-            // Bulkhead is disabled on the method so no exception expected
-            disableClient.waitWithBulkhead(CompletableFuture.completedFuture(null));
+            // Bulkhead is enabled on the class, so expect exception
+            Assert.assertThrows(BulkheadException.class, () -> disableClient.waitWithBulkhead(CompletableFuture.completedFuture(null)));
         }
         finally {
             // Clean up executor and first two executions
@@ -172,5 +176,4 @@ public class DisableAnnotationOnMethodsTest extends Arquillian {
             result2.get();
         }
     }
-
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnClassEnableOnMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnClassEnableOnMethodTest.java
@@ -35,6 +35,9 @@ import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -46,32 +49,35 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
- * Test the impact of policies disabling through config.
- *
- * The test assumes that the container supports both the MicroProfile Configuration API and the MicroProfile
- * Fault Tolerance API. Some Fault tolerance policies are disabled through configuration on DisabledClient methods.
- *
+ * Test that annotations can be disabled at the class level and then re-enabled at the method level.
+ * 
  * @author <a href="mailto:antoine@sabot-durand.net">Antoine Sabot-Durand</a>
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
  * @author <a href="mailto:anrouse@uk.ibm.com">Andrew Rouse</a>
  */
-public class DisableAnnotationOnMethodsTest extends Arquillian {
+public class DisableAnnotationOnClassEnableOnMethodTest extends Arquillian {
 
     @Inject
     private DisableAnnotationClient disableClient;
 
     @Deployment
     public static WebArchive deploy() {
-        Asset config = new DisableConfigAsset()
-                .disable(DisableAnnotationClient.class, "failAndRetryOnce", Retry.class)
-                .disable(DisableAnnotationClient.class, "failRetryOnceThenFallback", Fallback.class)
-                .disable(DisableAnnotationClient.class, "failWithCircuitBreaker", CircuitBreaker.class)
-                .disable(DisableAnnotationClient.class, "failWithTimeout", Timeout.class)
-                .disable(DisableAnnotationClient.class, "asyncWaitThenReturn", Asynchronous.class)
-                .disable(DisableAnnotationClient.class, "waitWithBulkhead", Bulkhead.class);
+       Asset config = new DisableConfigAsset()
+               .disable(DisableAnnotationClient.class, Retry.class)
+               .disable(DisableAnnotationClient.class, CircuitBreaker.class)
+               .disable(DisableAnnotationClient.class, Timeout.class)
+               .disable(DisableAnnotationClient.class, Asynchronous.class)
+               .disable(DisableAnnotationClient.class, Fallback.class)
+               .disable(DisableAnnotationClient.class, Bulkhead.class)
+               .enable(DisableAnnotationClient.class, "failAndRetryOnce", Retry.class)
+               .enable(DisableAnnotationClient.class, "failWithCircuitBreaker", CircuitBreaker.class)
+               .enable(DisableAnnotationClient.class, "failWithTimeout", Timeout.class)
+               .enable(DisableAnnotationClient.class, "asyncWaitThenReturn", Asynchronous.class)
+               .enable(DisableAnnotationClient.class, "failRetryOnceThenFallback", Fallback.class)
+               .enable(DisableAnnotationClient.class, "waitWithBulkhead", Bulkhead.class);
         
         JavaArchive testJar = ShrinkWrap
-            .create(JavaArchive.class, "ftDisableMethods.jar")
+            .create(JavaArchive.class, "ftDisableClassEnableMethod.jar")
             .addClasses(DisableAnnotationClient.class)
             .addPackage(Packages.UTILS)
             .addAsManifestResource(config, "microprofile-config.properties")
@@ -79,65 +85,64 @@ public class DisableAnnotationOnMethodsTest extends Arquillian {
             .as(JavaArchive.class);
 
         WebArchive war = ShrinkWrap
-            .create(WebArchive.class, "ftDisableMethods.war")
+            .create(WebArchive.class, "ftDisableClassEnableMethod.war")
             .addAsLibrary(testJar);
         return war;
     }
 
     /**
-     * failAndRetryOnce is annotated with maxRetries = 1 so it is expected to execute 2 times but as Retry is disabled,
-     * then no retries should be attempted.
+     * failAndRetryOnce is annotated with maxRetries = 1 so it is expected to execute 2 times.
      */
     @Test
-    public void testRetryDisabled() {
+    public void testRetryEnabled() {
+        // Always get a TestException
         Assert.assertThrows(TestException.class, () -> disableClient.failAndRetryOnce());
-        Assert.assertEquals(disableClient.getFailAndRetryOnceCounter(), 1, "Retry disabled - should be 1 exection");
+        // Should get two attempts if retry is enabled
+        Assert.assertEquals(disableClient.getFailAndRetryOnceCounter(), 2, "Retry enabled - should be 2 exections");
     }
 
     /**
-     * Test that a Fallback service is ignored when service fails.
+     * Test that a Fallback service is used when service fails.
      *
-     * ServiceB is annotated with maxRetries = 1 so serviceB is expected to execute 2 times (Retry is not disabled on the method)
+     * Retry has been disabled on the class and has not been enabled for the method,
+     * therefore there should only be one execution
      */
     @Test
     public void testFallbackDisabled() {
-        // Throw TestException because Fallback is disabled
-        Assert.assertThrows(TestException.class, () -> disableClient.failRetryOnceThenFallback());
-        // One execution because Retry is still enabled on this method
-        Assert.assertEquals(disableClient.getFailRetryOnceThenFallbackCounter(), 2, "Retry enabled - should be 2 executions");
+        // Expect no exception because fallback is enabled
+        disableClient.failRetryOnceThenFallback();
+        // One execution because Retry is disabled
+        Assert.assertEquals(disableClient.getFailRetryOnceThenFallbackCounter(), 1, "Retry disabled - should be 1 execution");
     }
 
     /**
-     * CircuitBreaker policy being disabled the policy shouldn't be applied
+     * CircuitBreaker is enabled on the method so the policy should be applied
      */
     @Test
-    public void testCircuitClosedThenOpen() {
+    public void testCircuitBreaker() {
         // Always get TestException on first execution
         Assert.assertThrows(TestException.class, () -> disableClient.failWithCircuitBreaker());
-        // Should get TestException on second execution because CircuitBreaker is disabled
-        Assert.assertThrows(TestException.class, () -> disableClient.failWithCircuitBreaker());
+        // Should get CircuitBreakerOpenException on second execution because CircuitBreaker is enabled
+        Assert.assertThrows(CircuitBreakerOpenException.class, () -> disableClient.failWithCircuitBreaker());
     }
 
     /**
-     * Test Timeout is disabled, should wait two seconds and then get a TestException
+     * Test Timeout is enabled, should fail with a timeout exception
      */
     @Test
     public void testTimeout() {
-        // Expect TestException because Timeout is disabled and will not fire
-        Assert.assertThrows(TestException.class, () -> disableClient.failWithTimeout());
+        // Expect TimeoutException because Timeout is enabled and method will time out
+        Assert.assertThrows(TimeoutException.class, () -> disableClient.failWithTimeout());
     }
 
     /**
-     * A test to check that asynchronous is disabled
-     *
-     * In normal operation, asyncClient.asyncWaitThenReturn() is launched asynchronously. As Asynchronous operation was disabled via config,
-     * test is expecting a synchronous operation.
+     * A test to check that asynchronous is enabled
      */
     @Test
     public void testAsync() throws InterruptedException, ExecutionException {
         Future<?> result = disableClient.asyncWaitThenReturn();
         try {
-            Assert.assertTrue(result.isDone(), "Returned future.isDone() expected true because Async disabled");
+            Assert.assertFalse(result.isDone(), "Returned future.isDone() expected false because Async enabled");
         }
         finally {
             result.get(); // Success or failure, don't leave the future lying around
@@ -160,8 +165,8 @@ public class DisableAnnotationOnMethodsTest extends Arquillian {
             disableClient.waitForBulkheadExecutions(2);
             
             // Try to start a third execution. This would throw a BulkheadException if Bulkhead is enabled.
-            // Bulkhead is disabled on the method so no exception expected
-            disableClient.waitWithBulkhead(CompletableFuture.completedFuture(null));
+            // Bulkhead is enabled on the method, so expect exception
+            Assert.assertThrows(BulkheadException.class, () -> disableClient.waitWithBulkhead(CompletableFuture.completedFuture(null)));
         }
         finally {
             // Clean up executor and first two executions
@@ -172,5 +177,4 @@ public class DisableAnnotationOnMethodsTest extends Arquillian {
             result2.get();
         }
     }
-
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnClassTest.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,17 +19,27 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.fault.tolerance.tck.asynchronous.AsyncClient;
-import org.eclipse.microprofile.fault.tolerance.tck.util.Connection;
-import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.StringFallbackHandler;
-import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
@@ -43,27 +53,28 @@ import org.testng.annotations.Test;
  *
  * @author <a href="mailto:antoine@sabot-durand.net">Antoine Sabot-Durand</a>
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
+ * @author <a href="mailto:anrouse@uk.ibm.com">Andrew Rouse</a>
  */
 public class DisableAnnotationOnClassTest extends Arquillian {
 
     @Inject
-    private DisableClient disableClient;
-
-    @Inject
-    private AsyncClient asyncClient;
+    private DisableAnnotationClient disableClient;
 
     @Deployment
     public static WebArchive deploy() {
+       Asset config = new DisableConfigAsset()
+               .disable(DisableAnnotationClient.class, Retry.class)
+               .disable(DisableAnnotationClient.class, CircuitBreaker.class)
+               .disable(DisableAnnotationClient.class, Timeout.class)
+               .disable(DisableAnnotationClient.class, Asynchronous.class)
+               .disable(DisableAnnotationClient.class, Fallback.class)
+               .disable(DisableAnnotationClient.class, Bulkhead.class);
+        
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftDisableClass.jar")
-            .addClasses(DisableClient.class, StringFallbackHandler.class, AsyncClient.class, Connection.class)
-            .addAsManifestResource(new StringAsset(
-              "org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableClient/Retry/enabled=false\n" +
-              "org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableClient/Fallback/enabled=false\n" +
-              "org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableClient/CircuitBreaker/enabled=false\n" +
-              "org.eclipse.microprofile.fault.tolerance.tck.disableEnv.DisableClient/Timeout/enabled=false\n" +
-              "org.eclipse.microprofile.fault.tolerance.tck.asynchronous.AsyncClient/Asynchronous/enabled=false"),
-              "microprofile-config.properties")
+            .addClasses(DisableAnnotationClient.class)
+            .addPackage(Packages.UTILS)
+            .addAsManifestResource(config, "microprofile-config.properties")
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
             .as(JavaArchive.class);
 
@@ -74,97 +85,92 @@ public class DisableAnnotationOnClassTest extends Arquillian {
     }
 
     /**
-     * Test maxRetries on @Retry.
-     *
-     * ServiceA is annotated with maxRetries = 1 so serviceA is expected to execute 2 times but as Retry is disabled,
+     * failAndRetryOnce is annotated with maxRetries = 1 so it is expected to execute 2 times but as Retry is disabled,
      * then no retries should be attempted.
      */
     @Test
     public void testRetryDisabled() {
-        try {
-            disableClient.serviceA();
-            Assert.fail("serviceA should throw a RuntimeException in testRetryDisabled");
-        }
-        catch (RuntimeException ex) {
-            // Expected
-        }
-        Assert.assertEquals(disableClient.getRetryCountForConnectionService(), 1, "The max number of executions should be 1");
+        Assert.assertThrows(TestException.class, () -> disableClient.failAndRetryOnce());
+        Assert.assertEquals(disableClient.getFailAndRetryOnceCounter(), 1, "Retry disabled - should be 1 exection");
     }
 
     /**
      * Test that a Fallback service is ignored when service fails.
      *
-     * ServiceB is annotated with maxRetries = 1 so serviceB is expected to execute 2 times but as Retry is disabled
+     * failRetryOnceThenFallback is annotated with maxRetries = 1 so serviceB is expected to execute 2 times but as Retry is disabled
      * then no retries should be attempted .
      */
     @Test
     public void testFallbackDisabled() {
-        Assert.assertThrows(RuntimeException.class, () -> disableClient.serviceB());
-        Assert.assertEquals(disableClient.getCounterForInvokingServiceB(), 1, "The execution count should be 1 (0 retries + 1)");
+        // Throw TestException because Fallback is disabled
+        Assert.assertThrows(TestException.class, () -> disableClient.failRetryOnceThenFallback());
+        // One execution because Retry is disabled
+        Assert.assertEquals(disableClient.getFailRetryOnceThenFallbackCounter(), 1, "Retry disabled - should be 1 execution");
     }
 
     /**
-     * A test to exercise Circuit Breaker thresholds, with a default SuccessThreshold
-     *
      * CircuitBreaker policy being disabled the policy shouldn't be applied
      */
     @Test
     public void testCircuitClosedThenOpen() {
-        for (int i = 0; i < 7; i++) {
-
-            try {
-                disableClient.serviceC();
-            }
-            catch (RuntimeException ex) {
-                // Expected
-            }
-            catch (Exception ex) {
-                // Not Expected
-                Assert.fail("serviceC should throw a RuntimeException in testCircuitClosedThenOpen on iteration " + i +
-                                " but caught exception " + ex);
-            }
-        }
-        int serviceCExecutions = disableClient.getCounterForInvokingServiceC();
-
-        Assert.assertEquals(serviceCExecutions, 7, "The number of executions should be 7");
+        // Always get TestException on first execution
+        Assert.assertThrows(TestException.class, () -> disableClient.failWithCircuitBreaker());
+        // Should get TestException on second execution because CircuitBreaker is disabled
+        Assert.assertThrows(TestException.class, () -> disableClient.failWithCircuitBreaker());
     }
 
     /**
-     * A test to exercise the default timeout.
-     *
-     * In normal operation, the default Fault Tolerance timeout is 1 second but serviceD will attempt to sleep for 3 seconds, so
-     * would be expected to throw a TimeoutException. However, Timeout policy being disabled, no Timeout will occur and a
-     * RuntimeException will be thrown after 3 seconds.
+     * Test Timeout is disabled, should wait two seconds and then get a TestException
      */
     @Test
     public void testTimeout() {
-        try {
-            disableClient.serviceD(3000);
-            Assert.fail("serviceD should throw a TimeoutException in testTimeout");
-        }
-        catch (TimeoutException ex) {
-            // Not Expected
-            Assert.fail("serviceD should throw a RuntimeException in testTimeout not a TimeoutException");
-        }
-        catch (RuntimeException ex) {
-            // Expected
-        }
+        // Expect TestException because Timeout is disabled and will not fire
+        Assert.assertThrows(TestException.class, () -> disableClient.failWithTimeout());
     }
 
-
     /**
-     * A test to check taht asynchronous is disabled
+     * A test to check that asynchronous is disabled
      *
-     * In normal operation, asyncClient.service() is launched asynchronously. As Asynchronous operation was disabled via config,
+     * In normal operation, asyncClient.asyncWaitThenReturn() is launched asynchronously. As Asynchronous operation was disabled via config,
      * test is expecting a synchronous operation.
-     *
-     * @throws InterruptedException
      */
     @Test
-    public void testAsync() throws InterruptedException {
-        long start = System.currentTimeMillis();
-        asyncClient.service();
-        Assert.assertTrue(System.currentTimeMillis()-start >= 1000);
-
+    public void testAsync() throws InterruptedException, ExecutionException {
+        Future<?> result = disableClient.asyncWaitThenReturn();
+        try {
+            Assert.assertTrue(result.isDone(), "Returned future.isDone() expected true because Async disabled");
+        }
+        finally {
+            result.get(); // Success or failure, don't leave the future lying around
+        }
+    }
+    
+    /**
+     * Test whether Bulkhead is enabled on {@code waitWithBulkhead()}
+     */
+    @Test
+    public void testBulkhead() throws ExecutionException, InterruptedException {
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        
+        // Start two executions at once
+        CompletableFuture<Void> waitingFuture = new CompletableFuture<>();
+        Future<?> result1 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
+        Future<?> result2 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
+        
+        try {
+            disableClient.waitForBulkheadExecutions(2);
+            
+            // Try to start a third execution. This would throw a BulkheadException if Bulkhead is enabled.
+            // Bulkhead is disabled on the class so no exception expected
+            disableClient.waitWithBulkhead(CompletableFuture.completedFuture(null));
+        }
+        finally {
+            // Clean up executor and first two executions
+            executor.shutdown();
+            
+            waitingFuture.complete(null);
+            result1.get();
+            result2.get();
+        }
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableConfigAsset.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableConfigAsset.java
@@ -1,0 +1,155 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.util.Properties;
+
+import org.jboss.shrinkwrap.api.asset.Asset;
+
+/**
+ * Asset which writes a config file with lines to enable and disable annotations
+ * 
+ * @author <a href="mailto:anrouse@uk.ibm.com">Andrew Rouse</a>
+ */
+public class DisableConfigAsset implements Asset {
+    
+    private Properties props = new Properties();
+
+    @Override
+    public InputStream openStream() {
+        try {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            props.store(os, null);
+            return new ByteArrayInputStream(os.toByteArray());
+        }
+        catch (IOException e) {
+            // Shouldn't happen since we're only using in memory streams
+            throw new RuntimeException("Unexpected error saving properties", e);
+        }
+    }
+    
+    /**
+     * Add config entry to disable an annotation on the given class and method
+     * 
+     * @param clazz the class
+     * @param method the method
+     * @param annotation the annotation
+     * @return itself
+     */
+    public DisableConfigAsset disable(Class<?> clazz, String method, Class<? extends Annotation> annotation) {
+        props.put(keyFor(clazz, method, annotation), "false");
+        return this;
+    }
+    
+    /**
+     * Add config entry to disable an annotation on the given class
+     * 
+     * @param clazz the class
+     * @param annotation the annotation
+     * @return itself
+     */
+    public DisableConfigAsset disable(Class<?> clazz, Class<? extends Annotation> annotation) {
+        props.put(keyFor(clazz, null, annotation), "false");
+        return this;
+    }
+    
+    /**
+     * Add config entry to disable an annotation globally
+     * 
+     * @param annotation the annotation
+     * @return itself
+     */
+    public DisableConfigAsset disable(Class<? extends Annotation> annotation) {
+        props.put(keyFor(null, null, annotation), "false");
+        return this;
+    }
+
+    /**
+     * Add config entry to enable an annotation on the given class and method
+     * 
+     * @param clazz the class
+     * @param method the method
+     * @param annotation the annotation
+     * @return itself
+     */
+    public DisableConfigAsset enable(Class<?> clazz, String method, Class<? extends Annotation> annotation) {
+        props.put(keyFor(clazz, method, annotation), "true");
+        return this;
+    }
+    
+    /**
+     * Add config entry to enable an annotation on the given class
+     * 
+     * @param clazz the class
+     * @param annotation the annotation
+     * @return itself
+     */
+    public DisableConfigAsset enable(Class<?> clazz, Class<? extends Annotation> annotation) {
+        props.put(keyFor(clazz, null, annotation), "true");
+        return this;
+    }
+    
+    /**
+     * Add config entry to enable an annotation globally
+     * 
+     * @param annotation the annotation
+     * @return itself
+     */
+    public DisableConfigAsset enable(Class<? extends Annotation> annotation) {
+        props.put(keyFor(null, null, annotation), "true");
+        return this;
+    }
+
+    
+    /**
+     * Build config key used to enable an annotation for a class and method
+     * <p>
+     * E.g. {@code com.example.MyClass/myMethod/Retry/enabled}
+     * 
+     * @param clazz may be null
+     * @param method may be null
+     * @param annotation required
+     * @return config key
+     */
+    private String keyFor(Class<?> clazz, String method, Class<? extends Annotation> annotation) {
+        StringBuilder sb = new StringBuilder();
+        if (clazz != null) {
+            sb.append(clazz.getCanonicalName());
+            sb.append("/");
+        }
+        
+        if (method != null) {
+            sb.append(method);
+            sb.append("/");
+        }
+        
+        sb.append(annotation.getSimpleName());
+        sb.append("/");
+        sb.append("enabled");
+        
+        return sb.toString();
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutionException;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -43,7 +44,8 @@ public class AllMetricsTest extends Arquillian {
     public static WebArchive deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricAll.war")
                 .addClasses(AllMetricsBean.class)
-                .addPackage(MetricGetter.class.getPackage());
+                .addPackage(Packages.UTILS)
+                .addPackage(Packages.METRIC_UTILS);
         
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/BulkheadMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/BulkheadMetricTest.java
@@ -34,6 +34,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.AsyncCaller;
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Snapshot;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -49,7 +50,8 @@ public class BulkheadMetricTest extends Arquillian {
     public static WebArchive deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricBulkhead.war")
                 .addClasses(BulkheadMetricBean.class)
-                .addPackage(MetricGetter.class.getPackage());
+                .addPackage(Packages.UTILS)
+                .addPackage(Packages.METRIC_UTILS);
         return war;
     }
     

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricBean.java
@@ -21,7 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
 import javax.enterprise.context.RequestScoped;
 
-import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.TestException;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 
 @RequestScoped

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricTest.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.CircuitBreakerMetricBean.Result;
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -44,7 +45,8 @@ public class CircuitBreakerMetricTest extends Arquillian {
     public static WebArchive deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricCircuitBreaker.war")
                 .addClasses(CircuitBreakerMetricBean.class)
-                .addPackage(MetricGetter.class.getPackage());
+                .addPackage(Packages.UTILS)
+                .addPackage(Packages.METRIC_UTILS);
         return war;
     }
     

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClassLevelMetricBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClassLevelMetricBean.java
@@ -21,7 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
 import javax.enterprise.context.RequestScoped;
 
-import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.TestException;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 /**

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClassLevelMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClassLevelMetricTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -42,7 +43,8 @@ public class ClassLevelMetricTest extends Arquillian {
     public static WebArchive deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricClassLevel.war")
                 .addClasses(ClassLevelMetricBean.class)
-                .addPackage(MetricGetter.class.getPackage());
+                .addPackage(Packages.UTILS)
+                .addPackage(Packages.METRIC_UTILS);
         
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricBean.java
@@ -21,7 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
 import javax.enterprise.context.ApplicationScoped;
 
-import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.TestException;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 
 @ApplicationScoped

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricHandler.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricHandler.java
@@ -23,7 +23,7 @@ import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricBean.Action;
-import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.TestException;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.ExecutionContext;
 import org.eclipse.microprofile.faulttolerance.FallbackHandler;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricTest.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.FallbackMetricBean.Action;
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -39,7 +40,8 @@ public class FallbackMetricTest extends Arquillian {
     public static WebArchive deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricFallback.war")
                 .addClasses(FallbackMetricBean.class, FallbackMetricHandler.class)
-                .addPackage(MetricGetter.class.getPackage());
+                .addPackage(Packages.UTILS)
+                .addPackage(Packages.METRIC_UTILS);
         return war;
     }
     

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/MetricsDisabledTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/MetricsDisabledTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutionException;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -43,7 +44,8 @@ public class MetricsDisabledTest extends Arquillian {
     public static WebArchive deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricDisabled.war")
                 .addClasses(AllMetricsBean.class)
-                .addPackage(MetricGetter.class.getPackage())
+                .addPackage(Packages.UTILS)
+                .addPackage(Packages.METRIC_UTILS)
                 .addAsResource(new StringAsset("MP_Fault_Tolerance_Metrics_Enabled=false"), "META-INF/microprofile-config.properties");
         
         return war;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/RetryMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/RetryMetricTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -38,7 +39,8 @@ public class RetryMetricTest extends Arquillian {
     public static WebArchive deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricRetry.war")
                 .addClasses(RetryMetricBean.class)
-                .addPackage(MetricGetter.class.getPackage());
+                .addPackage(Packages.UTILS)
+                .addPackage(Packages.METRIC_UTILS);
         
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/TimeoutMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/TimeoutMetricTest.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricComparator;
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Snapshot;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -41,7 +42,8 @@ public class TimeoutMetricTest extends Arquillian {
     public static WebArchive deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricTimeout.war")
                 .addClasses(TimeoutMetricBean.class)
-                .addPackage(MetricGetter.class.getPackage());
+                .addPackage(Packages.UTILS)
+                .addPackage(Packages.METRIC_UTILS);
         return war;
     }
     

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/util/Exceptions.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/util/Exceptions.java
@@ -24,6 +24,7 @@ import static org.testng.Assert.fail;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/ConcurrentExecutionTracker.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/ConcurrentExecutionTracker.java
@@ -1,0 +1,91 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.Dependent;
+
+/**
+ * Utility bean to track the number of concurrent executions of a method
+ * <p>
+ * The method being tracked needs to call {@link #executionStarted()} when it
+ * starts and {@link #executionEnded()} when it's about to end.
+ * 
+ * <pre>
+ * try {
+ *     tracker.executionStarted();
+ *     // whatever the method is meant to do
+ * }
+ * finally {
+ *     tracker.executionEnded()
+ * }
+ * </pre>
+ * <p>
+ * Another method can then call {@link #waitForRunningExecutions(int)} to wait
+ * for the expected number of executions to start.
+ */
+@Dependent
+public class ConcurrentExecutionTracker {
+    
+    // The Atomicness is not important, this is just an integer holder
+    private AtomicInteger executionCount = new AtomicInteger(0);
+    
+    private static final long WAIT_TIMEOUT = 3L * 1000 * 1_000_000; 
+
+    /**
+     * Wait for the given number of method executions to be running
+     * <p>
+     * This method will wait three seconds before returning an exception
+     */
+    public void waitForRunningExecutions(int executions) {
+        synchronized (executionCount) {
+            long startTime = System.nanoTime();
+            try {
+                while (executionCount.get() != executions && (System.nanoTime() - startTime) < WAIT_TIMEOUT) {
+                    executionCount.wait(500);
+                }
+            }
+            catch (InterruptedException e) {
+                // Stop waiting
+            }
+            
+            if (executionCount.get() != executions) {
+                // Timed out waiting
+                throw new RuntimeException("Timed out waiting for executions to start, expected " + executions + " but there were " + executionCount);
+            }
+        }
+    }
+    
+    public void executionStarted() {
+        synchronized (executionCount) {
+            executionCount.incrementAndGet();
+            executionCount.notifyAll();
+        }
+    }
+    
+    public void executionEnded() {
+        synchronized (executionCount) {
+            executionCount.decrementAndGet();
+            executionCount.notifyAll();
+        }
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/Packages.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/Packages.java
@@ -17,24 +17,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-package org.eclipse.microprofile.fault.tolerance.tck.metrics;
+package org.eclipse.microprofile.fault.tolerance.tck.util;
 
-import javax.enterprise.context.RequestScoped;
-
-import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
-import org.eclipse.microprofile.faulttolerance.Retry;
-
-@RequestScoped
-public class RetryMetricBean {
+/**
+ * Contains constants for utilities packages which need to be included by lots of tests.
+ */
+public class Packages {
     
-    private int calls = 0;
-
-    @Retry(maxRetries = 5)
-    public void failSeveralTimes(int timesToFail) {
-        calls++;
-        if (calls <= timesToFail) {
-            throw new TestException("call no. " + calls);
-        }
-    }
+    // Utility class only, no public constructors
+    private Packages() {}
     
+    /**
+     * The {@code org.eclipse.microprofile.fault.tolerance.tck.util} package
+     */
+    public static final Package UTILS = Package.getPackage("org.eclipse.microprofile.fault.tolerance.tck.util");
+    
+    /**
+     * The {@code org.eclipse.microprofile.fault.tolerance.tck.metrics.util} package
+     */
+    public static final Package METRIC_UTILS = Package.getPackage("org.eclipse.microprofile.fault.tolerance.tck.metrics.util");
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TestException.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TestException.java
@@ -17,7 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-package org.eclipse.microprofile.fault.tolerance.tck.metrics.util;
+package org.eclipse.microprofile.fault.tolerance.tck.util;
 
 /**
  * An identifiable exception thrown by tests which test handling of exceptions thrown by user code.


### PR DESCRIPTION
Allow annotations to be explicitly enabled via config as well as being disabled.

This allows a Fault Tolerance annotation to be disabled globally, but then enabled for a specific class or method.

Add TCKs to test this behaviour.

This is to address #266 

This includes and completes the work that @Emily-Jiang started under #270