### PR TITLE
Test CDI (Using XML configuration) and FT interceptors ordering

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -109,6 +109,11 @@
             <artifactId>shrinkwrap-api</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/xmlInterceptorEnabling/EarlyFtInterceptor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/xmlInterceptorEnabling/EarlyFtInterceptor.java
@@ -1,0 +1,62 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling;
+
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.EarlyFtInterceptor.InterceptEarly;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.OrderQueueProducer;
+
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InterceptorBinding;
+import javax.interceptor.InvocationContext;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * An interceptor that is called before the FT interceptor
+ * in the chain and count the invocation.
+ * @author carlosdlr
+ */
+@Interceptor
+@InterceptEarly
+public class EarlyFtInterceptor {
+
+    @Inject
+    private OrderQueueProducer orderFactory;
+
+    /**
+     * Interceptor binding for {@link EarlyFtInterceptor}
+     */
+    @Retention(RUNTIME)
+    @Target({ TYPE, METHOD })
+    @InterceptorBinding
+    public @interface InterceptEarly {}
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        orderFactory.getOrderQueue().add("EarlyOrderFtInterceptor");
+        return ctx.proceed();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/xmlInterceptorEnabling/FaultToleranceInterceptorEnableByXmlTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/xmlInterceptorEnabling/FaultToleranceInterceptorEnableByXmlTest.java
@@ -1,0 +1,111 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling;
+
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.OrderQueueProducer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.beans10.BeansDescriptor;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * A Client to demonstrate the interceptors ordering behavior of FT and CDI annotations
+ * @author carlosdlr
+ */
+public class FaultToleranceInterceptorEnableByXmlTest extends Arquillian {
+
+    @Inject
+    private InterceptorComponent testInterceptor;
+
+    @Inject
+    private OrderQueueProducer orderFactory;
+
+    @Deployment
+    public static WebArchive deploy() {
+        BeansDescriptor beans = Descriptors.create(BeansDescriptor.class)
+            .getOrCreateInterceptors()
+            .clazz("org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.EarlyFtInterceptor").up()
+            .getOrCreateInterceptors()
+            .clazz("org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.LateFtInterceptor").up();
+
+        JavaArchive testJar = ShrinkWrap
+            .create(JavaArchive.class, "interceptorFtXml.jar")
+            .addClasses(InterceptorComponent.class, EarlyFtInterceptor.class, LateFtInterceptor.class, OrderQueueProducer.class)
+             .addAsManifestResource(new StringAsset(beans.exportAsString()), "beans.xml")
+            .as(JavaArchive.class);
+
+        return ShrinkWrap.create(WebArchive.class, "interceptorFtXml.war")
+            .addAsLibrary(testJar);
+    }
+
+    /**
+     * This test validates the interceptors execution order after call a method
+     * annotated with Asynchronous FT annotation, using a queue type FIFO (first-in-first-out).
+     * The head of the queue is that element that has been on the queue the longest time.
+     * In this case is validating that the early interceptor is executed at first.
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     * @throws ExecutionException if the computation threw an exception
+     */
+    @Test
+    public void testAsync() throws InterruptedException, ExecutionException {
+        Future<String> result = testInterceptor.asyncGetString();
+        assertEquals(result.get(), "OK");
+        String [] expectedOrder = {"EarlyOrderFtInterceptor","LateOrderFtInterceptor","asyncGetString"};
+        assertEquals(orderFactory.getOrderQueue().toArray(), expectedOrder);
+    }
+
+    @Test
+    public void testRetryInterceptors() {
+        try {
+            testInterceptor.serviceRetryA();
+            fail("Exception not thrown");
+        }
+        catch (Exception e) {
+            assertEquals(e.getMessage().trim(), "retryGetString failed");
+        }
+
+        String [] expectedOrder = {"EarlyOrderFtInterceptor","LateOrderFtInterceptor","serviceRetryA",
+            "EarlyOrderFtInterceptor","LateOrderFtInterceptor","serviceRetryA"};
+        /* Executes 1 more time the early and late interceptor and the bean method annotated with maxRetries = 1.*/
+        /* When the interceptors are enable by xml and the bean method is annotated with retry both interceptors are executed each retry
+           to difference of the interceptors enabled using @Priority that just the late interceptor is executed each retry */
+        assertEquals(orderFactory.getOrderQueue().toArray(), expectedOrder);
+    }
+
+    @AfterMethod
+    public void clearResources() {
+        if (orderFactory != null) { //validate if not null because after the last test is called the context is cleared
+            orderFactory.getOrderQueue().clear();
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/xmlInterceptorEnabling/InterceptorComponent.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/xmlInterceptorEnabling/InterceptorComponent.java
@@ -1,0 +1,59 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling;
+
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.EarlyFtInterceptor.InterceptEarly;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.LateFtInterceptor.InterceptLate;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.OrderQueueProducer;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.testng.TestException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+/**
+ * Component to show the CDI interceptor ordering with FT annotations
+ * @author carlosdlr
+ */
+@ApplicationScoped
+public class InterceptorComponent {
+
+    @Inject
+    private OrderQueueProducer orderFactory;
+
+    @InterceptEarly
+    @InterceptLate
+    @Retry(maxRetries = 1)
+    public String serviceRetryA() {
+        orderFactory.getOrderQueue().add("serviceRetryA");
+        throw new TestException("retryGetString failed");
+    }
+
+    @InterceptEarly
+    @InterceptLate
+    @Asynchronous
+    public Future<String> asyncGetString() {
+        orderFactory.getOrderQueue().add("asyncGetString");
+        return CompletableFuture.completedFuture("OK");
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/xmlInterceptorEnabling/LateFtInterceptor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/xmlInterceptorEnabling/LateFtInterceptor.java
@@ -1,0 +1,65 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling;
+
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.LateFtInterceptor.InterceptLate;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.OrderQueueProducer;
+
+
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InterceptorBinding;
+import javax.interceptor.InvocationContext;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * An interceptor that is called after the FT interceptor
+ * in the chain and count the invocation.
+ * @author carlosdlr
+ */
+@Interceptor
+@InterceptLate
+public class LateFtInterceptor {
+
+    @Inject
+    private OrderQueueProducer orderFactory;
+
+
+    /**
+     * Interceptor binding for {@link LateFtInterceptor}
+     */
+    @Retention(RUNTIME)
+    @Target({ TYPE, METHOD })
+    @InterceptorBinding
+    public @interface InterceptLate {}
+
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        orderFactory.getOrderQueue().add("LateOrderFtInterceptor");
+        return ctx.proceed();
+    }
+}


### PR DESCRIPTION

https://github.com/eclipse/microprofile-fault-tolerance/issues/313

New test added to validate the CDI interceptors against FT interceptors
when the CDI interceptors are activated using xml configuration instead
using @Priority annotation configuration

Signed-off-by: carlos de la rosa <kusanagi12002@gmail.com>