### PR TITLE
373 - Change system time to use nanoseconds

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
@@ -79,7 +79,7 @@ public class AsyncTimeoutTest extends Arquillian {
 
         // Call serviceA. As it is annotated @Asynchronous, serviceA should return a future straight away even though 
         // the method has a 5s sleep in it
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
 
         Future<Connection> future = null;
         try {
@@ -89,7 +89,7 @@ public class AsyncTimeoutTest extends Arquillian {
             throw new AssertionError("testAsyncTimeout: unexpected InterruptedException calling serviceA");
         }
         
-        long end = System.currentTimeMillis();
+        long end = System.nanoTime();
 
         long duration = end - start;
         if (duration > TEST_FUTURE_THRESHOLD) { //should have returned almost instantly, if it takes TEST_FUTURE_THRESHOLD 
@@ -122,10 +122,10 @@ public class AsyncTimeoutTest extends Arquillian {
         catch (TimeoutException e) {
             throw new AssertionError("testAsyncTimeout: unexpected TimeoutException on future.get()");
         }
-        end = System.currentTimeMillis();
+        end = System.nanoTime();
 
         duration = end - start;
-        if (duration < TEST_TIMEOUT_SERVICEA) { // duration should be greater than the timeout configured on the service 
+        if (Duration.ofNanos(duration) < Duration.ofMillis(TEST_TIMEOUT_SERVICEA)) { // duration should be greater than the timeout configured on the service 
             throw new AssertionError("testAsyncTimeout: the service duration was less than the configured timeout - " + duration);
         }
     }
@@ -141,7 +141,7 @@ public class AsyncTimeoutTest extends Arquillian {
     public void testAsyncNoTimeout() {
         // Call serviceB. As it is annotated @Asynchronous, serviceB should return a future straight away even though 
         // the method has a 0.5s sleep in it
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
 
         Future<Connection> future = null;
         try {
@@ -150,7 +150,7 @@ public class AsyncTimeoutTest extends Arquillian {
         catch (InterruptedException e) {
             throw new AssertionError("testAsyncNoTimeout: unexpected InterruptedException calling serviceB");
         }
-        long end = System.currentTimeMillis();
+        long end = System.nanoTime();
 
         long duration = end - start;
         if (duration > TEST_FUTURE_THRESHOLD) { //should have returned almost instantly, if it takes TEST_FUTURE_THRESHOLD 
@@ -183,7 +183,7 @@ public class AsyncTimeoutTest extends Arquillian {
     public void testAsyncClassLevelTimeout() {
         // Call serviceA. As it is annotated @Asynchronous, serviceA should return a future straight away even though 
         // the method has a 5s sleep in it
-        long start = System.currentTimeMillis();
+        long start = System.nanoTime();
 
         Future<Connection> future = null;
         try {
@@ -192,7 +192,7 @@ public class AsyncTimeoutTest extends Arquillian {
         catch (InterruptedException e1) {
             throw new AssertionError("testAsyncClassLevelTimeout: unexpected InterruptedException calling serviceA");
         }
-        long end = System.currentTimeMillis();
+        long end = System.nanoTime();
 
         long duration = end - start;
         if (duration > TEST_FUTURE_THRESHOLD) { //should have returned almost instantly, if it takes TEST_FUTURE_THRESHOLD 
@@ -210,7 +210,7 @@ public class AsyncTimeoutTest extends Arquillian {
 
         // Call future.get() with a timeout (3 seconds) that is longer than the annotated timeout (2 seconds) specified on
         // the service but shorter than the overall service duration (5 seconds sleep)
-        start = System.currentTimeMillis();
+        start = System.nanoTime();
         try {
             future.get(TEST_TIMEOUT_SERVICEA + TEST_TIME_UNIT, TimeUnit.MILLISECONDS);
             throw new AssertionError("testAsyncClassLevelTimeout: Future not interrupted");
@@ -226,10 +226,10 @@ public class AsyncTimeoutTest extends Arquillian {
         catch (TimeoutException e) {
             throw new AssertionError("testAsyncClassLevelTimeout: unexpected TimeoutException on future.get()");
         }
-        end = System.currentTimeMillis();
+        end = System.nanoTime();
 
         duration = end - start;
-        if (duration < TEST_TIMEOUT_SERVICEA) { // duration should be greater than the timeout configured on the service 
+        if (Duration.ofNanos(duration) < Duration.ofMillis(TEST_TIMEOUT_SERVICEA)) { // duration should be greater than the timeout configured on the service 
             throw new AssertionError("testAsyncClassLevelTimeout: the service duration was less than the configured timeout - " + duration);
         }
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientWithDelay.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientWithDelay.java
@@ -46,7 +46,7 @@ public class RetryClientWithDelay {
     private Connection connectionService() {
        // the time delay between each invocation should be 0-800ms
        if (timestampForConnectionService != 0) {
-           long currentTime = System.currentTimeMillis() ;
+           long currentTime = System.nanoTime();
            delayTimes.add(currentTime -timestampForConnectionService );
            timestampForConnectionService = currentTime;
         


### PR DESCRIPTION
As per the java documentation nanoTime is the appropriate method for checking the duration of a running	thread. Using nanoTime will also protect the tests from any changes to the system clock while the tck is running.

Signed-off-by: Benjamin Confino <benjamic@uk.ibm.com>