### PR TITLE
Fix race condition in ClashingNameTest.testClashingName

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClashingNameTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClashingNameTest.java
@@ -23,6 +23,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 
+import java.util.concurrent.ExecutionException;
+
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
@@ -47,12 +49,12 @@ public class ClashingNameTest extends Arquillian {
     private ClashingNameBean clashingNameBean;
     
     @Test
-    public void testClashingName() {
+    public void testClashingName() throws InterruptedException, ExecutionException {
         MetricGetter m = new MetricGetter(ClashingNameBean.class, "doWork");
         m.baselineCounters();
         
-        clashingNameBean.doWork();
-        clashingNameBean.doWork("dummy");
+        clashingNameBean.doWork().get();
+        clashingNameBean.doWork("dummy").get();
         
         assertThat("invocations", m.getInvocationsDelta(), is(greaterThan(0L)));
     }


### PR DESCRIPTION
clashingNameTest was checking that the invocation counter had been
incremented, without waiting for the Asynchronous method to return.

Usually this passes for me as the `doWork()` methods are very simple, but occasionally it fails because the async method hasn't run by the time we check the counter.

The incorrect test is in the released 1.1 TCK. I'm not sure what we need to do about that.