### PR TITLE
Add test to validate proper execution when jitter = 0 - backport to 1.1.x branch

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ZeroRetryJitterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ZeroRetryJitterTest.java
@@ -30,7 +30,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.fail;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
@@ -56,14 +55,8 @@ public class ZeroRetryJitterTest extends Arquillian {
      */
     @Test
     public void test() {
-        try {
-            zeroJitterClient.serviceA();
-            assertEquals("Incorrect number of retires", 3, zeroJitterClient.getRetries());
-            assertTrue("It took too much time for 3 retries", zeroJitterClient.getTotalRetryTime() < 3 * 200);
-        }
-        catch (Exception e) {
-            e.printStackTrace();
-            fail("Unexpected exception");
-        }
+        zeroJitterClient.serviceA();
+        assertEquals("Incorrect number of retires", 3, zeroJitterClient.getRetries());
+        assertTrue("It took too much time for 3 retries", zeroJitterClient.getTotalRetryTime() < 3 * 200);
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ZeroRetryJitterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ZeroRetryJitterTest.java
@@ -1,0 +1,68 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientForZeroJitter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class ZeroRetryJitterTest extends Arquillian {
+
+    @Inject
+    private RetryClientForZeroJitter zeroJitterClient;
+
+    @Deployment
+    public static WebArchive deploy() {
+        JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftZeroTestJitter.jar")
+                                        .addClasses(RetryClientForZeroJitter.class)
+                                        .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                                        .as(JavaArchive.class);
+
+        return ShrinkWrap.create(WebArchive.class, "ftZeroTestJitter.war").addAsLibrary(testJar);
+    }
+
+    /**
+     * Test that checks that jitter = 0 does not generate error during method call.
+     * <p>
+     * A Service is annotated with a @Retry annotation with jitter = 0.
+     */
+    @Test
+    public void test() {
+        try {
+            zeroJitterClient.serviceA();
+            fail("This should not happen");
+        }
+        catch (RuntimeException e) {
+            assertEquals("Incorrect number of retires", 3, zeroJitterClient.getRetries());
+            assertTrue("It took too much time for 3 retries", zeroJitterClient.getTotalRetryTime() < 3 * 200);
+        }
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ZeroRetryJitterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ZeroRetryJitterTest.java
@@ -58,11 +58,11 @@ public class ZeroRetryJitterTest extends Arquillian {
     public void test() {
         try {
             zeroJitterClient.serviceA();
-            fail("This should not happen");
-        }
-        catch (RuntimeException e) {
             assertEquals("Incorrect number of retires", 3, zeroJitterClient.getRetries());
             assertTrue("It took too much time for 3 retries", zeroJitterClient.getTotalRetryTime() < 3 * 200);
+        }
+        catch (Exception e) {
+            fail("Unexpected exception");
         }
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ZeroRetryJitterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ZeroRetryJitterTest.java
@@ -62,6 +62,7 @@ public class ZeroRetryJitterTest extends Arquillian {
             assertTrue("It took too much time for 3 retries", zeroJitterClient.getTotalRetryTime() < 3 * 200);
         }
         catch (Exception e) {
+            e.printStackTrace();
             fail("Unexpected exception");
         }
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientForZeroJitter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientForZeroJitter.java
@@ -20,7 +20,6 @@
 package org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver;
 
 import javax.enterprise.context.ApplicationScoped;
-import java.sql.Connection;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
 
@@ -39,12 +38,14 @@ public class RetryClientForZeroJitter {
 
     private int retries = -1; // first call is normal call
 
-    @Retry(jitter = 0)
-    public Connection serviceA() {
+    @Retry(maxRetries = 3, jitter = 0)
+    public void serviceA() {
         long currentTime = System.currentTimeMillis();
         totalRetryTime += previousTime > 0 ? currentTime - previousTime : 0;
         previousTime = currentTime;
-        retries++;
+        if (++retries == 3) {
+            return;
+        }
         throw new RuntimeException();
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientForZeroJitter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientForZeroJitter.java
@@ -1,0 +1,58 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver;
+
+import javax.enterprise.context.ApplicationScoped;
+import java.sql.Connection;
+
+import org.eclipse.microprofile.faulttolerance.Retry;
+
+/**
+ * A client to check for proper processing of jitter = 0 on @Retry
+ * 
+ * @author <a href="mailto:doychin@dsoft-bg.com">Doychin Bondzhev</a>
+ *
+ */
+@ApplicationScoped
+public class RetryClientForZeroJitter {
+
+    private long totalRetryTime = 0;
+
+    private long previousTime = 0;
+
+    private int retries = -1; // first call is normal call
+
+    @Retry(jitter = 0)
+    public Connection serviceA() {
+        long currentTime = System.currentTimeMillis();
+        totalRetryTime += previousTime > 0 ? currentTime - previousTime : 0;
+        previousTime = currentTime;
+        retries++;
+        throw new RuntimeException();
+    }
+
+    public int getRetries() {
+        return retries;
+    }
+
+    public long getTotalRetryTime() {
+        return totalRetryTime;
+    }
+}


### PR DESCRIPTION
Incorrectly written code can lead to error during execution if jitter = 0 is not properly processed.

Signed-off-by: Doychin Bondzhev <doychin@dsoft-bg.com>