### PR TITLE
TCK: Packages.METRIC_UTILS may be null - causes a lot of tests to fail

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/Packages.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/Packages.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 package org.eclipse.microprofile.fault.tolerance.tck.util;
 
 /**
@@ -30,10 +29,10 @@ public class Packages {
     /**
      * The {@code org.eclipse.microprofile.fault.tolerance.tck.util} package
      */
-    public static final Package UTILS = Package.getPackage("org.eclipse.microprofile.fault.tolerance.tck.util");
+    public static final Package UTILS = org.eclipse.microprofile.fault.tolerance.tck.util.Packages.class.getPackage();
     
     /**
      * The {@code org.eclipse.microprofile.fault.tolerance.tck.metrics.util} package
      */
-    public static final Package METRIC_UTILS = Package.getPackage("org.eclipse.microprofile.fault.tolerance.tck.metrics.util");
+    public static final Package METRIC_UTILS = org.eclipse.microprofile.fault.tolerance.tck.metrics.util.AsyncCaller.class.getPackage();
 }


### PR DESCRIPTION
fixes #317

Signed-off-by: Antoine Sabot-Durand <antoine@sabot-durand.net>