### PR TITLE
Zero jitter

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ZeroRetryJitterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ZeroRetryJitterTest.java
@@ -1,0 +1,69 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientForZeroJitter;
+import org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+public class ZeroRetryJitterTest extends Arquillian {
+
+    @Inject
+    private RetryClientForZeroJitter zeroJitterClient;
+
+    @Deployment
+    @ShouldThrowException(value = FaultToleranceDefinitionException.class)
+    public static WebArchive deploy() {
+        JavaArchive testJar = ShrinkWrap
+            .create(JavaArchive.class, "ftZeroTestJitter.jar")
+            .addClasses(RetryClientForZeroJitter.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+            .as(JavaArchive.class);
+
+        return ShrinkWrap
+            .create(WebArchive.class, "ftZeroTestJitter.war")
+            .addAsLibrary(testJar);
+    }
+    /**
+     * Test that checks that jitter = 0 does not generate error during method call.
+     * 
+     * A Service is annotated with a @Retry annotation with jitter = 0.
+     */
+    @Test
+    public void test() {
+        try {
+            zeroJitterClient.serviceA();
+
+            Assert.fail("This should not happen");
+        } catch (RuntimeException e) {
+            // expected
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientForZeroJitter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientForZeroJitter.java
@@ -1,0 +1,40 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver;
+
+import javax.enterprise.context.RequestScoped;
+import java.sql.Connection;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+/**
+ * A client to check for proper processing of jitter = 0 on @Retry
+ * 
+ * @author <a href="mailto:doychin@dsoft-bg.com">Doychin Bondzhev</a>
+ *
+ */
+@RequestScoped
+public class RetryClientForZeroJitter {
+
+    @Retry(jitter = 0)
+    public Connection serviceA() {
+        throw new RuntimeException();
+    }
+}


### PR DESCRIPTION
I understand that this might be an overkill but 0 is not an ordinary number and sometimes implementors might forget that. 

An explicit check for zero will help them track their problem in case they did not properly implement jitter processing.