### PR TITLE
Specify interactions between annotations more completely

### DIFF
--- a/spec/src/main/asciidoc/asynchronous.asciidoc
+++ b/spec/src/main/asciidoc/asynchronous.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+// Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -18,18 +18,25 @@
 // Contributors:
 // Emily Jiang
 // Ondro Mihalyi
+// Andrew Rouse
 
 [[asynchronous]]
 == Asynchronous
 
 `Asynchronous` means the execution of the client request will be on a separate thread.
-This thread should have the correct security context or naming context associated with.
+This thread should have the correct security context or naming context associated with it.
 
 
 === Asynchronous Usage
 
 A method or a class can be annotated with `@Asynchronous`, which means the method or the methods under the class will be invoked by a separate thread.
-The method annotated with `@Asynchronous` must return a `Future` or a `CompletionStage` from the `java.util.concurrent` package. Otherwise, `FaultToleranceDefinitionException` occurs.
+The method annotated with `@Asynchronous` must return a `Future` or a `CompletionStage` from the `java.util.concurrent` package. Otherwise, a `FaultToleranceDefinitionException` occurs.
+
+When a method annotated with `@Asynchronous` is invoked, it immediately returns a `Future` or `CompletionStage`. The execution of the any remaining interceptors and the method body will then take place on a separate thread.
+
+* Until the execution has finished, the `Future` or `CompletionStage` which was returned will be incomplete.
+* If the execution throws an exception, the `Future` or `CompletionStage` will be completed with that exception. (I.e. `Future.get()` will throw an `ExecutionException` which wraps the thrown exception and any functions passed to `CompletionStage.exceptionally()` will run.)
+* If the execution completes normally and returns a value, the `Future` or `CompletionStage` will then delegate to the returned value.
 
 [source, java]
 ----
@@ -42,7 +49,13 @@ public CompletionStage<Connection> serviceA() {
 }
 ----
 
-The above code-snippet means the method serviceA applies the `Asynchronous` policy, which means the invocation will be done by a different thread.
+The above code-snippet means that the `Asynchronous` policy is applied to the `serviceA` method, which means that a call to `serviceA` will return a `CompletionStage` immediately and that execution of the method body will be done on a different thread.
 
-The `@Asynchronous` annotation can be used together with `@Timeout`, `@Fallback`, `@Bulkhead` and `@Retry`.
-Method invocation will occur in a different thread.
+The `@Asynchronous` annotation can be used together with `@Timeout`, `@Fallback`, `@Bulkhead`, `@CircuitBreaker` and `@Retry`.
+In this case, the method invocation and any fault tolerance processing will occur in a different thread. The returned `Future` or `CompletionStage` will be completed with the final result once all other Fault Tolerance processing has been completed.
+
+=== Exception Handling
+
+A call to a method annotated with `@Asynchronous` will never throw an exception directly. Instead, the returned `Future` or `CompletionStage` will report that its task failed with the exception which would have been thrown.
+
+For example, if `@Asynchronous` is used with `@Bulkhead` on a method which returns a `Future` and the bulkhead queue is full when the method is called, the method will return a `Future` where calling `isDone()` returns `true` and calling `get()` will throw an `ExecutionException` which wraps a `BulkheadException`.

--- a/spec/src/main/asciidoc/bulkhead.asciidoc
+++ b/spec/src/main/asciidoc/bulkhead.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -17,6 +17,7 @@
 // limitations under the License.
 // Contributors:
 // Emily Jiang
+// Andrew Rouse
 
 [[bulkhead]]
 == Bulkhead
@@ -34,7 +35,7 @@ The semaphore approach only allows the concurrent number of requests configurati
 
 ==== Semaphore style Bulkhead
 
-The below code-snippet means the method serviceA applies the `Bulkhead` policy, which is semaphore approach, limiting the maximum concurrent requests to 5.
+The below code-snippet means the method serviceA applies the `Bulkhead` policy with the semaphore approach, limiting the maximum concurrent requests to 5.
 
 [source, java]
 ----
@@ -52,7 +53,7 @@ When using the semaphore approach, on reaching maximum request counter, the extr
 
 ==== Thread pool style Bulkhead
 
-The below code-snippet means the method serviceA applies the `Bulkhead` policy, which is thread pool approach, limiting the maximum concurrent requests to 5 and the waiting queue size to 8.
+The below code-snippet means the method serviceA applies the `Bulkhead` policy with the thread pool approach, limiting the maximum concurrent requests to 5 and the waiting queue size to 8.
 
 [source, java]
 ----
@@ -71,4 +72,7 @@ public Future<Connection> serviceA() {
 When using the thread pool approach, when a request cannot be added to the waiting queue, `BulkheadException` will be thrown.
 
 The `@Bulkhead` annotation can be used together with `@Fallback`, `@CircuitBreaker`, `@Asynchronous`, `@Timeout` and `@Retry`.
+
 If a `@Fallback` is specified, it will be invoked if the `BulkheadException` is thrown.
+
+If `@Retry` is used with `@Bulkhead`, when an invocation fails due to a `BulkheadException` it is retried after waiting for the delay configured on `@Retry`. If an invocation is permitted to run by the bulkhead but then throws another exception which is handled by `@Retry`, it first leaves the bulkhead, reducing the count of running concurrent requests by 1, waits for the delay configured on `@Retry`, and then attempts to enter the bulkhead again. At this point, it may be accepted, queued (if the method is also annotated with `@Asynchronous`) or fail with a `BulkheadException` (which may result in further retries).

--- a/spec/src/main/asciidoc/circuitbreaker.asciidoc
+++ b/spec/src/main/asciidoc/circuitbreaker.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+// Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -17,6 +17,7 @@
 // limitations under the License.
 // Contributors:
 // Emily Jiang
+// Andrew Rouse
 
 [[circuitbreaker]]
 == Circuit Breaker
@@ -61,5 +62,9 @@ After 10 consecutive successful invocations, the circuit will be back to close a
 
 When a circuit is open, A `CircuitBreakerOpenException` must be thrown.
 The `@CircuitBreaker` annotation can be used together with `@Timeout`, `@Fallback`, `@Asynchronous`, `@Bulkhead` and `@Retry`.
-A `@Fallback` can be specified and it will be invoked if the `CircuitBreakerOpenException` is thrown.
-`@Timeout` can be configured to fail an operation if it takes longer than the `Timeout` value to complete.
+
+If `@Fallback` is used with `@CircuitBreaker`, the fallback method or handler will be invoked if a `CircuitBreakerOpenException` is thrown.
+
+If `@Retry` is used with `@CircuitBreaker`, each retry attempt is processed by the circuit breaker and recorded as either a success or a failure. If a `CircuitBreakerOpenException` is thrown, the execution may be retried, depending on how the `@Retry` is configured.
+
+If `@Bulkhead` is used with `@Circuitbreaker`, the circuit breaker is checked before attempting to enter the bulkhead. If attempting to enter the bulkhead results in a `BulkheadException`, this may be counted as a failure, depending on the value of the circuit breaker `failOn` attribute.

--- a/spec/src/main/asciidoc/retry.asciidoc
+++ b/spec/src/main/asciidoc/retry.asciidoc
@@ -1,6 +1,7 @@
 //
-// Copyright (c) 2016-2017 Eclipse Microprofile Contributors:
+// Copyright (c) 2016-2018 Eclipse Microprofile Contributors:
 // Emily Jiang
+// Andrew Rouse
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -71,6 +72,7 @@ If the `@Retry` policy applied on a class level and on a method level within tha
 ----
 
 The `@Retry` annotation can be used together with `@Fallback`, `@CircuitBreaker`, `@Asynchronous`, `@Bulkhead` and `@Timeout`.
-A `@Fallback` can be specified and it will be invoked if the `@Retry` still fails.
 
-If `@Retry` is used with `@Timeout`, a retry will only be triggered if `TimeoutException` or one of its super classes are defined in the `retryOn` attribute of the `@Retry`.
+A `@Fallback` can be specified and it will be invoked if the method still fails after any retires have been run.
+
+If `@Retry` is used with `@Asynchronous` and a retry is required, the new retry attempt may be run on the same thread as the previous attempt, or on a different thread.

--- a/spec/src/main/asciidoc/timeout.asciidoc
+++ b/spec/src/main/asciidoc/timeout.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 Contributors to the Eclipse Foundation
+// Copyright (c) 2017-2018 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -17,6 +17,7 @@
 // limitations under the License.
 // Contributors:
 // Emily Jiang
+// Andrew Rouse
 
 [[timeout]]
 == Timeout
@@ -52,8 +53,12 @@ When `@Timeout` is used without `@Asynchronous`, the current thread will be inte
 
 In the above situations, it is impossible to suspend the execution. The execution thread will finish its process. If the execution takes longer than the specified timeout, the `TimeoutException` will be thrown and the execution result will be discarded.
 
-When `@Timeout` is used with `@Asynchronous`, then a separate thread will be spawned to perform the work in the annotated method or methods, while a `Future` is returned on the main thread. If the work on the spawned thread does timeout, then a get() call to the `Future` on the main thread should throw an `ExecutionException` that wraps a fault tolerance `TimeoutException`.
+If `@Timeout` is used with `@Asynchronous`, then a separate thread will be spawned to perform the work in the annotated method or methods, while a `Future` or `CompletionStage` is returned on the main thread. If the work on the spawned thread does time out, then a get() call to the `Future` on the main thread will throw an `ExecutionException` that wraps a fault tolerance `TimeoutException`.
 
-A `@Fallback` can be specified and it will be invoked if the `TimeoutException` is thrown.
-If `@Timeout` is used together with `@Retry`, the `TimoutException` will trigger the retry.
-When `@Timeout` is used with `@CircuitBreaker` and if a `TimeoutException` occurs, the failure will contribute towards the circuit open.
+If `@Timeout` is used with `@Fallback` then the fallback method or handler will be invoked if a `TimeoutException` is thrown (unless the exception is handled by another fault tolerance component).
+
+If `@Timeout` is used with `@Retry`, a `TimeoutException` may trigger a retry, depending on the values of `retryOn` and `abortOn` of the `@Retry` annotation. The timeout is restarted for each retry. If `@Asynchronous` is also used and the retry is the result of a `TimeoutException`, the retry starts after any delay period, even if the original attempt is still running.
+
+If `@Timeout` is used with `@CircuitBreaker`, a `TimeoutException` may be counted as a failure by the circuit breaker and contribute towards opening the circuit, depending on the value of `failOn` on the `@CircuitBreaker` annotation.
+
+If `@Timeout` is used with `@Bulkhead` and `@Asynchronous`, the execution time measured by `@Timeout` should be the period starting when the execution is added to the Bulkhead queue, until the execution completes. If a timeout occurs while the execution is still in the queue, it must be removed from the queue and must not be started. If a timeout occurs while the method is executing, the thread where the method is executing must be interrupted but the method must still count as a running concurrent request for the Bulkhead until it actually returns.


### PR DESCRIPTION
Adds detail about how fault tolerance annotations interact and adds some
detail to @Asynchronous which was previously only present in the
Javadoc.

Addresses #291 