### PR TITLE
Add test class to RetryTest deployment

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
@@ -51,7 +51,10 @@ public class RetryTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftRetry.jar")
-                .addClasses(RetryClientForMaxRetries.class, RetryClientWithDelay.class, RetryClassLevelClientForMaxRetries.class)
+                .addClasses(RetryClientForMaxRetries.class,
+                            RetryClientWithDelay.class,
+                            RetryClassLevelClientForMaxRetries.class,
+                            RetryClientWithNoDelayAndJiter.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);
 


### PR DESCRIPTION
One of the test classes was missing which caused the deployed application to fail to start.