### PR TITLE
TCKs for interactions between Fault Tolerance annotations

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerBulkheadTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerBulkheadTest.java
@@ -1,0 +1,256 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expect;
+import static org.testng.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.AsyncBulkheadTask;
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTask;
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTaskManager;
+import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientWithAsyncBulkhead;
+import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientWithAsyncBulkheadNoFail;
+import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientWithSyncBulkhead;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
+import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+public class CircuitBreakerBulkheadTest extends Arquillian {
+
+    
+    @Deployment
+    public static WebArchive deploy() {
+        JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftCircuitBreakerBulkhead.jar")
+                        .addClasses(CircuitBreakerClientWithAsyncBulkhead.class,
+                                    CircuitBreakerClientWithSyncBulkhead.class,
+                                    CircuitBreakerClientWithAsyncBulkheadNoFail.class)
+                        .addPackage(BulkheadTask.class.getPackage())
+                        .addPackage(Packages.UTILS)
+                        .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                        .as(JavaArchive.class);
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "ftCircuitBreakerBulkhead.war")
+                        .addAsLibrary(testJar);
+        return war;
+    }
+    
+    @Inject
+    private CircuitBreakerClientWithAsyncBulkhead asyncBulkheadClient;
+    
+    @Inject
+    private CircuitBreakerClientWithSyncBulkhead syncBulkheadClient;
+    
+    @Inject
+    private CircuitBreakerClientWithAsyncBulkheadNoFail asyncBulkheadNoFailClient;
+
+    /**
+     * A test to ensure that the CircuitBreaker is checked before entering the
+     * Bulkhead and that BulkheadExceptions count as failures for the
+     * CircuitBreaker.
+     * 
+     * Uses an asynchronous bulkhead
+     * 
+     * With requestVolumeThreshold = 3, failureRatio = 1.0,
+     * delay = 50000 the expected behaviour is,
+     * 
+     * Execution Behaviour
+     * ========= =========
+     * 1 Fill Bulkhead
+     * 2 Fill Bulkhead
+     * 3 BulkheadException
+     * 4 BulkheadException
+     * 5 BulkheadException
+     * 6 CircuitBreakerOpenException
+     * 7 CircuitBreakerOpenException
+     * 
+     * @throws InterruptedException if the test is interrupted 
+     * @throws TimeoutException if waiting for a result takes too long
+     * @throws ExecutionException if an async method throws an unexpected exception
+     */
+    @Test
+    public void testCircuitBreakerAroundBulkheadAsync() throws InterruptedException, ExecutionException, TimeoutException {
+        AsyncBulkheadTask task1 = new AsyncBulkheadTask();
+        Future result1 = asyncBulkheadClient.test(task1);
+        task1.assertStarting(result1);
+        
+        AsyncBulkheadTask task2 = new AsyncBulkheadTask();
+        Future result2 = asyncBulkheadClient.test(task2);
+        task2.assertNotStarting();
+        
+        // While circuit closed, we get a BulkheadException
+        for (int i = 3; i < 6; i++) {
+            AsyncBulkheadTask taski = new AsyncBulkheadTask();
+            Future resulti = asyncBulkheadClient.test(taski);
+            expect(BulkheadException.class, resulti);
+        }
+        
+        // After circuit opens, we get CircuitBreakerOpenException
+        for (int i = 6; i < 8; i++) {
+            AsyncBulkheadTask taski = new AsyncBulkheadTask();
+            Future resulti = asyncBulkheadClient.test(taski);
+            expect(CircuitBreakerOpenException.class, resulti);
+        }
+        
+        // Tidy Up, complete task1 and 2, check task 2 starts
+        task1.complete(CompletableFuture.completedFuture("OK"));
+        task2.complete(CompletableFuture.completedFuture("OK"));
+        task2.assertStarting(result2);
+        
+        // Check both tasks return results
+        assertEquals(result1.get(2, SECONDS), "OK");
+        assertEquals(result2.get(2, SECONDS), "OK");
+    }
+    
+    /**
+     * A test to ensure that the CircuitBreaker is checked before entering the
+     * Bulkhead and that BulkheadExceptions count as failures for the
+     * CircuitBreaker.
+     * 
+     * Uses a synchronous bulkhead
+     * 
+     * With requestVolumeThreshold = 3, failureRatio = 1.0,
+     * delay = 50000 the expected behaviour is,
+     * 
+     * Execution Behaviour
+     * ========= =========
+     * 1 Fill Bulkhead
+     * 2 BulkheadException
+     * 3 BulkheadException
+     * 4 BulkheadException
+     * 5 CircuitBreakerOpenException
+     * 6 CircuitBreakerOpenException
+     * 
+     * @throws InterruptedException if the test is interrupted
+     * @throws TimeoutException if waiting for a result takes too long
+     * @throws ExecutionException if an async method throws an unexpected exception
+     */
+    @Test
+    public void testCircuitBreakerAroundBulkheadSync() throws InterruptedException, ExecutionException, TimeoutException {
+        BulkheadTaskManager manager = new BulkheadTaskManager();
+        
+        try {
+            BulkheadTask task1 = manager.startTask(syncBulkheadClient);
+            task1.assertStarting();
+            
+            // While circuit closed, we get a BulkheadException
+            for (int i = 2; i < 5; i++) {
+                BulkheadTask taski = manager.startTask(syncBulkheadClient);
+                taski.assertFinishing();
+                expect(BulkheadException.class, taski.getResultFuture());
+            }
+            
+            // After circuit opens, we get CircuitBreakerOpenException
+            for (int i = 5; i < 7; i++) {
+                BulkheadTask taski = manager.startTask(syncBulkheadClient);
+                taski.assertFinishing();
+                expect(CircuitBreakerOpenException.class, taski.getResultFuture());
+            }
+            
+            // Tidy up, complete task1 and check result
+            task1.complete(CompletableFuture.completedFuture("OK"));
+            task1.assertFinishing();
+            assertEquals(task1.getResult().get(2, TimeUnit.MINUTES), "OK");
+        }
+        finally {
+            manager.cleanup();
+        }
+    }
+    
+    /**
+     * A test to ensure that the CircuitBreaker does not open in response to a
+     * BulkheadException if {@code failOn} does not include BulkheadException
+     * 
+     * Uses an asynchronous bulkhead
+     * 
+     * With requestVolumeThreshold = 3, failureRatio = 1.0,
+     * delay = 50000, failOn=TestException the expected behaviour is,
+     * 
+     * Execution Behaviour
+     * ========= =========
+     * 1 Fill Bulkhead
+     * 2 Fill Bulkhead
+     * 3 BulkheadException
+     * 4 BulkheadException
+     * 5 BulkheadException
+     * 6 BulkheadException
+     * 7 BulkheadException
+     * 
+     * @throws InterruptedException if the test is interrupted
+     * @throws TimeoutException     if waiting for a result takes too long
+     * @throws ExecutionException   if an async method throws an unexpected exception
+     */
+    @Test
+    public void testCircuitBreaker() throws InterruptedException, ExecutionException, TimeoutException {
+        List<AsyncBulkheadTask> tasks = new ArrayList<>();
+        try {
+            AsyncBulkheadTask task1 = new AsyncBulkheadTask();
+            tasks.add(task1);
+            Future result1 = asyncBulkheadNoFailClient.test(task1);
+            task1.assertStarting(result1);
+            
+            AsyncBulkheadTask task2 = new AsyncBulkheadTask();
+            tasks.add(task2);
+            Future result2 = asyncBulkheadNoFailClient.test(task2);
+            task2.assertNotStarting();
+            
+            // While circuit closed, we get a BulkheadException
+            // Circuit should not open because failOn does not include BulkheadException
+            for (int i = 3; i < 8; i++) {
+                AsyncBulkheadTask taski = new AsyncBulkheadTask();
+                tasks.add(taski);
+                Future resulti = asyncBulkheadNoFailClient.test(taski);
+                expect(BulkheadException.class, resulti);
+            }
+            
+            // Tidy Up, complete task1 and 2, check task 2 starts
+            task1.complete(CompletableFuture.completedFuture("OK"));
+            task2.complete(CompletableFuture.completedFuture("OK"));
+            task2.assertStarting(result2);
+            
+            // Check both tasks return results
+            assertEquals(result1.get(2, SECONDS), "OK");
+            assertEquals(result2.get(2, SECONDS), "OK");
+        }
+        finally {
+            for (AsyncBulkheadTask task : tasks) {
+                task.complete();
+            }
+        }
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,11 +19,28 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck;
 
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThan;
+import static org.testng.Assert.fail;
+
+import java.sql.Connection;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClassLevelClientWithRetry;
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientWithRetry;
+import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientWithRetryAsync;
+import org.eclipse.microprofile.fault.tolerance.tck.util.DurationMatcher;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
+import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
+import org.hamcrest.MatcherAssert;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -37,18 +54,22 @@ import org.testng.annotations.Test;
  * Test CircuitBreaker Thresholds and delays with Retries.
  * 
  * @author <a href="mailto:neil_young@uk.ibm.com">Neil Young</a>
- *
+ * @author <a href="mailto:anrouse@uk.ibm.com">Andrew Rouse</a>
  */
 
 public class CircuitBreakerRetryTest extends Arquillian {
 
     private @Inject CircuitBreakerClientWithRetry clientForCBWithRetry;
     private @Inject CircuitBreakerClassLevelClientWithRetry clientForClassLevelCBWithRetry;
+    private @Inject CircuitBreakerClientWithRetryAsync clientForCBWithRetryAsync;
 
     @Deployment
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftCircuitBreakerRetry.jar")
-                        .addClasses(CircuitBreakerClientWithRetry.class, CircuitBreakerClassLevelClientWithRetry.class)
+                        .addClasses(CircuitBreakerClientWithRetry.class,
+                                    CircuitBreakerClassLevelClientWithRetry.class,
+                                    CircuitBreakerClientWithRetryAsync.class)
+                        .addPackage(Packages.UTILS)
                         .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                         .as(JavaArchive.class);
 
@@ -245,4 +266,321 @@ public class CircuitBreakerRetryTest extends Arquillian {
         invokeCounter = clientForCBWithRetry.getCounterForInvokingServiceC();
         Assert.assertEquals(invokeCounter, 4, "The number of executions should be 4");
     }
+    
+    /**
+     * Test that we retry around an open circuit breaker
+     * <p>
+     * Test that when retries are configured with sufficient delay, a call to an
+     * open circuit can retry until the circuit half-closes, allowing the call to
+     * succeed.
+     */
+    @Test
+    public void testRetriesSucceedWhenCircuitCloses() {
+        // Open the circuit by submitting four failures
+        for (int i = 0; i < 4; i++) {
+            try {
+                clientForCBWithRetry.serviceWithRetryOnCbOpen(true);
+            }
+            catch (TestException e) {
+                // Expected
+            }
+        }
+        
+        // Circuit is now open for 1 second
+        // Our next call should cause a CircuitBreakerOpenException which should then be retried
+        // The retry delay is 100ms, maxRetries is 20 so we expect a successful call after around 1 second when the circuit closes
+        long startTime = System.nanoTime();
+        clientForCBWithRetry.serviceWithRetryOnCbOpen(false);
+        long endTime = System.nanoTime();
+        
+        // Check that the call took the expected time
+        // Allow a margin of 250ms since there's a retry delay of 100ms
+        MatcherAssert.assertThat("Call was successful but did not take the expected time",
+                                 Duration.ofNanos(endTime - startTime),
+                                 DurationMatcher.closeTo(Duration.ofSeconds(1), Duration.ofMillis(250)));
+    }
+    
+    /**
+     * Test that we don't retry around an open circuit breaker if
+     * CircuitBreakerOpenException is not included in the retryOn attribute of the
+     * Retry annotation
+     * <p>
+     * This test calls a method which only retries on TimeoutException
+     */
+    public void testNoRetriesIfNotRetryOn() {
+        // Open the circuit by submitting four failures
+        for (int i = 0; i < 4; i++) {
+            try {
+                clientForCBWithRetry.serviceWithRetryOnTimeout(true);
+            }
+            catch (TestException e) {
+                // Expected
+            }
+        }
+        
+        // Circuit is now open for 1 second
+        // Our next call should cause a CircuitBreakerOpenException which should not be retried
+        // We expect a response almost immediately
+        long startTime = System.nanoTime();
+        Exceptions.expectCbOpen(() -> clientForCBWithRetry.serviceWithRetryOnTimeout(false));
+        long endTime = System.nanoTime();
+        
+        // Check that the call took less than 200ms (i.e. we didn't delay and retry)
+        MatcherAssert.assertThat("Call was successful but did not take the expected time",
+                                 Duration.ofNanos(endTime - startTime),
+                                 lessThan(Duration.ofMillis(200)));
+    }
+    
+    /**
+     * Test that we don't retry around an open circuit breaker if
+     * CircuitBreakerOpenException is included in the abortOn attribute of the
+     * Retry annotation
+     */
+    public void testNoRetriesIfAbortOn() {
+        // Open the circuit by submitting four failures
+        for (int i = 0; i < 4; i++) {
+            try {
+                clientForCBWithRetry.serviceWithRetryFailOnCbOpen(true);
+            }
+            catch (TestException e) {
+                // Expected
+            }
+        }
+        
+        // Circuit is now open for 1 second
+        // Our next call should cause a CircuitBreakerOpenException which should not be retried
+        // We expect a response almost immediately
+        long startTime = System.nanoTime();
+        Exceptions.expectCbOpen(() -> clientForCBWithRetry.serviceWithRetryFailOnCbOpen(false));
+        long endTime = System.nanoTime();
+        
+        // Check that the call took less than 200ms (i.e. we didn't delay and retry)
+        MatcherAssert.assertThat("Call was successful but did not take the expected time",
+                                 Duration.ofNanos(endTime - startTime),
+                                 lessThan(Duration.ofMillis(200)));
+    }
+
+
+    /**
+     * A test to exercise Circuit Breaker thresholds with sufficient retries to open the
+     * Circuit and result in a CircuitBreakerOpenException using an Asynchronous call.
+     */
+    @Test
+    public void testCircuitOpenWithMoreRetriesAsync() {
+        int invokeCounter = 0;
+        Future<Connection> result = clientForCBWithRetryAsync.serviceA();
+        try {
+            result.get(5, TimeUnit.SECONDS);
+            
+            // serviceA should retry until the CB threshold is reached. At that point a CircuitBreakerOpenException
+            // should be thrown. Assert if this does not happen.
+            invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceA();
+            Assert.fail("serviceA should retry in testCircuitOpenWithMoreRetries on iteration "
+                            + invokeCounter);
+        }
+        catch (ExecutionException executionException) {
+            // Expected execution exception wrapping CircuitBreakerOpenException
+            MatcherAssert.assertThat("Thrown exception is the wrong type",
+                                     executionException.getCause(),
+                                     instanceOf(CircuitBreakerOpenException.class));
+            
+            // Expected on iteration 4
+            invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceA();
+            if (invokeCounter < 4) {
+                Assert.fail("serviceA should retry in testCircuitOpenWithMoreRetries on iteration "
+                                + invokeCounter);
+            }
+        }
+        catch (Exception ex) {
+            // Not Expected
+            invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceA();
+            Assert.fail("serviceA should retry or throw a CircuitBreakerOpenException in testCircuitOpenWithMoreRetries on iteration "
+                            + invokeCounter);
+        }
+    
+        invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceA();
+        Assert.assertEquals(invokeCounter, 4, "The number of executions should be 4");
+    }
+
+    /**
+     * A test to exercise Circuit Breaker thresholds with insufficient retries to open the
+     * Circuit so that the Circuit remains closed and a RuntimeException is caught when
+     * using an Asynchronous call.
+     */
+    @Test
+    public void testCircuitOpenWithFewRetriesAsync() {
+        int invokeCounter = 0;
+        Future<Connection> result = clientForCBWithRetryAsync.serviceB();
+        try {
+            result.get(5, TimeUnit.SECONDS);
+            
+            // serviceB should retry until the CB threshold is reached. At that point a CircuitBreakerOpenException
+            // should be thrown. Assert if this does not happen.
+            invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceB();
+            Assert.fail("serviceB should retry in testCircuitOpenWithFewRetries on iteration "
+                            + invokeCounter);
+        }
+        catch (ExecutionException ex) {
+            // Expected execution exception wrapping TestException
+            MatcherAssert.assertThat("Thrown exception is the wrong type",
+                                     ex.getCause(),
+                                     instanceOf(TestException.class));
+
+            // Expected on iteration 3
+            invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceB();
+            if (invokeCounter < 3) {
+                Assert.fail("serviceB should retry in testCircuitOpenWithFewRetries on iteration "
+                                + invokeCounter);
+            }
+        }
+        catch (Exception ex) {
+            // Not Expected
+            invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceB();
+            Assert.fail("serviceB should retry or throw a RuntimeException in testCircuitOpenWithFewRetries on iteration "
+                            + invokeCounter);
+        }
+    
+        invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceB();
+        Assert.assertEquals(invokeCounter, 3, "The number of executions should be 3");
+    }
+
+    /**
+     * Analogous to testCircuitOpenWithMoreRetriesAsync but execution failures are caused by timeouts.
+     */
+    @Test
+    public void testCircuitOpenWithMultiTimeoutsAsync() {
+        int invokeCounter = 0;
+        Future<Connection> result = clientForCBWithRetryAsync.serviceC(1000);
+        try {
+            result.get(10, TimeUnit.SECONDS); // Expected to finish after about 2 seconds
+            
+            // serviceC should retry until the CB threshold is reached. At that point a CircuitBreakerOpenException
+            // should be thrown. Assert if this does not happen.
+            invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceC();
+            Assert.fail("serviceC should retry in testCircuitOpenWithMultiTimeouts on iteration "
+                                + invokeCounter);
+            
+        }
+        catch (ExecutionException executionException) {
+            // Expected execution exception wrapping CircuitBreakerOpenException
+            MatcherAssert.assertThat("Thrown exception is the wrong type",
+                                     executionException.getCause(),
+                                     instanceOf(CircuitBreakerOpenException.class));
+            
+            // Expected on iteration 4          
+            invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceC();
+            if (invokeCounter < 4) {
+                Assert.fail("serviceC should retry in testCircuitOpenWithMultiTimeouts on iteration "
+                                + invokeCounter);
+            }
+        }
+        catch (Exception ex) {
+            // Not Expected
+            invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceC();
+            Assert.fail("serviceC should retry or throw a CircuitBreakerOpenException in testCircuitOpenWithMultiTimeouts on iteration "
+                            + invokeCounter + ", caught exception: " + ex);
+        }
+    
+        invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceC();
+        Assert.assertEquals(invokeCounter, 4, "The number of executions should be 4");
+    }
+
+    /**
+     * Test that we retry around an open circuit breaker
+     * <p>
+     * Test that when retries are configured with sufficient delay, a call to an
+     * open circuit can retry until the circuit half-closes, allowing the call to
+     * succeed.
+     */
+    @Test
+    public void testRetriesSucceedWhenCircuitClosesAsync() {
+        // Open the circuit by submitting four failures
+        for (int i = 0; i < 4; i++) {
+            Future<String> result = clientForCBWithRetryAsync.serviceWithRetryOnCbOpen(true);
+            Exceptions.expect(TestException.class, result);
+        }
+        
+        // Circuit is now open for 1 second
+        // Our next call should cause a CircuitBreakerOpenException which should then be retried
+        // The retry delay is 100ms, maxRetries is 20 so we expect a successful call after around 1 second when the circuit closes
+        long startTime = System.nanoTime();
+        Future<String> result = clientForCBWithRetryAsync.serviceWithRetryOnCbOpen(false);
+        try {
+            result.get(10, TimeUnit.SECONDS);
+        }
+        catch (TimeoutException e) {
+            fail("Call to serviceWithRetryOnCbOpen did not succeed within 10 seconds");
+        }
+        catch (ExecutionException e) {
+            fail("Call to serviceWithRetryOnCbOpen failed with exception", e);
+        }
+        catch (InterruptedException e) {
+            fail("Call to serviceWithRetryOnCbOpen was interrupted", e);
+        }
+        long endTime = System.nanoTime();
+        
+        // Check that the call took the expected time
+        // Allow a margin of 250ms since there's a retry delay of 100ms
+        MatcherAssert.assertThat("Call was successful but did not take the expected time",
+                                 Duration.ofNanos(endTime - startTime),
+                                 DurationMatcher.closeTo(Duration.ofSeconds(1), Duration.ofMillis(250)));
+    }
+    
+    /**
+     * Test that we don't retry around an open circuit breaker if
+     * CircuitBreakerOpenException is not included in the retryOn attribute of the
+     * Retry annotation
+     * <p>
+     * This test calls a method which only retries on TimeoutException
+     */
+    @Test
+    public void testNoRetriesIfNotRetryOnAsync() {
+        // Open the circuit by submitting four failures
+        for (int i = 0; i < 4; i++) {
+            Future<String> result = clientForCBWithRetryAsync.serviceWithRetryOnTimeout(true);
+            Exceptions.expect(TestException.class, result);
+        }
+        
+        // Circuit is now open for 1 second
+        // Our next call should cause a CircuitBreakerOpenException which should then be retried
+        // The retry delay is 100ms, maxRetries is 20 so we expect a successful call after around 1 second when the circuit closes
+        long startTime = System.nanoTime();
+        Future<String> result = clientForCBWithRetryAsync.serviceWithRetryOnTimeout(false);
+        Exceptions.expect(CircuitBreakerOpenException.class, result);
+        long endTime = System.nanoTime();
+        
+        // Check that the call took less than 200ms (i.e. we didn't delay and retry)
+        MatcherAssert.assertThat("Call was successful but did not take the expected time",
+                                 Duration.ofNanos(endTime - startTime),
+                                 lessThan(Duration.ofMillis(200)));
+    }
+    
+    /**
+     * Test that we don't retry around an open circuit breaker if
+     * CircuitBreakerOpenException is included in the abortOn attribute of the
+     * Retry annotation
+     */
+    @Test
+    public void testNoRetriesIfAbortOnAsync() {
+        // Open the circuit by submitting four failures
+        for (int i = 0; i < 4; i++) {
+            Future<String> result = clientForCBWithRetryAsync.serviceWithRetryFailOnCbOpen(true);
+            Exceptions.expect(TestException.class, result);
+        }
+        
+        // Circuit is now open for 1 second
+        // Our next call should cause a CircuitBreakerOpenException which should then be retried
+        // The retry delay is 100ms, maxRetries is 20 so we expect a successful call after around 1 second when the circuit closes
+        long startTime = System.nanoTime();
+        Future<String> result = clientForCBWithRetryAsync.serviceWithRetryFailOnCbOpen(false);
+        Exceptions.expect(CircuitBreakerOpenException.class, result);
+        long endTime = System.nanoTime();
+        
+        // Check that the call took less than 200ms (i.e. we didn't delay and retry)
+        MatcherAssert.assertThat("Call was successful but did not take the expected time",
+                                 Duration.ofNanos(endTime - startTime),
+                                 lessThan(Duration.ofMillis(200)));
+    }
+
+
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerTimeoutTest.java
@@ -1,0 +1,87 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientWithTimeout;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * Test the combination of {@code @CircuitBreaker} and {@code @Timeout}
+ * 
+ * @author <a href="mailto:anrouse@uk.ibm.com">Andrew Rouse</a>
+ */
+public class CircuitBreakerTimeoutTest extends Arquillian {
+    
+    @Deployment
+    public static WebArchive deploy() {
+        JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftCircuitBreakerTimeout.jar")
+                                        .addClasses(CircuitBreakerClientWithTimeout.class)
+                                        .addPackage(Packages.UTILS)
+                                        .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                                        .as(JavaArchive.class);
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "ftCircuitBreakerTimeout.war")
+                                   .addAsLibrary(testJar);
+        return war;
+    }
+    
+    @Inject
+    private CircuitBreakerClientWithTimeout timeoutClient;
+    
+    /**
+     * Test that timeouts cause the circuit to open
+     */
+    @Test
+    public void testTimeout() {
+        // Run method twice, should timeout
+        for (int i = 0; i < 2; i++) {
+            Exceptions.expectTimeout(() -> timeoutClient.serviceWithTimeout());
+        }
+        
+        //Circuit should now be open, next call should get CircuitBreakerOpenException
+        Exceptions.expectCbOpen(() -> timeoutClient.serviceWithTimeout());
+    }
+    
+    /**
+     * Test that timeouts do not cause the circuit to open when failOn attribute does not include TimeoutException
+     */
+    @Test
+    public void testTimeoutWithoutFailOn() {
+        // Run method twice, should timeout
+        for (int i = 0; i < 2; i++) {
+            Exceptions.expectTimeout(() -> timeoutClient.serviceWithTimeoutWithoutFailOn());
+        }
+        
+        // CircuitBreaker has failOn = TestException so the timeouts should not cause the circuit to open
+        // Therefore expect timeout exception, not circuit breaker open exception
+        Exceptions.expectTimeout(() -> timeoutClient.serviceWithTimeoutWithoutFailOn());
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTimeoutTest.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,6 +19,9 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.retrytimeout.clientserver.RetryTimeoutClient;
@@ -35,6 +38,7 @@ import org.testng.annotations.Test;
  * Test the combination of the @Retry and @Timeout annotations.
  * 
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
+ * @author <a href="mailto:anrouse@uk.ibm.com">Andrew Rouse</a>
  *
  */
 public class RetryTimeoutTest extends Arquillian {
@@ -101,4 +105,37 @@ public class RetryTimeoutTest extends Arquillian {
 
         Assert.assertEquals(clientForRetryTimeout.getCounterForInvokingServiceA(), 2, "The execution count should be 2 (1 retry + 1)");
     }
+    
+    /**
+     * Test that a service is not retried if TimeoutException is not included in the retryOn attribute
+     */
+    @Test
+    public void testRetryWithoutRetryOn() {
+        try {
+            clientForRetryTimeout.serviceWithoutRetryOn();
+            fail("Timeout exception not thrown");
+        }
+        catch (TimeoutException e) {
+            // expected
+        }
+        
+        assertEquals(clientForRetryTimeout.getCounterForInvokingServiceWithoutRetryOn(), 1, "The execution count should be 1 (no retries)");
+    }
+    
+    /**
+     * Test that a service is not retried if TimeoutException is included in the abortOn attribute
+     */
+    @Test
+    public void testRetryWithAbortOn() {
+        try {
+            clientForRetryTimeout.serviceWithAbortOn();
+            fail("Timeout exception not thrown");
+        }
+        catch (TimeoutException e) {
+            // expected
+        }
+        
+        assertEquals(clientForRetryTimeout.getCounterForInvokingServiceWithAbortOn(), 1, "The execution count should be 1 (no retries)");
+    }
+
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutUninterruptableTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutUninterruptableTest.java
@@ -1,0 +1,290 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck;
+
+import static org.eclipse.microprofile.fault.tolerance.tck.util.DurationMatcher.closeTo;
+import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expect;
+import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expectTimeout;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.fail;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.UninterruptableTimeoutClient;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
+import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
+import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Test behaviour when a {@code @Timeout} is used but the method does not respond to interrupts.
+ * <p>
+ * This provokes a lot of edge case interactions between Timeout and other annotations.
+ * <p>
+ * Includes test for Timeout, Timeout + Async, Timeout + Async + Bulkhead, Timeout + Async + Retry.
+ */
+public class TimeoutUninterruptableTest extends Arquillian {
+
+    @Deployment
+    public static WebArchive deployment() {
+        JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftTimeoutUninterruptable.jar")
+                                        .addClass(UninterruptableTimeoutClient.class)
+                                        .addPackage(Packages.UTILS)
+                                        .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        WebArchive testWar = ShrinkWrap.create(WebArchive.class, "ftTimeoutUninterruptable.war")
+                                       .addAsLibrary(testJar);
+
+        return testWar;
+    }
+
+    private List<CompletableFuture<Void>> waitingFutures = new ArrayList<>();
+
+    @Inject
+    private UninterruptableTimeoutClient client;
+
+    @Test
+    public void testTimeout() {
+        long startTime = System.nanoTime();
+        expectTimeout(() -> client.serviceTimeout(1000));
+        long endTime = System.nanoTime();
+        
+        // Interrupt flag should not be set
+        assertFalse(Thread.interrupted(), "Thread was still interrupted when method returned");
+
+        // Expect that execution will take at least the full 1000ms because the method does not respond to being
+        // interrupted
+        assertThat("Execution time (ns)", endTime - startTime, greaterThanOrEqualTo(Duration.ofMillis(1000).toNanos()));
+    }
+
+    @Test
+    public void testTimeoutAsync() throws Exception {
+        CompletableFuture<Void> waitingFuture = newWaitingFuture();
+        CompletableFuture<Void> completionFuture = new CompletableFuture<Void>();
+
+        long startTime = System.nanoTime();
+        Future<Void> result = client.serviceTimeoutAsync(waitingFuture, completionFuture);
+        expect(TimeoutException.class, result);
+        long resultTime = System.nanoTime();
+
+        // We should get the TimeoutException after 500ms
+        assertThat("Time for result to be complete", Duration.ofNanos(resultTime - startTime), closeTo(Duration.ofMillis(500)));
+
+        assertFalse(completionFuture.isDone(), "Method should still be running");
+
+        // If we release the waitingFuture, the method should quickly complete
+        waitingFuture.complete(null);
+        completionFuture.get(2, TimeUnit.SECONDS);
+    }
+    
+    @Test
+    public void testTimeoutAsyncCS() throws InterruptedException {
+        AtomicBoolean wasInterrupted = new AtomicBoolean(false);
+        CompletableFuture<Void> completionFuture = new CompletableFuture<>();
+        AtomicLong endTime = new AtomicLong();
+        
+        long startTime = System.nanoTime();
+        client.serviceTimeoutAsyncCS(1000)
+              .thenRun(() -> completionFuture.complete(null))
+              .exceptionally((e) -> {
+                  completionFuture.completeExceptionally(e);
+                  return null;
+              })
+              .thenRun(() -> endTime.set(System.nanoTime()))
+              .thenRun(() -> wasInterrupted.set(Thread.interrupted()));
+        
+        expect(TimeoutException.class, completionFuture);
+        
+        // Interrupt flag should not be set
+        assertFalse(wasInterrupted.get(), "Thread was still interrupted when thenRun steps were run");
+        
+        // Expect that the method will timeout after 500ms
+        assertThat("Execution time", Duration.ofNanos(endTime.get() - startTime), closeTo(Duration.ofMillis(500)));
+
+    }
+
+    @Test
+    public void testTimeoutAsyncBulkhead() throws InterruptedException {
+        CompletableFuture<?> waitingFuture = newWaitingFuture();
+
+        long startTime = System.nanoTime();
+        Future<Void> resultA = client.serviceTimeoutAsyncBulkhead(waitingFuture);
+        expect(TimeoutException.class, resultA);
+        long resultTime = System.nanoTime();
+
+        // Should get the TimeoutException after 500ms
+        assertThat("Time for result to be complete", Duration.ofNanos(resultTime - startTime), closeTo(Duration.ofMillis(500)));
+
+        // Should record one execution
+        assertEquals(client.getTimeoutAsyncBulkheadCounter(), 1, "Execution count after first call");
+
+        // At this point, the first execution should still be running, so the next one should get queued
+        startTime = System.nanoTime();
+        Future<Void> resultB = client.serviceTimeoutAsyncBulkhead(waitingFuture);
+        expect(TimeoutException.class, resultB);
+        resultTime = System.nanoTime();
+
+        // Should get the TimeoutException after 500ms
+        assertThat("Time for result to be complete", Duration.ofNanos(resultTime - startTime), closeTo(Duration.ofMillis(500)));
+
+        // This time though, we shouldn't record a second execution since the request timed out before it got to start running
+        assertEquals(client.getTimeoutAsyncBulkheadCounter(), 1, "Execution count after second call");
+
+        // Make two more calls with a short gap
+        Future<Void> resultC = client.serviceTimeoutAsyncBulkhead(waitingFuture);
+        Thread.sleep(100);
+        Future<Void> resultD = client.serviceTimeoutAsyncBulkhead(waitingFuture);
+
+        // The first call should be queued and eventually time out
+        // The second call should get a BulkheadException because the queue is full
+        expect(TimeoutException.class, resultC);
+        expect(BulkheadException.class, resultD);
+
+        // Lastly, neither of these calls actually got to run, so there should be no more executions
+        assertEquals(client.getTimeoutAsyncBulkheadCounter(), 1, "Execution count after fourth call");
+        
+        // Complete the waiting future and check that, after a short wait, we have no additional executions
+        waitingFuture.complete(null);
+        Thread.sleep(300);
+        assertEquals(client.getTimeoutAsyncBulkheadCounter(), 1, "Execution count after completing all tasks");
+    }
+    
+    /**
+     * Test that the timeout timer is started when the execution is added to the queue
+     * 
+     * @throws InterruptedException if the test is interrupted
+     */
+    @Test
+    public void testTimeoutAsyncBulkheadQueueTimed() throws InterruptedException {
+        CompletableFuture<Void> waitingFutureA = newWaitingFuture();
+        CompletableFuture<Void> waitingFutureB = newWaitingFuture();
+        
+        client.serviceTimeoutAsyncBulkheadQueueTimed(waitingFutureA);
+        Thread.sleep(100);
+        
+        long startTime = System.nanoTime();
+        Future<Void> resultB = client.serviceTimeoutAsyncBulkheadQueueTimed(waitingFutureB);
+        
+        Thread.sleep(300);
+        
+        // Allow call A to finish, this should allow call B to start
+        waitingFutureA.complete(null);
+        
+        // Wait for call B to time out
+        expect(TimeoutException.class, resultB);
+        long endTime = System.nanoTime();
+        
+        // B should time out 500ms after it was submitted, even though it spent 300ms queued
+        assertThat("Time taken for call B to timeout", Duration.ofNanos(endTime - startTime), closeTo(Duration.ofMillis(500)));
+    }
+
+    @Test
+    public void testTimeoutAsyncRetry() {
+        CompletableFuture<?> waitingFuture = newWaitingFuture();
+
+        // Expect to run method three times, each one timing out after 500ms
+        long startTime = System.nanoTime();
+        Future<Void> result = client.serviceTimeoutAsyncRetry(waitingFuture);
+        expect(TimeoutException.class, result);
+        long resultTime = System.nanoTime();
+
+        // Should get TimeoutException after 1500ms (3 attempts * 500ms)
+        // Also use a wider margin (300ms) for consistency with other tests
+        assertThat("Time for result to complete",
+                   Duration.ofNanos(resultTime - startTime),
+                   closeTo(Duration.ofMillis(1500), Duration.ofMillis(300)));
+        
+        // Expect all executions to be run
+        assertEquals(client.getTimeoutAsyncRetryCounter(), 3, "Execution count after one call");
+    }
+    
+    /**
+     * Test that the fallback is run as soon as the timeout occurs
+     * 
+     * @throws InterruptedException if the test is interrupted
+     */
+    @Test
+    public void testTimeoutAsyncFallback() throws InterruptedException {
+        CompletableFuture<?> waitingFuture = newWaitingFuture();
+        
+        long startTime = System.nanoTime();
+        Future<String> resultFuture = client.serviceTimeoutAsyncFallback(waitingFuture);
+        
+        try {
+            // Expect TimeoutException causing fallback to be invoked and the result returned
+            assertEquals(resultFuture.get(1, TimeUnit.MINUTES), "FALLBACK");
+        }
+        catch (java.util.concurrent.TimeoutException e) {
+            fail("Method did not complete", e);
+        }
+        catch (ExecutionException e) {
+            fail("Unexpected exception thrown", e);
+        }
+
+        long resultTime = System.nanoTime();
+        
+        // Should get the TimeoutException + Fallback after 500ms
+        assertThat("Time for result to be complete", Duration.ofNanos(resultTime - startTime), closeTo(Duration.ofMillis(500)));
+    }
+
+    /**
+     * Creates a waiting future and adds it to a list to be cleaned up at the end of the test
+     * 
+     * @return the waiting future
+     */
+    private CompletableFuture<Void> newWaitingFuture() {
+        CompletableFuture<Void> waitingFuture = new CompletableFuture<Void>();
+        waitingFutures.add(waitingFuture);
+        return waitingFuture;
+    }
+
+    /**
+     * Cleans up any waiting futures that have been created in the test
+     */
+    @AfterMethod
+    public void cleanup() {
+        for (CompletableFuture<Void> future : waitingFutures) {
+            future.complete(null);
+        }
+
+        waitingFutures.clear();
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchTest.java
@@ -35,6 +35,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhe
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Checker;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.TestData;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -86,8 +87,11 @@ public class BulkheadAsynchTest extends Arquillian {
     @Deployment
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftBulkheadAsynchTest.jar")
-                .addPackage(BulkheadClassAsynchronousDefaultBean.class.getPackage()).addClass(Utils.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);
+                .addPackage(BulkheadClassAsynchronousDefaultBean.class.getPackage())
+                .addClass(Utils.class)
+                .addPackage(Packages.UTILS)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .as(JavaArchive.class);
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftBulkheadAsynchTest.war").addAsLibrary(testJar);
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
@@ -28,6 +28,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhe
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadMethodAsynchronousDefaultBean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Checker;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.FutureChecker;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -58,8 +59,11 @@ public class BulkheadFutureTest extends Arquillian {
     @Deployment
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftBulkheadFutureTest.jar")
-                .addPackage(FutureChecker.class.getPackage()).addClass(Utils.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);
+                .addPackage(FutureChecker.class.getPackage())
+                .addClass(Utils.class)
+                .addPackage(Packages.UTILS)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .as(JavaArchive.class);
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftBulkheadTest.war").addAsLibrary(testJar);
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchConfigTest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhe
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.ParrallelBulkheadTest;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.TestData;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -58,7 +59,9 @@ public class BulkheadSynchConfigTest extends Arquillian {
     @Deployment
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftBulkheadSynchTest.jar")
-            .addPackage(BulkheadClassSemaphoreDefaultBean.class.getPackage()).addClass(Utils.class)
+            .addPackage(BulkheadClassSemaphoreDefaultBean.class.getPackage())
+            .addClass(Utils.class)
+            .addPackage(Packages.UTILS)
             .addAsManifestResource(new StringAsset(
                 "Bulkhead/value=5"), "microprofile-config.properties")
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchConfigTest.java
@@ -20,8 +20,6 @@
 package org.eclipse.microprofile.fault.tolerance.tck.bulkhead;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import javax.inject.Inject;
@@ -31,6 +29,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhe
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.ParrallelBulkheadTest;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.TestData;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCaller;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -42,8 +41,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.ITestContext;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-
-//import org.jboss.arquillian.core.api.Asynchronousing.ExecutorService;
 
 /**
  * @author Gordon Hutchison
@@ -106,12 +103,11 @@ public class BulkheadSynchConfigTest extends Arquillian {
     }
 
     /*
-     * We use an executer service to simulate the parallelism of multiple
+     * We use an AsyncCaller bean to simulate the parallelism of multiple
      * simultaneous requests
      */
-    private static final int THREADPOOL_SIZE = 30;
-
-    private ExecutorService xService = Executors.newFixedThreadPool(THREADPOOL_SIZE);
+    @Inject
+    private AsyncCaller xService;
 
     /*
      * As the FaultTolerance annotation only work on business methods of

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchRetryTest.java
@@ -153,7 +153,7 @@ public class BulkheadSynchRetryTest extends Arquillian {
      */
     @Test()
     public void testBulkheadRetriedMethodDueToFailures() {
-        int threads = 10;
+        int threads = 5;
         int maxSimultaneousWorkers = 5;
         TestData td = new TestData();
         td.setExpectedInstances(threads);
@@ -185,7 +185,7 @@ public class BulkheadSynchRetryTest extends Arquillian {
      */
     @Test()
     public void testBulkheadRetriedClassDueToFailures() {
-        int threads = 10;
+        int threads = 5;
         int maxSimultaneousWorkers = 5;
         TestData td = new TestData();
         td.setExpectedInstances(threads);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchTest.java
@@ -36,6 +36,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhe
 
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.ParrallelBulkheadTest;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.TestData;
+import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 //import org.jboss.arquillian.core.api.Asynchronousing.ExecutorService;
 import org.jboss.arquillian.testng.Arquillian;
@@ -88,8 +89,11 @@ public class BulkheadSynchTest extends Arquillian {
     @Deployment
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftBulkheadSynchTest.jar")
-                .addPackage(BulkheadClassSemaphoreDefaultBean.class.getPackage()).addClass(Utils.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);
+                .addPackage(BulkheadClassSemaphoreDefaultBean.class.getPackage())
+                .addClass(Utils.class)
+                .addPackage(Packages.UTILS)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .as(JavaArchive.class);
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftBulkheadSynchTest.war").addAsLibrary(testJar);
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadSynchTest.java
@@ -20,22 +20,20 @@
 package org.eclipse.microprofile.fault.tolerance.tck.bulkhead;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhead10ClassSemaphoreBean;
-import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhead3ClassSemaphoreBean;
-import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadClassSemaphoreDefaultBean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhead10MethodSemaphoreBean;
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhead3ClassSemaphoreBean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.Bulkhead3MethodSemaphoreBean;
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadClassSemaphoreDefaultBean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadMethodSemaphoreDefaultBean;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
-
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.ParrallelBulkheadTest;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.TestData;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCaller;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
 //import org.jboss.arquillian.core.api.Asynchronousing.ExecutorService;
@@ -53,12 +51,8 @@ import org.testng.annotations.Test;
  */
 public class BulkheadSynchTest extends Arquillian {
 
-    /*
-     * We use an executer service to simulate the parallelism of multiple
-     * simultaneous requests
-     */
-    private static final int THREADPOOL_SIZE = 30;
-    private ExecutorService xService = Executors.newFixedThreadPool(THREADPOOL_SIZE);
+    @Inject
+    private AsyncCaller xService;
 
     /*
      * As the FaultTolerance annotation only work on business methods of

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/AbstractBulkheadTask.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/AbstractBulkheadTask.java
@@ -1,0 +1,197 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
+
+import static org.testng.Assert.fail;
+
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.testng.Assert;
+
+public class AbstractBulkheadTask {
+
+    /**
+     * Future that completes when the task starts running.
+     */
+    protected CompletableFuture<Void> runningLatch = new CompletableFuture<>();
+    /**
+     * Future that completes when {@link #complete()} is called
+     * <p>
+     * Execution of the task waits on this object
+     */
+    protected CompletableFuture<Future> releaseLatch = new CompletableFuture<>();
+
+    public AbstractBulkheadTask() {
+        super();
+    }
+
+    /**
+     * Wait until this task starts running
+     * 
+     * @param timeout time to wait
+     * @param unit units of timeout
+     * @throws InterruptedException if the thread is interrupted
+     * @throws TimeoutException if the task does not start within the timeout
+     */
+    public void awaitRunning(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
+        try {
+            runningLatch.get(timeout, unit);
+        }
+        catch (ExecutionException e) {
+            // Don't expect an execution exception from a latch
+            Assert.fail("Unexpected execution exception during awaitRunning", e);
+        }
+    }
+
+    /**
+     * Allow this task to complete
+     */
+    public void complete() {
+        releaseLatch.complete(CompletableFuture.completedFuture("OK"));
+    }
+
+    /**
+     * Allow this task to complete with the given result
+     * @param result the result
+     */
+    public void complete(Future result) {
+        releaseLatch.complete(result);
+    }
+
+    /**
+     * Allow this task to complete by throwing an exception
+     * 
+     * @param e the exception
+     */
+    public void completeExceptionally(RuntimeException e) {
+        releaseLatch.completeExceptionally(e);
+    }
+
+    /**
+     * Asserts that the task starts within 2 seconds
+     * 
+     * @throws InterruptedException if the thread is interrupted while waiting for the task to start
+     */
+    public void assertStarting() throws InterruptedException {
+        doAssertStarting();
+    }
+
+    /**
+     * Asserts that the task does not start within 2 seconds
+     * 
+     * @throws InterruptedException if the thread is interrupted while waiting for the task to start
+     */
+    public void assertNotStarting() throws InterruptedException {
+        try {
+            awaitRunning(2, TimeUnit.SECONDS);
+            Assert.fail("Task started unexpectedly");
+        }
+        catch (TimeoutException e) {
+            // Expected
+        }
+    }
+    
+    /**
+     * The base implementation of {@link #assertStarting()}
+     * <p>
+     * This exists so superclasses can override {@link #assertStarting()} but this logic can still be called
+     * 
+     * @throws InterruptedException
+     */
+    private final void doAssertStarting() throws InterruptedException {
+        try {
+            awaitRunning(2, TimeUnit.SECONDS);
+        }
+        catch (TimeoutException e) {
+            Assert.fail("Task did not start within 2 seconds");
+        }
+    }
+    
+    /**
+     * Asserts that the task starts within 2 seconds
+     * <p>
+     * If the task doesn't start, this method will also report the status of
+     * {@code methodResult}.
+     * 
+     * @param methodResult Future representing the result of a method expected to run this task
+     * @throws InterruptedException if the thread is interrupted while waiting for the task to start
+     */
+    public void assertStarting(Future methodResult) throws InterruptedException {
+        try {
+            doAssertStarting();
+        }
+        catch (AssertionError err) {
+            // Task has failed to start, check the result future to see if we can provide any more diagnostics
+            if (methodResult.isDone()) {
+                try {
+                    Object result = methodResult.get(0, TimeUnit.SECONDS);
+                    fail("Task did not start within 2 seconds. Method result: complete with result: " + result);
+                }
+                catch (CancellationException e) {
+                    fail("Task did not start within 2 seconds. Method result: cancelled", e);
+                }
+                catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    fail("Task did not start within 2 seconds. Method result: failed with exception: " + cause, cause);
+                }
+                catch (InterruptedException e) {
+                    fail("Task did not start within 2 seconds. "
+                       + "Additionally, an InterruptedException was received when trying to check the method result",
+                         e);
+                }
+                catch (TimeoutException e) {
+                    fail("Task did not start within 2 seconds. "
+                            + "Additionally, although the method result future reported done, "
+                            + "a TimeoutException was received when trying to check the method result",
+                              e);
+                }
+            }
+            else {
+                fail("Task did not start within 2 seconds. Method result: incomplete");
+            }
+        }
+    }
+
+
+    protected class TestDelegate implements BackendTestDelegate {
+    
+        @Override
+        public Future perform() throws InterruptedException {
+            runningLatch.complete(null);
+            try {
+                return releaseLatch.get(1, TimeUnit.MINUTES);
+            }
+            catch (ExecutionException e) {
+                // Should be a runtime exception because that's all that completeExceptionally accepts
+                throw (RuntimeException) e.getCause();
+            }
+            catch (TimeoutException e) {
+                Assert.fail("Timeout waiting for release() to be called", e);
+                return null; // Compiler requires a return even though fail() will throw an exception
+            }
+        }
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/AbstractBulkheadTask.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/AbstractBulkheadTask.java
@@ -19,8 +19,10 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
 
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.fail;
 
+import java.util.Collection;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -110,6 +112,25 @@ public class AbstractBulkheadTask {
         }
         catch (TimeoutException e) {
             // Expected
+        }
+    }
+    
+    /**
+     * Asserts that all of the given tasks do not start within 2 seconds
+     * <p>
+     * If you have lots of tasks to check, this method will wait 2 seconds and check
+     * all of them. This is much quicker than waiting 2 seconds for each task using
+     * {@link #assertNotStarting()}.
+     * 
+     * @param tasks the tasks to check
+     * @throws InterruptedException if the thread is interrupted while waiting
+     */
+    public static void assertAllNotStarting(Collection<? extends AbstractBulkheadTask> tasks) throws InterruptedException {
+        Thread.sleep(2000);
+        int i = 0;
+        for (AbstractBulkheadTask task : tasks) {
+            assertFalse(task.runningLatch.isDone(), "Task " + i + " is running.");
+            i++;
         }
     }
     

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/AsyncBulkheadTask.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/AsyncBulkheadTask.java
@@ -1,0 +1,50 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
+
+import java.util.concurrent.Future;
+
+/**
+ * Manages the execution of an asynchronous call to
+ * {@link BulkheadTestBackend#test(BackendTestDelegate)}
+ * <p>
+ * The {@link #perform()} method will not return until {@link #complete()} has
+ * been called.
+ * <p>
+ * {@link #assertStarting()} and {@link #assertNotStarting()} can be used to
+ * test whether the method starts executing within a short period.
+ * <p>
+ * Example usage:
+ * <pre><code>AsyncBulkheadTask task = new AsyncBulkheadTask();
+ * Future result = asyncBeanUnderTest.call(task);
+ * task.assertStarting(result);
+ * assertFalse(result.isDone());
+ * task.complete("Foo");
+ * assertEquals(result.get(2, SECONDS), "Foo");
+ * </code></pre>
+ */
+public class AsyncBulkheadTask extends AbstractBulkheadTask implements BackendTestDelegate {
+
+    @Override
+    public Future perform() throws InterruptedException {
+        return new TestDelegate().perform();
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10ClassAsynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10ClassAsynchBean.java
@@ -28,7 +28,6 @@ import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 
 /**
  * A simple method level Asynchronous @Bulkhead bean that has a retry option.
@@ -38,8 +37,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 @ApplicationScoped
 @Bulkhead(waitingTaskQueue = 5, value = 5)
 @Asynchronous
-@Retry(retryOn =
-{ BulkheadException.class }, delay = 1, delayUnit = ChronoUnit.MICROS, maxRetries = 10, maxDuration=999999)
+@Retry(delay = 1, delayUnit = ChronoUnit.MICROS, maxRetries = 10, maxDuration=999999)
 public class Bulkhead55RapidRetry10ClassAsynchBean implements BulkheadTestBackend {
 
     public Future test(BackendTestDelegate action) throws InterruptedException {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10ClassSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10ClassSynchBean.java
@@ -27,7 +27,6 @@ import javax.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 
 /**
  * A simple class level synchronous @Bulkhead bean that has a retry option.
@@ -36,8 +35,7 @@ import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
  */
 @ApplicationScoped
 @Bulkhead(waitingTaskQueue = 5, value = 5)
-@Retry(retryOn =
-{ BulkheadException.class }, delay = 1, delayUnit = ChronoUnit.MICROS, maxRetries = 10, maxDuration=999999)
+@Retry(delay = 1, delayUnit = ChronoUnit.MICROS, maxRetries = 10, maxDuration=999999)
 public class Bulkhead55RapidRetry10ClassSynchBean implements BulkheadTestBackend {
 
     public Future test(BackendTestDelegate action) throws InterruptedException {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10MethodSynchBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/Bulkhead55RapidRetry10MethodSynchBean.java
@@ -27,7 +27,6 @@ import javax.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.Utils;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 
 /**
  * A simple method level synchronous @Bulkhead bean that has a retry option.
@@ -39,8 +38,7 @@ public class Bulkhead55RapidRetry10MethodSynchBean implements BulkheadTestBacken
 
     @Override
     @Bulkhead(waitingTaskQueue = 5, value = 5)
-    @Retry(retryOn =
-    { BulkheadException.class }, delay = 1, delayUnit = ChronoUnit.MILLIS, maxRetries = 10, maxDuration=999999)
+    @Retry(delay = 1, delayUnit = ChronoUnit.MILLIS, maxRetries = 10, maxDuration=999999)
     public Future test(BackendTestDelegate action) throws InterruptedException {
         Utils.log("in business method of bean " + this.getClass().getName());
         return action.perform();

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRetryAbortOnAsyncBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRetryAbortOnAsyncBean.java
@@ -1,0 +1,49 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
+
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
+
+/**
+ * Test to ensure that retries do not occur if BulkheadException is included in abortOn attribute.
+ * <p>
+ * Has a bulkhead of size 1 and a queue size of 1
+ * <p>
+ * Retries 1 time on any exception except BulkheadException with 1 second delay
+ */
+@Retry(maxRetries = 1, delay = 1000, jitter = 0, abortOn = BulkheadException.class)
+@Bulkhead(value = 1, waitingTaskQueue = 1)
+@Asynchronous
+@ApplicationScoped
+public class BulkheadRetryAbortOnAsyncBean implements BulkheadTestBackend {
+    
+    @Override
+    public Future test(BackendTestDelegate action) throws InterruptedException {
+        return action.perform();
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRetryAbortOnSyncBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRetryAbortOnSyncBean.java
@@ -1,0 +1,47 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
+
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
+
+/**
+ * Test to ensure that retries do not occur if BulkheadException is included in abortOn attribute.
+ * <p>
+ * Has a bulkhead of size 1
+ * <p>
+ * Retries 1 time on any exception except BulkheadException with 1 second delay
+ */
+@Retry(maxRetries = 1, delay = 1000, jitter = 0, abortOn = BulkheadException.class)
+@Bulkhead(1)
+@ApplicationScoped
+public class BulkheadRetryAbortOnSyncBean implements BulkheadTestBackend {
+    
+    @Override
+    public Future test(BackendTestDelegate action) throws InterruptedException {
+        return action.perform();
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRetryDelayAsyncBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRetryDelayAsyncBean.java
@@ -1,0 +1,49 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
+
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+/**
+ * Test to ensure that the bulkhead slot is released when retrying.
+ * <p>
+ * Has a bulkhead of size 1
+ * <p>
+ * Retries 1 time on thrown TestException with 1 second delay
+ */
+@Retry(maxRetries = 1, delay = 1000, jitter = 0, retryOn = TestException.class)
+@Bulkhead(value = 1, waitingTaskQueue = 1)
+@Asynchronous
+@ApplicationScoped
+public class BulkheadRetryDelayAsyncBean implements BulkheadTestBackend {
+    
+    @Override
+    public Future test(BackendTestDelegate action) throws InterruptedException {
+        return action.perform();
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRetryDelaySyncBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRetryDelaySyncBean.java
@@ -1,0 +1,47 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
+
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+/**
+ * Test to ensure that the bulkhead slot is released when retrying.
+ * <p>
+ * Has a bulkhead of size 1
+ * <p>
+ * Retries 1 time on thrown TestException with 1 second delay
+ */
+@Retry(maxRetries = 1, delay = 1000, jitter = 0, retryOn = TestException.class)
+@Bulkhead(1)
+@ApplicationScoped
+public class BulkheadRetryDelaySyncBean implements BulkheadTestBackend {
+    
+    @Override
+    public Future test(BackendTestDelegate action) throws InterruptedException {
+        return action.perform();
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRetryQueueAsyncBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadRetryQueueAsyncBean.java
@@ -1,0 +1,49 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
+
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+/**
+ * Test to ensure that the executions which are retried join the back of the queue
+ * <p>
+ * Has a bulkhead of size 1 and a queue size of 5
+ * <p>
+ * Retries 1 time on thrown TestException with no delay
+ */
+@Retry(maxRetries = 1, delay = 0, jitter = 0, retryOn = TestException.class)
+@Bulkhead(value = 1, waitingTaskQueue = 5)
+@Asynchronous
+@ApplicationScoped
+public class BulkheadRetryQueueAsyncBean implements BulkheadTestBackend {
+    
+    @Override
+    public Future test(BackendTestDelegate action) throws InterruptedException {
+        return action.perform();
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadTask.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadTask.java
@@ -1,0 +1,182 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCaller;
+import org.testng.Assert;
+
+/**
+ * Manages the execution of a synchronous call to
+ * {@link BulkheadTestBackend#test(BackendTestDelegate)}
+ * <p>
+ * This class is designed for testing synchronous bulkheads. When testing
+ * synchronous bulkheads, you need multiple calls happening at once, so this
+ * class starts an <i>asynchronous</i> task which calls into the bean from a
+ * different thread.
+ * <p>
+ * Tasks start running and then wait for {@link #complete()} to be called. Some
+ * time after this, the task will complete and the result can be retrieved with
+ * {@link #getResult()} or {@link #getResultFuture()}.
+ * <p>
+ * There are also methods to assert that execution of the method is either
+ * starting or not starting and finishing or not finishing. These methods assert
+ * that the desired state is reached within a short period, to account for the
+ * unpredictable ordering and timing of asynchronous execution.
+ * <p>
+ * Example use:
+ * 
+ * <pre>
+ * <code>
+ * BulkheadTask taskA = bulkheadTaskManager.startTask(beanUnderTest);
+ * taskA.assertStarting();
+ * taskA.complete(CompletableFuture.completedFuture("MyResult"));
+ * taskA.assertFinishing();
+ * assertThat(taskA.getResult().get(), is("MyResult"));
+ * </code>
+ * </pre>
+ */
+public class BulkheadTask extends AbstractBulkheadTask {
+    
+    private BulkheadTestBackend testBackend;
+    
+    private AsyncCaller executor;
+    
+    /**
+     * Future that completes with the result of the method.
+     * <p>
+     * If the method throws an exception, this future will complete exceptionally.
+     */
+    private CompletableFuture<Future> resultFuture = new CompletableFuture<Future>();
+    
+    public BulkheadTask(AsyncCaller executor, BulkheadTestBackend testBackend) {
+        super();
+        this.executor = executor;
+        this.testBackend = testBackend;
+    }
+
+    /**
+     * Wait until this task finishes
+     * 
+     * @param timeout time to wait
+     * @param unit units of timeout
+     * @throws InterruptedException if the thread is interrupted
+     * @throws TimeoutException if the task does not start within the timeout
+     */
+    public void awaitFinished(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
+        try {
+            resultFuture.get(timeout, unit);
+        }
+        catch (ExecutionException e) {
+            // Ignore exceptions, user just wants to know if we've finished
+        }
+    }
+    
+    /**
+     * Get the result of the task
+     * 
+     * @return the result of the task
+     * @throws ExecutionException if the task threw an exception
+     */
+    public Future getResult() throws ExecutionException {
+        try {
+            return resultFuture.get(0, TimeUnit.MILLISECONDS);
+        }
+        catch (TimeoutException e) {
+            Assert.fail("getResult() called when task not finished", e);
+            return null; // compiler doesn't know that Assert.fail will always throw an exception
+        }
+        catch (InterruptedException e) {
+            // Should not get interrupted because we asked not to wait
+            Assert.fail("Unexpected InterruptedException when getting the result", e);
+            return null; // compiler doesn't know that Assert.fail will always throw an exception
+        }
+    }
+    
+    /**
+     * Returns a Future representing the result of this task
+     * @return the future
+     */
+    public Future getResultFuture() {
+        return resultFuture;
+    }
+    
+    public void run() {
+        executor.run(() -> {
+            try {
+                resultFuture.complete(testBackend.test(new TestDelegate()));
+            }
+            catch (Exception e) {
+                resultFuture.completeExceptionally(e);
+            }
+        });
+    }
+
+    // Override assertStarting to provide diagnostics from resultFuture
+    @Override
+    public void assertStarting() throws InterruptedException {
+        super.assertStarting(resultFuture);
+    }
+
+    public void assertFinishing() throws InterruptedException {
+        try {
+            awaitFinished(2, TimeUnit.SECONDS);
+        }
+        catch (TimeoutException e) {
+            Assert.fail("Task did not finish within 2 seconds");
+        }
+    }
+    
+    public void assertNotFinishing() throws InterruptedException {
+        try {
+            awaitFinished(2, TimeUnit.SECONDS);
+            Assert.fail("Task finished unexpectedly");
+        }
+        catch (TimeoutException e) {
+        }
+    }
+    
+    public void assertSuccessful() throws InterruptedException {
+        try {
+            getResult();
+        }
+        catch (ExecutionException e) {
+            Assert.fail("Task did not complete successfully", e);
+        }
+    }
+    
+    public void assertThrows(Class<? extends Throwable> exceptionClazz) throws InterruptedException {
+        try {
+            getResult();
+            Assert.fail("Task did not throw " + exceptionClazz.getName());
+        }
+        catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (!exceptionClazz.isInstance(cause)) {
+                Assert.fail("Unexpected exception thrown from task: " + cause, cause);
+            }
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadTaskManager.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadTaskManager.java
@@ -1,0 +1,87 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
+
+
+import static org.testng.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.CDI;
+
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCaller;
+
+/**
+ * Allows BulkheadTasks to be created and ensures they all get cleaned up at the end of the test
+ */
+public class BulkheadTaskManager {
+    
+    private AsyncCaller executor;
+    private List<BulkheadTask> startedTasks = new ArrayList<>();
+    
+    private synchronized AsyncCaller getExecutor() {
+        if (executor == null) {
+            // Lookup the AsyncCaller bean instance from CDI
+            BeanManager bm = CDI.current().getBeanManager();
+            Bean<?> asyncCallerBean = bm.resolve(bm.getBeans(AsyncCaller.class));
+            executor = (AsyncCaller) bm.getReference(asyncCallerBean, AsyncCaller.class, bm.createCreationalContext(null));
+        }
+        return executor;
+    }
+    
+    public BulkheadTask startTask(BulkheadTestBackend backend) {
+        BulkheadTask task = new BulkheadTask(getExecutor(), backend);
+        task.run();
+        startedTasks.add(task);
+        return task;
+    }
+    
+    /**
+     * Makes the BulkheadTaskManager ready to run a new set of tasks.
+     * <p>
+     * Release any started tasks and waits for them to complete.
+     * <p>
+     * This should be called at the end of each test.
+     * 
+     * @throws InterruptedException if the thread is interrupted
+     */
+    public void cleanup() throws InterruptedException {
+        for (BulkheadTask task : startedTasks) {
+            task.complete();
+        }
+        
+        for (BulkheadTask task : startedTasks) {
+            try {
+                task.awaitFinished(1, TimeUnit.MINUTES);
+            }
+            catch (TimeoutException e) {
+                fail("Unable to clean up all tasks");
+            }
+        }
+        
+        startedTasks = new ArrayList<>();
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/ParrallelBulkheadTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/ParrallelBulkheadTest.java
@@ -75,7 +75,7 @@ public class ParrallelBulkheadTest implements Callable<Future> {
             Utils.log("Might expect a Bulkhead exception from some tests : " + b.toString() + b.getMessage());
         }
         catch( Throwable t ){
-            Assert.fail("Unexpected exception" +  t.getMessage() );
+            Assert.fail("Unexpected exception: " + t.toString(), t);
         }
         return result;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithAsyncBulkhead.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithAsyncBulkhead.java
@@ -1,0 +1,41 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver;
+
+import java.util.concurrent.Future;
+
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BackendTestDelegate;
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+/**
+ * Client bean with CircuitBreaker, Bulkhead and Asynchronous
+ */
+@CircuitBreaker(requestVolumeThreshold = 3, failureRatio = 1.0, delay = 50000)
+@Bulkhead(value = 1, waitingTaskQueue = 1)
+@Asynchronous
+public class CircuitBreakerClientWithAsyncBulkhead implements BulkheadTestBackend {
+    
+    public Future test(BackendTestDelegate action) throws InterruptedException {
+        return action.perform();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithAsyncBulkheadNoFail.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithAsyncBulkheadNoFail.java
@@ -1,0 +1,42 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver;
+
+import java.util.concurrent.Future;
+
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BackendTestDelegate;
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+/**
+ * Client bean with CircuitBreaker, Bulkhead and Asynchronous
+ */
+@CircuitBreaker(requestVolumeThreshold = 3, failureRatio = 1.0, delay = 50000, failOn = TestException.class)
+@Bulkhead(value = 1, waitingTaskQueue = 1)
+@Asynchronous
+public class CircuitBreakerClientWithAsyncBulkheadNoFail implements BulkheadTestBackend {
+    
+    public Future test(BackendTestDelegate action) throws InterruptedException {
+        return action.perform();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithSyncBulkhead.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithSyncBulkhead.java
@@ -1,0 +1,39 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver;
+
+import java.util.concurrent.Future;
+
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BackendTestDelegate;
+import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+
+/**
+ * Client bean with CircuitBreaker and Bulkhead
+ */
+@CircuitBreaker(requestVolumeThreshold = 3, failureRatio = 1.0)
+@Bulkhead(value = 1, waitingTaskQueue = 1)
+public class CircuitBreakerClientWithSyncBulkhead implements BulkheadTestBackend {
+    
+    public Future test(BackendTestDelegate action) throws InterruptedException {
+        return action.perform();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithTimeout.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithTimeout.java
@@ -1,0 +1,74 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver;
+
+import static org.testng.Assert.fail;
+
+import javax.enterprise.context.RequestScoped;
+
+import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
+
+@RequestScoped
+public class CircuitBreakerClientWithTimeout {
+
+    /**
+     * Sleeps for 1000ms, times out after 500ms
+     * <p>
+     * CircuitBreaker opens after two failed requests
+     * 
+     * @return should always throw TimeoutException, unless CircuitBreaker prevents execution
+     */
+    @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 2, failureRatio = 0.75, delay = 50000)
+    @Timeout(500)
+    public String serviceWithTimeout() {
+        try {
+            Thread.sleep(1000);
+            fail("Thread not interrupted by timeout");
+        }
+        catch (InterruptedException e) {
+            // Expected
+        }
+        return "OK";
+    }
+    
+    /**
+     * Sleeps for 1000ms, times out after 500ms
+     * <p>
+     * CircuitBreaker opens after two BulkheadExceptions
+     * <p>
+     * The method should never throw a BulkheadException so the CircuitBreaker should have no effect
+     * 
+     * @return should always throw TimeoutException
+     */
+    @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 2, failureRatio = 0.75, delay = 50000, failOn = BulkheadException.class)
+    @Timeout(500)
+    public String serviceWithTimeoutWithoutFailOn() {
+        try {
+            Thread.sleep(1000);
+            fail("Thread not interrupted by timeout");
+        }
+        catch (InterruptedException e) {
+            // Expected
+        }
+        return "OK";
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationClient.java
@@ -73,10 +73,12 @@ public class DisableAnnotationClient {
      * Should return normally if Fallback is enabled or throw TestException if not
      * <p>
      * Should increment counter by two if Retry is enabled or one if it is not
+     * 
+     * @return nothing, always throws TestException
      */
     @Retry(maxRetries = 1)
     @Fallback(fallbackMethod = "fallback")
-    public void failRetryOnceThenFallback() {
+    public String failRetryOnceThenFallback() {
         failRetryOnceThenFallbackCounter++;
         throw new TestException();
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidAsynchronousClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidAsynchronousClassTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidAsynchronousClassTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidAsnycClass.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidAsynchronousMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/invalidParameters/InvalidAsynchronousMethodTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
 public class InvalidAsynchronousMethodTest extends Arquillian {
 
     @Deployment
-    @ShouldThrowException(value = DefinitionException.class, testable = true)
+    @ShouldThrowException(value = DefinitionException.class)
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftInvalidAsnycMethod.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/BulkheadMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/BulkheadMetricTest.java
@@ -18,8 +18,8 @@
  */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
-import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectBulkheadException;
 import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricComparator.approxMillis;
+import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expectBulkheadException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/BulkheadMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/BulkheadMetricTest.java
@@ -31,8 +31,8 @@ import java.util.concurrent.Future;
 
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.AsyncCaller;
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCaller;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Snapshot;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/BulkheadMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/BulkheadMetricTest.java
@@ -201,7 +201,7 @@ public class BulkheadMetricTest extends Arquillian {
         
         Future<?> f3 = bulkheadBean.waitForAsync(waitingFuture);
         Future<?> f4 = bulkheadBean.waitForAsync(waitingFuture);
-        expectBulkheadException(() -> bulkheadBean.waitForAsync(waitingFuture));
+        expectBulkheadException(bulkheadBean.waitForAsync(waitingFuture));
         
         assertThat("concurrent executions", m.getBulkheadConcurrentExecutions().get(), is(2L));
         assertThat("queue population", m.getBulkheadQueuePopulation().get(), is(2L));

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricTest.java
@@ -18,8 +18,8 @@
  */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
-import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectCbOpen;
-import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectTestException;
+import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expectCbOpen;
+import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expectTestException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClassLevelMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/ClassLevelMetricTest.java
@@ -18,7 +18,7 @@
  */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
-import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectTestException;
+import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expectTestException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/FallbackMetricTest.java
@@ -18,7 +18,7 @@
  */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
-import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectTestException;
+import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expectTestException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/RetryMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/RetryMetricTest.java
@@ -18,7 +18,7 @@
  */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
-import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectTestException;
+import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expectTestException;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/TimeoutMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/TimeoutMetricTest.java
@@ -18,7 +18,7 @@
  */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
-import static org.eclipse.microprofile.fault.tolerance.tck.metrics.util.Exceptions.expectTimeout;
+import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expectTimeout;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/UninterruptableTimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/UninterruptableTimeoutClient.java
@@ -1,0 +1,272 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.enterprise.context.RequestScoped;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.testng.Assert;
+
+@RequestScoped
+public class UninterruptableTimeoutClient {
+    
+    /**
+     * Waits for at least {@code waitms}, then returns
+     * <p>
+     * Times out in 500ms.
+     * <p>
+     * Does not respect thread interruption.
+     * <p>
+     * Uses a tight loop so the thread interrupted flag should be set when the method returns
+     * 
+     * @param waitMs the time to wait
+     */
+    @Timeout(value = 500, unit = ChronoUnit.MILLIS)
+    public void serviceTimeout(int waitMs) {
+        long waitNs = Duration.ofMillis(waitMs).toNanos();
+        long startTime = System.nanoTime();
+        
+        while (true) {
+            if (System.nanoTime() - startTime > waitNs) {
+                return;
+            }
+        }
+    }
+    
+    /**
+     * Waits for waitingFuture to complete, then returns.
+     * <p>
+     * Times out in 500ms.
+     * <p>
+     * Runs asynchronously.
+     * <p>
+     * Does not respect thread interruption.
+     * 
+     * @param waitingFuture future to wait for
+     * @param completion future that this method will complete before returning
+     * @return a completed future
+     */
+    @Timeout(value = 500, unit = ChronoUnit.MILLIS)
+    @Asynchronous
+    public Future<Void> serviceTimeoutAsync(Future<?> waitingFuture, CompletableFuture<Void> completion) {
+        while (true) {
+            try {
+                waitingFuture.get();
+                completion.complete(null);
+                return CompletableFuture.completedFuture(null);
+            }
+            catch (InterruptedException e) {
+                // Ignore
+            } catch (ExecutionException e) {
+                Assert.fail("Waiting future threw exception", e);
+            }
+        }
+    }
+    
+    /**
+     * Waits for at least {@code waitMs}, then returns
+     * <p>
+     * Times out in 500ms
+     * <p>
+     * Runs asynchronously
+     * <p>
+     * Does not respect thread interruption.
+     * <p>
+     * Uses a tight loop so the thread interrupted flag should be set when the method returns
+     * 
+     * @param waitMs the time to wait
+     * @return a completed CompletionStage
+     */
+    @Timeout(value = 500, unit = ChronoUnit.MILLIS)
+    @Asynchronous
+    public CompletionStage<Void> serviceTimeoutAsyncCS(long waitMs) {
+        long waitNs = Duration.ofMillis(waitMs).toNanos();
+        long startTime = System.nanoTime();
+        
+        while (true) {
+            if (System.nanoTime() - startTime > waitNs) {
+                return CompletableFuture.completedFuture(null);
+            }
+        }
+    }
+    
+    
+    /**
+     * Waits for waitingFuture to complete, then returns.
+     * <p>
+     * Times out in 500ms.
+     * <p>
+     * Runs asynchronously.
+     * <p>
+     * Does not respect thread interruption.
+     * <p>
+     * Has a bulkhead with capacity of 1, queue size of 1.
+     * <p>
+     * Increments timeoutAsyncBulkheadCounter.
+     * 
+     * @param waitingFuture future to wait for
+     * @return a completed future
+     */
+    @Timeout(value = 500, unit = ChronoUnit.MILLIS)
+    @Asynchronous
+    @Bulkhead(value = 1, waitingTaskQueue = 1)
+    public Future<Void> serviceTimeoutAsyncBulkhead(Future<?> waitingFuture) {
+        timeoutAsyncBulkheadCounter.incrementAndGet();
+        while (true) {
+            try {
+                waitingFuture.get();
+                return CompletableFuture.completedFuture(null);
+            }
+            catch (InterruptedException e) {
+                // Ignore
+            } catch (ExecutionException e) {
+                Assert.fail("Waiting future threw exception", e);
+            }
+        }
+    }
+    
+    private AtomicInteger timeoutAsyncBulkheadCounter = new AtomicInteger();
+    
+    public int getTimeoutAsyncBulkheadCounter() {
+        return timeoutAsyncBulkheadCounter.get();
+    }
+    
+    /**
+     * Waits for waitingFuture to complete, then returns.
+     * <p>
+     * Times out in 500ms.
+     * <p>
+     * Runs asynchronously.
+     * <p>
+     * Does not respect thread interruption.
+     * <p>
+     * Has a bulkhead with capacity of 1, queue size of 1.
+     * 
+     * @param waitingFuture future to wait for
+     * @return a completed Future
+     */
+    @Timeout(value = 500, unit = ChronoUnit.MILLIS)
+    @Asynchronous
+    @Bulkhead(value = 1, waitingTaskQueue = 1)
+    public Future<Void> serviceTimeoutAsyncBulkheadQueueTimed(Future<?> waitingFuture) {
+        while (true) {
+            try {
+                waitingFuture.get();
+                return CompletableFuture.completedFuture(null);
+            }
+            catch (InterruptedException e) {
+                // Ignore
+            } catch (ExecutionException e) {
+                Assert.fail("Waiting future threw exception", e);
+            }
+        }
+    }
+    
+    /**
+     * Waits for waitingFuture to complete, then returns.
+     * <p>
+     * Times out in 500ms.
+     * <p>
+     * Runs asynchronously.
+     * <p>
+     * Does not respect thread interruption.
+     * <p>
+     * Will do 2 retries with no delay.
+     * <p>
+     * Increments timeoutAsyncRetryCounter.
+     * 
+     * @param waitingFuture future to wait for
+     * @return a completed Future
+     */
+    @Timeout(value = 500, unit = ChronoUnit.MILLIS)
+    @Asynchronous
+    @Retry(maxRetries = 2, delay = 0, jitter = 0)
+    public Future<Void> serviceTimeoutAsyncRetry(Future<?> waitingFuture) {
+        timeoutAsyncRetryCounter.incrementAndGet();
+        while (true) {
+            try {
+                waitingFuture.get();
+                return CompletableFuture.completedFuture(null);
+            }
+            catch (InterruptedException e) {
+                // Ignore
+            } catch (ExecutionException e) {
+                Assert.fail("Waiting future threw exception", e);
+            }
+        }
+    }
+    
+    private AtomicInteger timeoutAsyncRetryCounter = new AtomicInteger();
+    
+    /**
+     * @return value of timeoutAsyncRetryCounter
+     */
+    public int getTimeoutAsyncRetryCounter() {
+        return timeoutAsyncRetryCounter.get();
+    }
+    
+    /**
+     * Waits for waitingFuture to complete, then returns.
+     * <p>
+     * Times out in 500ms.
+     * <p>
+     * Runs asynchronously.
+     * <p>
+     * Does not respect thread interruption.
+     * <p>
+     * Will run the fallback method on exception
+     * 
+     * @param waitingFuture future to wait for
+     * @return Future completed with "OK", or completed with "FALLBACK" if the fallback ran
+     */
+    @Timeout(value = 500, unit = ChronoUnit.MILLIS)
+    @Asynchronous
+    @Fallback(fallbackMethod = "fallback")
+    public Future<String> serviceTimeoutAsyncFallback(Future<?> waitingFuture) {
+        while (true) {
+            try {
+                waitingFuture.get();
+                return CompletableFuture.completedFuture("OK");
+            }
+            catch (InterruptedException e) {
+                // Ignore
+            } catch (ExecutionException e) {
+                Assert.fail("Waiting future threw exception", e);
+            }
+        }
+    }
+    
+    public Future<String> fallback(Future<?> waitingFuture) {
+        return CompletableFuture.completedFuture("FALLBACK");
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/AsyncCaller.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/AsyncCaller.java
@@ -17,8 +17,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-package org.eclipse.microprofile.fault.tolerance.tck.metrics.util;
+package org.eclipse.microprofile.fault.tolerance.tck.util;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
@@ -27,6 +28,7 @@ import javax.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 
 @ApplicationScoped
+@Asynchronous
 public class AsyncCaller {
 
     /**
@@ -35,10 +37,27 @@ public class AsyncCaller {
      * @param runnable task to execute
      * @return a completed future set to null
      */
-    @Asynchronous
     public Future<Void> run(Runnable runnable) {
         runnable.run();
         return CompletableFuture.completedFuture(null);
+    }
+    
+    /**
+     * Run a callable asynchronously
+     * 
+     * @param callable the callable to run
+     * @param <T> the type returned by {@code callable}
+     * @return a future which can be used to get the result of running {@code callable}
+     */
+    public <T> Future<T> submit(Callable<T> callable) {
+        try {
+            return CompletableFuture.completedFuture(callable.call());
+        }
+        catch (Exception e) {
+            CompletableFuture<T> result = new CompletableFuture<T>();
+            result.completeExceptionally(e);
+            return result;
+        }
     }
 
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/DurationMatcher.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/DurationMatcher.java
@@ -1,0 +1,78 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.util;
+
+import java.time.Duration;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+
+public class DurationMatcher extends TypeSafeDiagnosingMatcher<Duration> {
+
+    private Duration target;
+    private Duration margin;
+
+    public DurationMatcher(Duration target, Duration margin) {
+        super();
+        this.target = target;
+        this.margin = margin;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("Duration within ")
+                   .appendValue(margin)
+                   .appendText(" of ")
+                   .appendValue(target);
+    }
+
+    @Override
+    protected boolean matchesSafely(Duration item, Description mismatchDescription) {
+        Duration difference = item.minus(target).abs();
+        mismatchDescription.appendValue(item)
+                           .appendText(" which is ")
+                           .appendValue(difference)
+                           .appendText(" from ")
+                           .appendValue(target);
+        return difference.compareTo(margin) <= 0; // difference <= margin
+    }
+    
+    /**
+     * Matcher that asserts that a duration is within {@code margin} of {@code target}
+     * 
+     * @param target the target duration
+     * @param margin the margin
+     * @return the matcher
+     */
+    public static DurationMatcher closeTo(Duration target, Duration margin) {
+        return new DurationMatcher(target, margin);
+    }
+    
+    /**
+     * Matcher that asserts that a duration is within 100ms of {@code target}
+     * 
+     * @param target the target duration
+     * @return the matcher
+     */
+    public static DurationMatcher closeTo(Duration target) {
+        return new DurationMatcher(target, Duration.ofMillis(100));
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/Exceptions.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/Exceptions.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.fail;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
@@ -81,9 +82,15 @@ public class Exceptions {
         expect(BulkheadException.class, future);
     }
     
+    /**
+     * Call {@code future.get()} and check that it throws an ExecutionException wrapping the {@code expectedException}
+     * 
+     * @param expectedException the expected exception type
+     * @param future the future to check
+     */
     public static void expect(Class<? extends Exception> expectedException, Future<?> future) {
         try {
-            future.get();
+            future.get(1, TimeUnit.MINUTES); // Long timeout here to avoid possibility of tests hanging
             fail("Execution exception not thrown from Future");
         }
         catch (ExecutionException e) {
@@ -93,6 +100,9 @@ public class Exceptions {
         }
         catch (InterruptedException e) {
             fail("Getting future result was interrupted", e);
+        }
+        catch (java.util.concurrent.TimeoutException e) {
+            fail("Timed out waiting for future to throw " + expectedException.getSimpleName());
         }
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/Exceptions.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/Exceptions.java
@@ -17,14 +17,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *******************************************************************************/
-package org.eclipse.microprofile.fault.tolerance.tck.metrics.util;
+package org.eclipse.microprofile.fault.tolerance.tck.util;
 
 import static org.testng.Assert.fail;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/Packages.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/Packages.java
@@ -34,5 +34,5 @@ public class Packages {
     /**
      * The {@code org.eclipse.microprofile.fault.tolerance.tck.metrics.util} package
      */
-    public static final Package METRIC_UTILS = org.eclipse.microprofile.fault.tolerance.tck.metrics.util.AsyncCaller.class.getPackage();
+    public static final Package METRIC_UTILS = org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricComparator.class.getPackage();
 }


### PR DESCRIPTION
These are the TCKs to match the spec changes in #314 

There are quite a lot of tests here:
* Test `@Timeout` with methods which ignore thread interruption
  * Check that when using `@Asynchronous`, results are returned or retries are started as soon as the timeout fires, rather than waiting for the method body to return
  * Check that although results are returned when the timeout fires, the method continues to count as running by the bulkhead until it actually returns
* Add tests for `@Bulkhead` and `@Retry`
  * Check that each retry _attempt_ checks that the bulkhead is not full before running and releases its place when it ends
  * Check that when using `@Asynchronous`, retry attempts join the back of the bulkhead queue
* Add tests for `@CircuitBreaker` and `@Bulkhead`
  * Check that the circuit breaker is checked before attempting to enter the bulkhead
  * Check that a `BulkheadException` is counted as a circuit breaker failure, as long as `failOn` includes `BulkheadException` (or a superclass)
* Extend existing tests for `CircuitBreaker` and `Retry`
  * Check that `CircuitBreakerOpenException`s are retried, resulting in a successful execution if the circuit closes while retry attempts are being made
  * Check that `Retry` only retries `CircuitBreakerOpenException` if `retryOn` includes `CircuitBreakerOpenException` and `abortOn` does not.
* Update existing `@Bulkhead` tests to conform with the new spec
  * Particularly around how exceptions are thrown when using `@Asynchronous`
  * This involved some refactoring to ensure we check the result of every method call because exceptions are now thrown from the returned `Future` or `CompletionStage`
    * This in turn exposed some tests which weren't working correctly and required fixing
* Add tests that `Retry` only retries methods which fail due to timeouts if it would retry a `TimeoutException` (based on `retryOn` and `abortOn`)
* Add tests that `Retry` only retries methods which fail due to a full bulkhead if it would retry a `BulkheadException` (based on `retryOn` and `abortOn`)
* Add tests that `CircuitBreaker` only considers a method that times out to be a failure if it considers a `TimeoutException` a failure (based on `failOn`)

In addition, I also made the following changes which were not directly related to the issue:
* Check that the calling thread is not interrupted when the method returns (this one is for #322 and fitted nicely with the other non-interruptable method timeout tests I was adding)
* Add an explicit test that a full bulkhead throws a `BulkheadException` (this may have been caught somewhere else, but I couldn't see a test that filled the bulkhead and actually checked for the bulkhead exception)
* Some refactoring to allow reuse of existing utility classes
* Improving the error reporting from some tests I had trouble debugging
* Fixing two tests by making the deployment non-testable for tests which were testing invalid applications (I think I messed this up when I added the tests originally, they don't pass without this change)

Final note: The first commit (08d9de9) is from #331, I'll remove it when that PR gets merged.