### PR TITLE
Fix mistake in the metrics integration spec

### DIFF
--- a/spec/src/main/asciidoc/metrics.asciidoc
+++ b/spec/src/main/asciidoc/metrics.asciidoc
@@ -175,7 +175,7 @@ Similarly, the sum of `ft.<name>.circuitbreaker.open.total`, `ft.<name>.circuitb
 | Name | Type | Unit | Description
 
 |`ft.<name>.fallback.calls.total`
-| Gauge<Long> | None
+| Counter | None
 | Number of times the fallback handler or method was called
 |===
 


### PR DESCRIPTION
`ft.<name>.fallback.calls.total` is a `Counter`, not a `Gauge`.

The TCK already tests that it is a `Counter` and does not need changed.