### PR TITLE
Fix tests where ms had been changed to ns inconsistently

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
@@ -207,7 +207,6 @@ public class AsyncTimeoutTest extends Arquillian {
 
         // Call future.get() with a timeout (3 seconds) that is longer than the annotated timeout (2 seconds) specified on
         // the service but shorter than the overall service duration (5 seconds sleep)
-        start = System.nanoTime();
         try {
             future.get(TEST_TIMEOUT_SERVICEA.plus(TEST_TIME_UNIT).toMillis(), TimeUnit.MILLISECONDS);
             throw new AssertionError("testAsyncClassLevelTimeout: Future not interrupted");


### PR DESCRIPTION
I've used Duration where possible to avoid having the same mistake
happen again.

Also fix RetryClientWithDelay so that it records the delay between
subsequent executions correctly.

Fixes #373

I also came across an issue where we were measuring times incorrectly in `testAsyncClassLevelTimeout` so I've fixed that too.

Signed-off-by: Andrew Rouse <anrouse@uk.ibm.com>