### PR TITLE
Add spec changes to clarify the configuration order

### DIFF
--- a/spec/src/main/asciidoc/configuration.asciidoc
+++ b/spec/src/main/asciidoc/configuration.asciidoc
@@ -160,7 +160,7 @@ Policy will be disabled everywhere ignoring existing policy annotations on metho
 
 If the above configurations patterns are used with a value other than `true` or `false` (i.e. `<classname>/<methodname>/<annotation>/enabled=whatever`) non-portable behaviour results.
 
-When the above configuration is used together with `MP_Fault_Tolerance_NonFallback_Enabled`, `MP_Fault_Tolerance_NonFallback_Enabled`has the lowest priority. 
+When the above configuration is used together with `MP_Fault_Tolerance_NonFallback_Enabled`, `MP_Fault_Tolerance_NonFallback_Enabled` has the lowest priority. 
 `MP_Fault_Tolerance_NonFallback_Enabled=true`
 `Bulkhead/enabled=true`
 All other annotations except `Fallback` and `Bulkhead` will not be enabled.

--- a/spec/src/main/asciidoc/configuration.asciidoc
+++ b/spec/src/main/asciidoc/configuration.asciidoc
@@ -159,3 +159,10 @@ For instance the following config will disable bulkhead policy globally:
 Policy will be disabled everywhere ignoring existing policy annotations on methods and classes.
 
 If the above configurations patterns are used with a value other than `true` or `false` (i.e. `<classname>/<methodname>/<annotation>/enabled=whatever`) non-portable behaviour results.
+
+When the above configuration is used together with `MP_Fault_Tolerance_NonFallback_Enabled`, `MP_Fault_Tolerance_NonFallback_Enabled`has the lowest priority. 
+`MP_Fault_Tolerance_NonFallback_Enabled=true`
+`Bulkhead/enabled=true`
+All other annotations except `Fallback` and `Bulkhead` will not be enabled.
+
+ 

--- a/spec/src/main/asciidoc/configuration.asciidoc
+++ b/spec/src/main/asciidoc/configuration.asciidoc
@@ -160,7 +160,7 @@ Policy will be disabled everywhere ignoring existing policy annotations on metho
 
 If the above configurations patterns are used with a value other than `true` or `false` (i.e. `<classname>/<methodname>/<annotation>/enabled=whatever`) non-portable behaviour results.
 
-When the above configuration is used together with `MP_Fault_Tolerance_NonFallback_Enabled`, `MP_Fault_Tolerance_NonFallback_Enabled` has the lowest priority. 
+When the above property is used together with the property `MP_Fault_Tolerance_NonFallback_Enabled`, the propoerty `MP_Fault_Tolerance_NonFallback_Enabled` has the lowest priority. 
 `MP_Fault_Tolerance_NonFallback_Enabled=true`
 `Bulkhead/enabled=true`
 All other annotations except `Fallback` and `Bulkhead` will not be enabled.


### PR DESCRIPTION
when using `MP_Fault_Tolerance_NonFallback_Enabled` together with other individual configuration, the property `MP_Fault_Tolerance_NonFallback_Enabled` has the lowest priority.