### PR TITLE
Make failRetryOnceThenFallback match its fallback method

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationClient.java
@@ -73,10 +73,12 @@ public class DisableAnnotationClient {
      * Should return normally if Fallback is enabled or throw TestException if not
      * <p>
      * Should increment counter by two if Retry is enabled or one if it is not
+     * 
+     * @return nothing, always throws TestException
      */
     @Retry(maxRetries = 1)
     @Fallback(fallbackMethod = "fallback")
-    public void failRetryOnceThenFallback() {
+    public String failRetryOnceThenFallback() {
         failRetryOnceThenFallbackCounter++;
         throw new TestException();
     }


### PR DESCRIPTION
A previous change updated the return type of DisableAnnotationClient but
did not change the return type of its fallback method. This is an
invalid configuration and causes a FaultToleranceDefinitionException at
startup, causing tests to fail when they shouldn't.

Signed-off-by: Andrew Rouse <anrouse@uk.ibm.com>