### PR TITLE
Remove testable=true from ShouldThrowException annotations

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodTest.java
@@ -37,7 +37,7 @@ public class IncompatibleFallbackMethodTest extends Arquillian {
     FallbackMethodClient fallbackMethodClient;
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deployAnotherApp() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalid.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodWithArgsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackMethodWithArgsTest.java
@@ -37,7 +37,7 @@ public class IncompatibleFallbackMethodWithArgsTest extends Arquillian {
     FallbackMethodWithArgsClient fallbackMethodClient;
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deployAnotherApp() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftInvalid.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackPolicies.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackPolicies.java
@@ -37,7 +37,7 @@ public class IncompatibleFallbackPolicies extends Arquillian {
     FallbackClient fallbackClient;
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalid.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackTest.java
@@ -37,7 +37,7 @@ public class IncompatibleFallbackTest extends Arquillian {
     FallbackClient fallbackClient;
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalid.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadAsynchQueueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadAsynchQueueTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidBulkheadAsynchQueueTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidBulkhead3.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadValueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidBulkheadValueTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidBulkheadValueTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidBulkhead1.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerDelayTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerDelayTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerDelayTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB1.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioNegTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureRatioNegTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB3.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioPosTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureRatioPosTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureRatioPosTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB2.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVol0Test.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVol0Test.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureReqVol0Test extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB4.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVolNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureReqVolNegTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureReqVolNegTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB5.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccess0Test.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccess0Test.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureSuccess0Test extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB6.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccessNegTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidCircuitBreakerFailureSuccessNegTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidCircuitBreakerFailureSuccessNegTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidCB7.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayDurationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayDurationTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidRetryDelayDurationTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy2() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidRetry3.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryDelayTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidRetryDelayTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidRetry1.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryJitterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryJitterTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidRetryJitterTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidRetry4.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryMaxRetriesTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidRetryMaxRetriesTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidRetryMaxRetriesTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidRetry2.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidTimeoutValueTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidTimeoutValueTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidTimeoutValueTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidTimeout.jar")


### PR DESCRIPTION
Signed-off-by: Gordon Hutchison <Gordon.Hutchison@gmail.com>

As discussed in #211 it is not possible for an implementor of DeployableContainer
to both throw an exception from deploy AND give arquillian-core the metadata it needs to make
a test testable (for example to get the context endpoints needed to speak to communicate with the test on the container). 

So TCK tests with ShouldThrowException( ... testable = true ) could never be testable on a
arquillian container and indeed the current arquillian core will NPE. There is no way to code
round this in the Container code with the current DeployableContainer interface.

This can be seen in 
wildfly - https://issues.jboss.org/browse/WFARQ-36 and
liberty - #211  ( and OpenLiberty/open-liberty#3100 )