### PR TITLE
TCK: Tests in org.eclipse.microprofile.fault.tolerance.tck.metrics do not add beans.xml to deployments

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsTest.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -32,6 +31,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -45,7 +45,8 @@ public class AllMetricsTest extends Arquillian {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricAll.war")
                 .addClasses(AllMetricsBean.class)
                 .addPackage(Packages.UTILS)
-                .addPackage(Packages.METRIC_UTILS);
+                .addPackage(Packages.METRIC_UTILS)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/BulkheadMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/BulkheadMetricTest.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
 import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectBulkheadException;
@@ -40,6 +39,7 @@ import org.eclipse.microprofile.metrics.Snapshot;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.Test;
@@ -51,7 +51,8 @@ public class BulkheadMetricTest extends Arquillian {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricBulkhead.war")
                 .addClasses(BulkheadMetricBean.class)
                 .addPackage(Packages.UTILS)
-                .addPackage(Packages.METRIC_UTILS);
+                .addPackage(Packages.METRIC_UTILS)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         return war;
     }
     

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricTest.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
 import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectCbOpen;
@@ -33,6 +32,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenExce
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -46,7 +46,8 @@ public class CircuitBreakerMetricTest extends Arquillian {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricCircuitBreaker.war")
                 .addClasses(CircuitBreakerMetricBean.class)
                 .addPackage(Packages.UTILS)
-                .addPackage(Packages.METRIC_UTILS);
+                .addPackage(Packages.METRIC_UTILS)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         return war;
     }
     

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClashingNameTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClashingNameTest.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,6 +30,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -40,7 +40,8 @@ public class ClashingNameTest extends Arquillian {
     public static WebArchive deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricClash.war")
                 .addClasses(ClashingNameBean.class)
-                .addPackage(MetricGetter.class.getPackage());
+                .addPackage(MetricGetter.class.getPackage())
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClassLevelMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClassLevelMetricTest.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
 import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectTestException;
@@ -30,6 +29,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -44,7 +44,8 @@ public class ClassLevelMetricTest extends Arquillian {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricClassLevel.war")
                 .addClasses(ClassLevelMetricBean.class)
                 .addPackage(Packages.UTILS)
-                .addPackage(Packages.METRIC_UTILS);
+                .addPackage(Packages.METRIC_UTILS)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricTest.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
 import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectTestException;
@@ -31,6 +30,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -41,7 +41,8 @@ public class FallbackMetricTest extends Arquillian {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricFallback.war")
                 .addClasses(FallbackMetricBean.class, FallbackMetricHandler.class)
                 .addPackage(Packages.UTILS)
-                .addPackage(Packages.METRIC_UTILS);
+                .addPackage(Packages.METRIC_UTILS)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         return war;
     }
     

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/MetricsDisabledTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/MetricsDisabledTest.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,6 +30,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
@@ -46,7 +46,8 @@ public class MetricsDisabledTest extends Arquillian {
                 .addClasses(AllMetricsBean.class)
                 .addPackage(Packages.UTILS)
                 .addPackage(Packages.METRIC_UTILS)
-                .addAsResource(new StringAsset("MP_Fault_Tolerance_Metrics_Enabled=false"), "META-INF/microprofile-config.properties");
+                .addAsResource(new StringAsset("MP_Fault_Tolerance_Metrics_Enabled=false"), "META-INF/microprofile-config.properties")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/RetryMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/RetryMetricTest.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
 import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectTestException;
@@ -30,6 +29,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -40,7 +40,8 @@ public class RetryMetricTest extends Arquillian {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricRetry.war")
                 .addClasses(RetryMetricBean.class)
                 .addPackage(Packages.UTILS)
-                .addPackage(Packages.METRIC_UTILS);
+                .addPackage(Packages.METRIC_UTILS)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/TimeoutMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/TimeoutMetricTest.java
@@ -1,5 +1,4 @@
 /*
- *******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
@@ -16,7 +15,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *******************************************************************************/
+ */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
 import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectTimeout;
@@ -33,6 +32,7 @@ import org.eclipse.microprofile.metrics.Snapshot;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -43,7 +43,8 @@ public class TimeoutMetricTest extends Arquillian {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricTimeout.war")
                 .addClasses(TimeoutMetricBean.class)
                 .addPackage(Packages.UTILS)
-                .addPackage(Packages.METRIC_UTILS);
+                .addPackage(Packages.METRIC_UTILS)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
         return war;
     }
     


### PR DESCRIPTION
Fixes #318

Signed-off-by: Antoine Sabot-Durand <antoine@sabot-durand.net>