### PR TITLE
Added same fix as issue 242 to testBulkheadMethodAsynchFutureDoneWithoutGet

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
@@ -122,6 +122,12 @@ public class BulkheadFutureTest extends Arquillian {
         Assert.assertFalse(result.isDone(), "Future reporting Done when not");
         try {
             Thread.sleep(SHORT_TIME + SHORT_TIME);
+            // Usually, we will not enter the loop, 
+            // but we are prepared to wait up to 100 SHORT_TIMES (10sec)
+            int loops = 0;
+            while(!result.isDone() && loops++ < 100) {
+                Thread.sleep(SHORT_TIME);
+            }
         }
         catch (Throwable t) {
             Assert.assertNull(t);


### PR DESCRIPTION
We see a small percentage of the same error as #242 on this test on unusually slow hardware
or virtual hosts where something happens to create a moment of slowness.

This fix is the same safety net as 242 just to ensure the test is not brittle to such
platform treacle slow issues.

Signed-off-by: Gordon Hutchison <Gordon.Hutchison@gmail.com>