### PR TITLE
Remove incorrect uses of junit

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncCancellationTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncCancellationTest.java
@@ -41,7 +41,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.After;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -78,7 +78,7 @@ public class AsyncCancellationTest extends Arquillian {
     
     private static List<AsyncBulkheadTask> tasks = new ArrayList<>();
     
-    @After
+    @AfterMethod
     public void cleanup() {
         for (AsyncBulkheadTask task : tasks) {
             task.complete();

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ZeroRetryJitterTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ZeroRetryJitterTest.java
@@ -19,6 +19,10 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+import static org.testng.Assert.assertEquals;
+
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientForZeroJitter;
@@ -30,8 +34,6 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
 
 public class ZeroRetryJitterTest extends Arquillian {
 
@@ -56,7 +58,7 @@ public class ZeroRetryJitterTest extends Arquillian {
     @Test
     public void test() {
         zeroJitterClient.serviceA();
-        assertEquals("Incorrect number of retries", 3, zeroJitterClient.getRetries());
-        assertTrue("It took too much time for 3 retries", zeroJitterClient.getTotalRetryTime() < 3 * 200);
+        assertEquals(zeroJitterClient.getRetries(), 3, "Incorrect number of retries");
+        assertThat("It took too much time for 3 retries", zeroJitterClient.getTotalRetryTime(), lessThan(3 * 200L));
     }
 }


### PR DESCRIPTION
Replace with testng or hamcrest assertions

Note that the usage of junit `@After` in `TestAsyncCancellationTest` is actually a bug which will result in one of the test execution tasks never completing because the cleanup logic will not be run.