### PR TITLE
Test CDI and FT interceptors ordering changing FT interceptor priority

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/EarlyFtInterceptor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/EarlyFtInterceptor.java
@@ -42,7 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Interceptor
 @InterceptEarly
-@Priority(Interceptor.Priority.PLATFORM_AFTER - 100)
+@Priority(Interceptor.Priority.PLATFORM_AFTER - 200)
 public class EarlyFtInterceptor {
 
     @Inject

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/EarlyFtInterceptor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/EarlyFtInterceptor.java
@@ -1,0 +1,64 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange;
+
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange.EarlyFtInterceptor.InterceptEarly;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.OrderQueueProducer;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InterceptorBinding;
+import javax.interceptor.InvocationContext;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * An interceptor that is called before the FT interceptor
+ * in the chain and count the invocation.
+ * @author carlosdlr
+ */
+@Interceptor
+@InterceptEarly
+@Priority(Interceptor.Priority.PLATFORM_AFTER - 100)
+public class EarlyFtInterceptor {
+
+    @Inject
+    private OrderQueueProducer orderFactory;
+
+    /**
+     * Interceptor binding for {@link EarlyFtInterceptor}
+     */
+    @Retention(RUNTIME)
+    @Target({ TYPE, METHOD })
+    @InterceptorBinding
+    public @interface InterceptEarly {}
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        orderFactory.getOrderQueue().add("EarlyOrderFtInterceptor");
+        return ctx.proceed();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/FaultToleranceInterceptorPriorityChangeAnnotationConfTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/FaultToleranceInterceptorPriorityChangeAnnotationConfTest.java
@@ -19,9 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange;
 
-import org.eclipse.microprofile.fault.tolerance.tck.interceptor.EarlyFtInterceptor;
-import org.eclipse.microprofile.fault.tolerance.tck.interceptor.InterceptorComponent;
-import org.eclipse.microprofile.fault.tolerance.tck.interceptor.LateFtInterceptor;
 import org.eclipse.microprofile.fault.tolerance.tck.interceptor.OrderQueueProducer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -57,8 +54,8 @@ public class FaultToleranceInterceptorPriorityChangeAnnotationConfTest extends A
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "interceptorChangeFtAnnotation.jar")
             .addClasses(InterceptorComponent.class, EarlyFtInterceptor.class, LateFtInterceptor.class, OrderQueueProducer.class)
-             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-            .addAsManifestResource(new StringAsset("mp.fault.tolerance.interceptor.priority=2100"), "microprofile-config.properties")
+            .addAsManifestResource(new StringAsset("mp.fault.tolerance.interceptor.priority=3700"), "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
             .as(JavaArchive.class);
 
         return ShrinkWrap.create(WebArchive.class, "interceptorChangeFtAnnotation.war")
@@ -77,8 +74,8 @@ public class FaultToleranceInterceptorPriorityChangeAnnotationConfTest extends A
     public void testAsync() throws InterruptedException, ExecutionException {
         Future<String> result = testInterceptor.asyncGetString();
         assertEquals(result.get(), "OK");
-        String [] expectedOrder = {"EarlyOrderFtInterceptor","LateOrderFtInterceptor","asyncGetString"};
-        /*After changing the FT interceptor priority the order continues working in the same way using annotated interceptors injection*/
+        String [] expectedOrder = {"asyncGetString","LateOrderFtInterceptor","EarlyOrderFtInterceptor"};
+        /*After changing the FT interceptor priority the first interceptor to be called must be FT interceptor*/
         assertEquals(orderFactory.getOrderQueue().toArray(), expectedOrder);
     }
 
@@ -92,9 +89,9 @@ public class FaultToleranceInterceptorPriorityChangeAnnotationConfTest extends A
             assertEquals(e.getMessage().trim(), "retryGetString failed");
         }
 
-        String [] expectedOrder = {"EarlyOrderFtInterceptor","LateOrderFtInterceptor","serviceRetryA",
-            "LateOrderFtInterceptor","serviceRetryA"};
-        /*After changing the FT interceptor priority the order continues working in the same way using annotated interceptors injection*/
+        String [] expectedOrder = {"serviceRetryA","LateOrderFtInterceptor","EarlyOrderFtInterceptor",
+            "serviceRetryA","LateOrderFtInterceptor","EarlyOrderFtInterceptor"};
+        /*After changing the FT interceptor priority the first interceptor to be called must be FT interceptor*/
         assertEquals(orderFactory.getOrderQueue().toArray(), expectedOrder);
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/FaultToleranceInterceptorPriorityChangeAnnotationConfTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/FaultToleranceInterceptorPriorityChangeAnnotationConfTest.java
@@ -74,8 +74,7 @@ public class FaultToleranceInterceptorPriorityChangeAnnotationConfTest extends A
     public void testAsync() throws InterruptedException, ExecutionException {
         Future<String> result = testInterceptor.asyncGetString();
         assertEquals(result.get(), "OK");
-        String [] expectedOrder = {"asyncGetString","EarlyOrderFtInterceptor","LateOrderFtInterceptor"};
-        /*After changing the FT interceptor priority the first interceptor to be called must be FT interceptor*/
+        String [] expectedOrder = {"EarlyOrderFtInterceptor","LateOrderFtInterceptor","asyncGetString"};
         assertEquals(orderFactory.getOrderQueue().toArray(), expectedOrder);
     }
 
@@ -89,9 +88,8 @@ public class FaultToleranceInterceptorPriorityChangeAnnotationConfTest extends A
             assertEquals(e.getMessage().trim(), "retryGetString failed");
         }
 
-        String [] expectedOrder = {"serviceRetryA","EarlyOrderFtInterceptor","LateOrderFtInterceptor",
-            "serviceRetryA","EarlyOrderFtInterceptor","LateOrderFtInterceptor"};
-        /*After changing the FT interceptor priority the first interceptor to be called must be FT interceptor*/
+        String [] expectedOrder = {"EarlyOrderFtInterceptor","LateOrderFtInterceptor","serviceRetryA",
+            "EarlyOrderFtInterceptor","LateOrderFtInterceptor","serviceRetryA"};
         assertEquals(orderFactory.getOrderQueue().toArray(), expectedOrder);
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/FaultToleranceInterceptorPriorityChangeAnnotationConfTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/FaultToleranceInterceptorPriorityChangeAnnotationConfTest.java
@@ -1,0 +1,107 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange;
+
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.EarlyFtInterceptor;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.InterceptorComponent;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.LateFtInterceptor;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.OrderQueueProducer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * A Client to demonstrate the interceptors ordering behavior of FT and CDI annotations
+ * @author carlosdlr
+ */
+public class FaultToleranceInterceptorPriorityChangeAnnotationConfTest extends Arquillian {
+
+    @Inject
+    private InterceptorComponent testInterceptor;
+
+    @Inject
+    private OrderQueueProducer orderFactory;
+
+    @Deployment
+    public static WebArchive deploy() {
+        JavaArchive testJar = ShrinkWrap
+            .create(JavaArchive.class, "interceptorChangeFtAnnotation.jar")
+            .addClasses(InterceptorComponent.class, EarlyFtInterceptor.class, LateFtInterceptor.class, OrderQueueProducer.class)
+             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsManifestResource(new StringAsset("mp.fault.tolerance.interceptor.priority=2100"), "microprofile-config.properties")
+            .as(JavaArchive.class);
+
+        return ShrinkWrap.create(WebArchive.class, "interceptorChangeFtAnnotation.war")
+            .addAsLibrary(testJar);
+    }
+
+    /**
+     * This test validates the interceptors execution order after call a method
+     * annotated with Asynchronous FT annotation, using a queue type FIFO (first-in-first-out).
+     * The head of the queue is that element that has been on the queue the longest time.
+     * In this case is validating that the early interceptor is executed at first.
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     * @throws ExecutionException if the computation threw an exception
+     */
+    @Test
+    public void testAsync() throws InterruptedException, ExecutionException {
+        Future<String> result = testInterceptor.asyncGetString();
+        assertEquals(result.get(), "OK");
+        String [] expectedOrder = {"EarlyOrderFtInterceptor","LateOrderFtInterceptor","asyncGetString"};
+        /*After changing the FT interceptor priority the order continues working in the same way using annotated interceptors injection*/
+        assertEquals(orderFactory.getOrderQueue().toArray(), expectedOrder);
+    }
+
+    @Test
+    public void testRetryInterceptors() {
+        try {
+            testInterceptor.serviceRetryA();
+            fail("Exception not thrown");
+        }
+        catch (Exception e) {
+            assertEquals(e.getMessage().trim(), "retryGetString failed");
+        }
+
+        String [] expectedOrder = {"EarlyOrderFtInterceptor","LateOrderFtInterceptor","serviceRetryA",
+            "LateOrderFtInterceptor","serviceRetryA"};
+        /*After changing the FT interceptor priority the order continues working in the same way using annotated interceptors injection*/
+        assertEquals(orderFactory.getOrderQueue().toArray(), expectedOrder);
+    }
+
+    @AfterMethod
+    public void clearResources() {
+        if (orderFactory != null) { //validate if not null because after the last test is called the context is cleared
+            orderFactory.getOrderQueue().clear();
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/FaultToleranceInterceptorPriorityChangeAnnotationConfTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/FaultToleranceInterceptorPriorityChangeAnnotationConfTest.java
@@ -74,7 +74,7 @@ public class FaultToleranceInterceptorPriorityChangeAnnotationConfTest extends A
     public void testAsync() throws InterruptedException, ExecutionException {
         Future<String> result = testInterceptor.asyncGetString();
         assertEquals(result.get(), "OK");
-        String [] expectedOrder = {"asyncGetString","LateOrderFtInterceptor","EarlyOrderFtInterceptor"};
+        String [] expectedOrder = {"asyncGetString","EarlyOrderFtInterceptor","LateOrderFtInterceptor"};
         /*After changing the FT interceptor priority the first interceptor to be called must be FT interceptor*/
         assertEquals(orderFactory.getOrderQueue().toArray(), expectedOrder);
     }
@@ -89,8 +89,8 @@ public class FaultToleranceInterceptorPriorityChangeAnnotationConfTest extends A
             assertEquals(e.getMessage().trim(), "retryGetString failed");
         }
 
-        String [] expectedOrder = {"serviceRetryA","LateOrderFtInterceptor","EarlyOrderFtInterceptor",
-            "serviceRetryA","LateOrderFtInterceptor","EarlyOrderFtInterceptor"};
+        String [] expectedOrder = {"serviceRetryA","EarlyOrderFtInterceptor","LateOrderFtInterceptor",
+            "serviceRetryA","EarlyOrderFtInterceptor","LateOrderFtInterceptor"};
         /*After changing the FT interceptor priority the first interceptor to be called must be FT interceptor*/
         assertEquals(orderFactory.getOrderQueue().toArray(), expectedOrder);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/FaultToleranceInterceptorPriorityChangeXmlConfTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/FaultToleranceInterceptorPriorityChangeXmlConfTest.java
@@ -1,0 +1,114 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange;
+
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.OrderQueueProducer;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.EarlyFtInterceptor;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.InterceptorComponent;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.LateFtInterceptor;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.beans10.BeansDescriptor;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+/**
+ * A Client to demonstrate the interceptors ordering behavior of FT and CDI annotations
+ * @author carlosdlr
+ */
+public class FaultToleranceInterceptorPriorityChangeXmlConfTest extends Arquillian {
+
+    @Inject
+    private InterceptorComponent testInterceptor;
+
+    @Inject
+    private OrderQueueProducer orderFactory;
+
+    @Deployment
+    public static WebArchive deploy() {
+        BeansDescriptor beans = Descriptors.create(BeansDescriptor.class)
+            .getOrCreateInterceptors()
+            .clazz("org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.EarlyFtInterceptor").up()
+            .getOrCreateInterceptors()
+            .clazz("org.eclipse.microprofile.fault.tolerance.tck.interceptor.xmlInterceptorEnabling.LateFtInterceptor").up();
+
+        JavaArchive testJar = ShrinkWrap
+            .create(JavaArchive.class, "interceptorChangeFtXml.jar")
+            .addClasses(InterceptorComponent.class, EarlyFtInterceptor.class, LateFtInterceptor.class, OrderQueueProducer.class)
+             .addAsManifestResource(new StringAsset(beans.exportAsString()), "beans.xml")
+            .addAsManifestResource(new StringAsset("mp.fault.tolerance.interceptor.priority=1200"), "microprofile-config.properties")
+            .as(JavaArchive.class);
+
+        return ShrinkWrap.create(WebArchive.class, "interceptorChangeFtXml.war")
+            .addAsLibrary(testJar);
+    }
+
+    /**
+     * This test validates the interceptors execution order after call a method
+     * annotated with Asynchronous FT annotation, using a queue type FIFO (first-in-first-out).
+     * The head of the queue is that element that has been on the queue the longest time.
+     * In this case is validating that the early interceptor is executed at first.
+     * @throws InterruptedException if the current thread was interrupted while waiting
+     * @throws ExecutionException if the computation threw an exception
+     */
+    @Test
+    public void testAsync() throws InterruptedException, ExecutionException {
+        Future<String> result = testInterceptor.asyncGetString();
+        assertEquals(result.get(), "OK");
+        String [] expectedOrder = {"EarlyOrderFtInterceptor","LateOrderFtInterceptor","asyncGetString"};
+        /*After changing the FT interceptor priority the order continues working in the same way using xml interceptors configuration injection*/
+        assertEquals(orderFactory.getOrderQueue().toArray(), expectedOrder);
+    }
+
+    @Test
+    public void testRetryInterceptors() {
+        try {
+            testInterceptor.serviceRetryA();
+            fail("Exception not thrown");
+        }
+        catch (Exception e) {
+            assertEquals(e.getMessage().trim(), "retryGetString failed");
+        }
+
+        String [] expectedOrder = {"EarlyOrderFtInterceptor","LateOrderFtInterceptor","serviceRetryA",
+            "EarlyOrderFtInterceptor","LateOrderFtInterceptor","serviceRetryA"};
+        /*After changing the FT interceptor priority the order continues working in the same way using xml interceptors configuration injection*/
+        assertEquals(orderFactory.getOrderQueue().toArray(), expectedOrder);
+    }
+
+    @AfterMethod
+    public void clearResources() {
+        if (orderFactory != null) { //validate if not null because after the last test is called the context is cleared
+            orderFactory.getOrderQueue().clear();
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/InterceptorComponent.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/InterceptorComponent.java
@@ -1,0 +1,59 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange;
+
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange.EarlyFtInterceptor.InterceptEarly;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange.LateFtInterceptor.InterceptLate;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.OrderQueueProducer;
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Retry;
+import org.testng.TestException;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+/**
+ * Component to show the CDI interceptor ordering with FT annotations
+ * @author carlosdlr
+ */
+@ApplicationScoped
+public class InterceptorComponent {
+
+    @Inject
+    private OrderQueueProducer orderFactory;
+
+    @InterceptEarly
+    @InterceptLate
+    @Retry(maxRetries = 1)
+    public String serviceRetryA() {
+        orderFactory.getOrderQueue().add("serviceRetryA");
+        throw new TestException("retryGetString failed");
+    }
+
+    @InterceptEarly
+    @InterceptLate
+    @Asynchronous
+    public Future<String> asyncGetString() {
+        orderFactory.getOrderQueue().add("asyncGetString");
+        return CompletableFuture.completedFuture("OK");
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/LateFtInterceptor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/LateFtInterceptor.java
@@ -42,7 +42,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Interceptor
 @InterceptLate
-@Priority(Interceptor.Priority.PLATFORM_AFTER - 200)
+@Priority(Interceptor.Priority.PLATFORM_AFTER - 100)
 public class LateFtInterceptor {
 
     @Inject

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/LateFtInterceptor.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/interceptor/ftPriorityChange/LateFtInterceptor.java
@@ -1,0 +1,66 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange;
+
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.ftPriorityChange.LateFtInterceptor.InterceptLate;
+import org.eclipse.microprofile.fault.tolerance.tck.interceptor.OrderQueueProducer;
+
+import javax.annotation.Priority;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InterceptorBinding;
+import javax.interceptor.InvocationContext;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * An interceptor that is called after the FT interceptor
+ * in the chain and count the invocation.
+ * @author carlosdlr
+ */
+@Interceptor
+@InterceptLate
+@Priority(Interceptor.Priority.PLATFORM_AFTER - 200)
+public class LateFtInterceptor {
+
+    @Inject
+    private OrderQueueProducer orderFactory;
+
+
+    /**
+     * Interceptor binding for {@link LateFtInterceptor}
+     */
+    @Retention(RUNTIME)
+    @Target({ TYPE, METHOD })
+    @InterceptorBinding
+    public @interface InterceptLate {}
+
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        orderFactory.getOrderQueue().add("LateOrderFtInterceptor");
+        return ctx.proceed();
+    }
+}


### PR DESCRIPTION
FT interceptor priority issue 313

https://github.com/eclipse/microprofile-fault-tolerance/issues/313

New tests added to validate the CDI interceptors against FT interceptor
when the FT interceptor priority is changed and the CDI interceptors
are injected to the context using xml or annotation base configuration.

Signed-off-by: carlos de la rosa <kusanagi12002@gmail.com>