### PR TITLE
prepare release - fix the api version and use baseline to verify

### DIFF
--- a/api/bnd.bnd
+++ b/api/bnd.bnd
@@ -1,5 +1,8 @@
 -exportcontents: \
     org.eclipse.microprofile.*
+Import-Package: \
+    javax.enterprise.util;version="[1.1,3)", \
+    *
 Bundle-SymbolicName: org.eclipse.microprofile.fault.tolerance
 Bundle-Name: MicroProfile Fault Tolerance Bundle
 Bundle-License: Apache License, Version 2.0

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -93,6 +93,24 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-baseline-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <base>
+                        <version>1.0</version>
+                    </base>
+                 </configuration>
+                <executions>
+                    <execution>
+                        <id>baseline</id>
+                        <goals>
+                            <goal>baseline</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/ExecutionContext.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/ExecutionContext.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Method;
  * 
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  */
-
+@org.osgi.annotation.versioning.ProviderType
 public interface ExecutionContext {
 
      /**

--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/package-info.java
@@ -25,6 +25,6 @@
  *
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  */
-@org.osgi.annotation.versioning.Version("1.0")
+@org.osgi.annotation.versioning.Version("1.1")
 package org.eclipse.microprofile.faulttolerance;
 


### PR DESCRIPTION
update package version and use the bnd baseline to verify
update the cdi dependency to work with both cdi 1.2 and cdi 2.0

Signed-off-by: Emily Jiang <emijiang@uk.ibm.com>