### PR TITLE
Issue #312 - Retry: What happens when delay is less than jitter? 

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/Retry.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/Retry.java
@@ -81,6 +81,8 @@ public @interface Retry {
     /**
      * Set the jitter to randomly vary retry delays for. The value must be greater than or equals to 0. 
      * 0 means not set.
+     * The effective delay will be [delay - jitter, delay + jitter] and allways greater than or equal to 0.
+     * Negative effective delays will be 0.
      * @return the jitter that randomly vary retry delays by. e.g. a jitter of 200 milliseconds
      * will randomly add between -200 and 200 milliseconds to each retry delay.
      */

--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/Retry.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/Retry.java
@@ -83,7 +83,7 @@ public @interface Retry {
      * Set the jitter to randomly vary retry delays for. The value must be greater than or equals to 0.
      * 0 means not set.
      * </p>
-     * The effective delay will be [delay - jitter, delay + jitter] and allways greater than or equal to 0.
+     * The effective delay will be [delay - jitter, delay + jitter] and always greater than or equal to 0.
      * Negative effective delays will be 0.
      *
      * @return the jitter that randomly vary retry delays by. e.g. a jitter of 200 milliseconds

--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/Retry.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/Retry.java
@@ -18,6 +18,8 @@
  */
 package org.eclipse.microprofile.faulttolerance;
 
+import javax.enterprise.util.Nonbinding;
+import javax.interceptor.InterceptorBinding;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -25,9 +27,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.time.temporal.ChronoUnit;
-
-import javax.enterprise.util.Nonbinding;
-import javax.interceptor.InterceptorBinding;
 
 /**
  * The Retry annotation to define the number of the retries and the fallback method on reaching the
@@ -79,10 +78,13 @@ public @interface Retry {
     ChronoUnit durationUnit() default ChronoUnit.MILLIS;
 
     /**
-     * Set the jitter to randomly vary retry delays for. The value must be greater than or equals to 0. 
+     * <p>
+     * Set the jitter to randomly vary retry delays for. The value must be greater than or equals to 0.
      * 0 means not set.
+     * </p>
      * The effective delay will be [delay - jitter, delay + jitter] and allways greater than or equal to 0.
      * Negative effective delays will be 0.
+     *
      * @return the jitter that randomly vary retry delays by. e.g. a jitter of 200 milliseconds
      * will randomly add between -200 and 200 milliseconds to each retry delay.
      */

--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/Retry.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/Retry.java
@@ -18,8 +18,6 @@
  */
 package org.eclipse.microprofile.faulttolerance;
 
-import javax.enterprise.util.Nonbinding;
-import javax.interceptor.InterceptorBinding;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -27,6 +25,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.time.temporal.ChronoUnit;
+
+import javax.enterprise.util.Nonbinding;
+import javax.interceptor.InterceptorBinding;
 
 /**
  * The Retry annotation to define the number of the retries and the fallback method on reaching the

--- a/spec/src/main/asciidoc/retry.asciidoc
+++ b/spec/src/main/asciidoc/retry.asciidoc
@@ -62,6 +62,17 @@ If the `@Retry` policy applied on a class level and on a method level within tha
     }
 
     /**
+    * There should be 0-400ms delays between each invocation.
+    * The effective delay will be between:
+    * [delay - jitter, delay + jitter] and allways >= 0. Negative effective delays will be 0.
+    * There should be at least 8 retries but no more than 10 retries.
+    */
+    @Retry(delay = 0, maxDuration= 3200, jitter= 400, maxRetries = 10)
+    public Connection serviceA() {
+        return connectionService();
+    }
+
+    /**
     * Sets retry condition, which means Retry will be performed on
     * IOException.
     */

--- a/spec/src/main/asciidoc/retry.asciidoc
+++ b/spec/src/main/asciidoc/retry.asciidoc
@@ -64,7 +64,7 @@ If the `@Retry` policy applied on a class level and on a method level within tha
     /**
     * There should be 0-400ms delays between each invocation.
     * The effective delay will be between:
-    * [delay - jitter, delay + jitter] and allways >= 0. Negative effective delays will be 0.
+    * [delay - jitter, delay + jitter] and always >= 0. Negative effective delays will be 0.
     * There should be at least 8 retries but no more than 10 retries.
     */
     @Retry(delay = 0, maxDuration= 3200, jitter= 400, maxRetries = 10)

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
@@ -132,7 +132,7 @@ public class RetryTest extends Arquillian {
      * Testing whether the {@code @Retry} annotation on method serviceB overrides the Class level
      * {@code @Retry} annotation.
      *
-     * Delay is 0 and jitter 400ms. Invocation takes 3200ms and efective
+     * Delay is 0 and jitter 400ms. Invocation takes a maximum of 3200ms and should perform at least 8 tries.
      */
     @Test
     public void testRetryWithNoDelayAndJitter() {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
@@ -21,7 +21,6 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 
 import javax.inject.Inject;
 
-import jdk.nashorn.internal.ir.annotations.Ignore;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClassLevelClientForMaxRetries;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientForMaxRetries;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientWithDelay;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
@@ -128,7 +128,6 @@ public class RetryTest extends Arquillian {
         Assert.assertTrue(clientForDelay.isDelayInRange(), "The delay between each retry should be 0-800ms");
     }
 
-
     /**
      * Testing whether the {@code @Retry} annotation on method serviceB overrides the Class level
      * {@code @Retry} annotation.
@@ -146,18 +145,18 @@ public class RetryTest extends Arquillian {
         }
 
         final int retryCountForConnectionService = retryClientWithNoDelayAndJiter.getRetryCountForConnectionService();
-        final int fastDelays = retryClientWithNoDelayAndJiter.fastDelays();
 
-        // 60% to discard false positives
-        Assert.assertTrue(fastDelays < (retryCountForConnectionService * 0.6),
-            "Jitter not uniformly distributed. More than 60% retries got delay smaller than 5ms. Got " + fastDelays + " in " +
-                retryCountForConnectionService + " tries");
+        // we have positive delays
+        Assert.assertTrue(retryClientWithNoDelayAndJiter.positiveDelays() > 0,
+            "Using jitter must cause some effective delay even when delay is set to 0");
+
         Assert.assertTrue(retryCountForConnectionService > 8 && retryCountForConnectionService < 50,
             "The max number of execution should be between 8 and 50 but it was " + retryCountForConnectionService +
                 ". Too many retries mean jitter is not being applied.");
-        Assert.assertTrue(retryClientWithNoDelayAndJiter.isDelayInRange(), "The delay between each retry should be 0-400ms");
-    }
 
+        Assert.assertTrue(retryClientWithNoDelayAndJiter.isDelayInRange(),
+            "The delay between each retry should be 0-400ms");
+    }
 
     /**
      * Analogous to testRetryMaxRetries but using a Class level rather

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
@@ -133,7 +133,7 @@ public class RetryTest extends Arquillian {
      * Testing whether the {@code @Retry} annotation on method serviceB overrides the Class level
      * {@code @Retry} annotation.
      *
-     * Delay is 0 and jitter 400ms. Invocation takes 3200ms and efective
+     * Delay is 0 and jitter 400ms. Invocation takes 3200ms and effective delay must be between 0 and 400ms.
      */
     @Test
     public void testRetryWithNoDelayAndJitter() {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientWithNoDelayAndJiter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientWithNoDelayAndJiter.java
@@ -70,11 +70,12 @@ public class RetryClientWithNoDelayAndJiter {
         return counterForInvokingConnenectionService;
     }
 
-    public int fastDelays() {
+    public int positiveDelays() {
         System.out.println("delays are: " + delayTimes);
         int count = 0;
+        // ignore fast delays
         for (long delayTime : delayTimes) {
-            if (delayTime < 5) {
+            if (delayTime > 5) {
                 count++;
             }
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientWithNoDelayAndJiter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientWithNoDelayAndJiter.java
@@ -1,0 +1,75 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+import javax.enterprise.context.RequestScoped;
+import java.sql.Connection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A client to demonstrate the delay configurations
+ * @author <a href="mailto:bbaptista@tomitribe.com">Bruno Baptista</a>
+ *
+ */
+@RequestScoped
+public class RetryClientWithNoDelayAndJiter {
+    private int counterForInvokingConnenectionService;
+    private long timestampForConnectionService = 0;
+    private Set<Long> delayTimes = new HashSet<Long>();
+
+
+    //There should be 0-400ms (jitter is -400ms - 400ms but min value must be 0) delays between each invocation
+    //there should be at least 8 retries
+    @Retry(delay = 0, maxDuration= 3200, jitter= 400, maxRetries = 20)
+    public Connection serviceA() {
+        return connectionService();
+    }
+
+    //simulate a backend service
+    private Connection connectionService() {
+       // the time delay between each invocation should be 0-400ms
+       if (timestampForConnectionService != 0) {
+           long currentTime = System.currentTimeMillis() ;
+           delayTimes.add(currentTime -timestampForConnectionService );
+           timestampForConnectionService = currentTime;
+        
+       }
+        counterForInvokingConnenectionService++;
+        throw new RuntimeException("Connection failed");
+    }
+    
+    public boolean isDelayInRange() {
+        boolean isDelayInRange = true;        
+        for (long delayTime : delayTimes) {
+            if (delayTime > 400) {
+                return false;
+            }
+        }
+        return isDelayInRange;
+    }
+   
+    public int getRetryCountForConnectionService() {
+        return counterForInvokingConnenectionService;
+    }
+   
+}


### PR DESCRIPTION
Test to make sure the minimum effective delay is 0, even when jitter > delay.
Tested this in Safegard... It implements Jitter after all. These were the effective delays, in ms:
[1, 0, 0, 1, 0, 0, 28, 279, 0, 86, 19, 0, 370, 360, 142, 325, 1, 0, 200, 350, 1, 369, 0, 1, 0, 0, 0, 0, 43, 0, 0, 0, 51, 230, 37, 0, 1, 87, 0, 149, 70]


Signed-off-by: brunobat <bbaptista@tomitribe.com>