### PR TITLE
CheckStyle Rules moved to an external configuration file issue 252

### DIFF
--- a/mp_checkstyle_rules.xml
+++ b/mp_checkstyle_rules.xml
@@ -28,7 +28,6 @@
     </module>
     <module name="FileTabCharacter" />
     <module name="TreeWalker">
-        <module name="SuppressionCommentFilter" />
         <module name="ConstantName">
             <property name="format" value="^(([A-Z][A-Z0-9]*(_[A-Z0-9]+)*))$" />
         </module>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <checkstyle.version>2.17</checkstyle.version>
-        <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9]*$</checkstyle.methodNameFormat>
         <!-- whether autorelease maven central staging repositories - default true to allow review and manually release repositories -->
         <autorelease>false</autorelease>
         <!-- keeping closed repos with failure - default is false because the errors are visible in the maven output, but true will leave the repo open for investigation in Sonatype Nexus -->
@@ -173,77 +172,7 @@
                     <failsOnError>true</failsOnError>
                     <linkXRef>true</linkXRef>
                     <logViolationsToConsole>true</logViolationsToConsole>
-                    <checkstyleRules>
-                        <module name="Checker">
-                            <module name="SuppressionCommentFilter" />
-                            <module name="FileLength">
-                                <property name="max" value="3500" />
-                                <property name="fileExtensions" value="java" />
-                            </module>
-                            <module name="FileTabCharacter" />
-                            <module name="TreeWalker">
-                                <module name="FileContentsHolder" />
-                                <module name="ConstantName">
-                                    <property name="format" value="^(([A-Z][A-Z0-9]*(_[A-Z0-9]+)*))$" />
-                                </module>
-                                <module name="LocalVariableName" />
-                                <module name="MethodName">
-                                    <property name="format" value="${checkstyle.methodNameFormat}" />
-                                </module>
-                                <module name="PackageName" />
-                                <module name="LocalFinalVariableName" />
-                                <module name="ParameterName" />
-                                <module name="StaticVariableName" />
-
-                                <module name="TypeName">
-                                    <property name="format" value="^_?[A-Z][a-zA-Z0-9]*$|packageinfo" />
-                                </module>
-                                <module name="AvoidStarImport">
-                                    <property name="excludes" value="java.io,java.net,java.util,javax.enterprise.inject.spi,javax.enterprise.context" />
-                                </module>
-                                <module name="IllegalImport" />
-                                <module name="RedundantImport" />
-                                <module name="UnusedImports" />
-                                <module name="LineLength">
-                                    <property name="max" value="150" />
-                                    <property name="ignorePattern" value="@version|@see" />
-                                </module>
-                                <module name="MethodLength">
-                                    <property name="max" value="250" />
-                                </module>
-                                <module name="ParameterNumber">
-                                    <property name="max" value="11" />
-                                </module>
-                                <module name="EmptyBlock">
-                                    <property name="option" value="text" />
-                                </module>
-                                <module name="NeedBraces" />
-                                <module name="LeftCurly">
-                                    <property name="option" value="EOL" />
-                                </module>
-                                <module name="RightCurly">
-                                    <property name="option" value="ALONE" />
-                                </module>
-                                <module name="EmptyStatement" />
-                                <module name="EqualsHashCode" />
-                                <module name="DefaultComesLast" />
-                                <module name="MissingSwitchDefault" />
-                                <module name="FallThrough" />
-                                <module name="MultipleVariableDeclarations" />
-                                <module name="com.puppycrawl.tools.checkstyle.checks.design.DesignForExtensionCheck">
-                                    <property name="severity" value="ignore" />
-                                </module>
-                                <module name="HideUtilityClassConstructor" />
-                                <module name="com.puppycrawl.tools.checkstyle.checks.design.VisibilityModifierCheck">
-                                    <property name="packageAllowed" value="false" />
-                                    <property name="protectedAllowed" value="true" />
-                                    <property name="publicMemberPattern" value="^serialVersionUID" />
-                                    <property name="severity" value="warning" />
-                                </module>
-                                <module name="UpperEll" />
-                            </module>
-                        </module>
-                    </checkstyleRules>
+                    <configLocation>mp_checkstyle_rules.xml</configLocation>
                 </configuration>
             </plugin>
 

--- a/tck/src/test/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/PureJ2SERetryVisibilityTest.java
+++ b/tck/src/test/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/PureJ2SERetryVisibilityTest.java
@@ -55,7 +55,7 @@ public class PureJ2SERetryVisibilityTest {
     }
 
     @Test
-    public void check_BASE_ROM_RETRY_MISSING_ON_METHOD() throws Exception {
+    public void checkBaseRomRetryMissingOnMethod() throws Exception {
         Retry foundAnnotation;
         Method m = RetryOnMethodServiceNoAnnotationOnOverridedMethod.class.getDeclaredMethod("service");
         


### PR DESCRIPTION
https://github.com/eclipse/microprofile-fault-tolerance/issues/252

CheckStyle Rules moved to an external configuration file to allow
maintain these rules in an easy and centralized way.

This file can be used by the CI server to validate the project code style

Signed-off-by: carlos de la rosa <kusanagi12002@gmail.com>