### PR TITLE
Widen the timing bounds on TimeoutUninterruptableTest

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/UninterruptableTimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/UninterruptableTimeoutClient.java
@@ -19,12 +19,15 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.enterprise.context.RequestScoped;
@@ -80,14 +83,18 @@ public class UninterruptableTimeoutClient {
     public Future<Void> serviceTimeoutAsync(Future<?> waitingFuture, CompletableFuture<Void> completion) {
         while (true) {
             try {
-                waitingFuture.get();
+                waitingFuture.get(5, SECONDS);
                 completion.complete(null);
                 return CompletableFuture.completedFuture(null);
             }
             catch (InterruptedException e) {
                 // Ignore
-            } catch (ExecutionException e) {
+            }
+            catch (ExecutionException e) {
                 Assert.fail("Waiting future threw exception", e);
+            }
+            catch (TimeoutException e) {
+                return CompletableFuture.completedFuture(null);
             }
         }
     }
@@ -143,13 +150,17 @@ public class UninterruptableTimeoutClient {
         timeoutAsyncBulkheadCounter.incrementAndGet();
         while (true) {
             try {
-                waitingFuture.get();
+                waitingFuture.get(5, SECONDS);
                 return CompletableFuture.completedFuture(null);
             }
             catch (InterruptedException e) {
                 // Ignore
-            } catch (ExecutionException e) {
+            }
+            catch (ExecutionException e) {
                 Assert.fail("Waiting future threw exception", e);
+            }
+            catch (TimeoutException e) {
+                return CompletableFuture.completedFuture(null);
             }
         }
     }
@@ -180,13 +191,17 @@ public class UninterruptableTimeoutClient {
     public Future<Void> serviceTimeoutAsyncBulkheadQueueTimed(Future<?> waitingFuture) {
         while (true) {
             try {
-                waitingFuture.get();
+                waitingFuture.get(5, SECONDS);
                 return CompletableFuture.completedFuture(null);
             }
             catch (InterruptedException e) {
                 // Ignore
-            } catch (ExecutionException e) {
+            }
+            catch (ExecutionException e) {
                 Assert.fail("Waiting future threw exception", e);
+            }
+            catch (TimeoutException e) {
+                return CompletableFuture.completedFuture(null);
             }
         }
     }
@@ -214,13 +229,17 @@ public class UninterruptableTimeoutClient {
         timeoutAsyncRetryCounter.incrementAndGet();
         while (true) {
             try {
-                waitingFuture.get();
+                waitingFuture.get(5, SECONDS);
                 return CompletableFuture.completedFuture(null);
             }
             catch (InterruptedException e) {
                 // Ignore
-            } catch (ExecutionException e) {
+            }
+            catch (ExecutionException e) {
                 Assert.fail("Waiting future threw exception", e);
+            }
+            catch (TimeoutException e) {
+                return CompletableFuture.completedFuture(null);
             }
         }
     }
@@ -254,13 +273,17 @@ public class UninterruptableTimeoutClient {
     public Future<String> serviceTimeoutAsyncFallback(Future<?> waitingFuture) {
         while (true) {
             try {
-                waitingFuture.get();
+                waitingFuture.get(5, SECONDS);
                 return CompletableFuture.completedFuture("OK");
             }
             catch (InterruptedException e) {
                 // Ignore
-            } catch (ExecutionException e) {
+            }
+            catch (ExecutionException e) {
                 Assert.fail("Waiting future threw exception", e);
+            }
+            catch (TimeoutException e) {
+                return CompletableFuture.completedFuture("TIMEDOUT");
             }
         }
     }


### PR DESCRIPTION
Unnecessarily tight time bounds can cause spurious failures in case of
unexpected pauses (e.g. CG, jit, CPU time starvation)

TimeoutUninterruptableTest had quite tight bounds on how quickly the
TimeoutException is returned. However, what's important in this test is
that the TimeoutException is returned before the method has returned so
the bounds can be loosened without invalidating the test.

This sort of problem should be resolved properly by making the timeouts configurable under #399, this is a stop-gap measure to reduce the chance of spurious failures when running the 2.0 TCK.

Also change calls which would wait forever so that the test doesn't hang if the implementation does not work correctly.