### PR TITLE
Make timeouts in tests configurable - Part I

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -127,26 +127,6 @@ public class FaultToleranceBean {
 }
 }
 ```
-##### Timeout Configs
-Since v2.1 we can configure the existing test timeouts. With the following configurations, timeouts can be greatly 
-reduced for local usage or in fast CI environments. 
-
-The properties can be set either with MP Config or System Properties. 
-
-.TCK Timeout configs
-|===
-|Property |Default |unit
-
-|org.eclipse.microprofile.fault.tolerance.basetimeout
-|100
-|ms
-
-|org.eclipse.microprofile.fault.tolerance.basemultiplier
-|10
-|Dimensionless
-|===
-
-
 ## Impact on existing code
 
 n/a

--- a/README.adoc
+++ b/README.adoc
@@ -127,6 +127,26 @@ public class FaultToleranceBean {
 }
 }
 ```
+##### Timeout Configs
+Since v2.1 we can configure the existing test timeouts. With the following configurations, timeouts can be greatly 
+reduced for local usage or in fast CI environments. 
+
+The properties can be set either with MP Config or System Properties. 
+
+.TCK Timeout configs
+|===
+|Property |Default |unit
+
+|org.eclipse.microprofile.fault.tolerance.basetimeout
+|100
+|ms
+
+|org.eclipse.microprofile.fault.tolerance.basemultiplier
+|10
+|Dimensionless
+|===
+
+
 ## Impact on existing code
 
 n/a

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -31,6 +31,7 @@
     <properties>
         <arquillian.version>1.1.14.Final</arquillian.version>
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9_]*$</checkstyle.methodNameFormat>
+        <microprofile-config-api.version>1.3</microprofile-config-api.version>
     </properties>
 
     <dependencyManagement>
@@ -65,6 +66,13 @@
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
             <version>1.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+            <version>${microprofile-config-api.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/tck/running_the_tck.asciidoc
+++ b/tck/running_the_tck.asciidoc
@@ -115,3 +115,21 @@ Once you've added the dependency, you don't need a `tck-suite.xml` you can just 
     </plugins>
 </build>
 ----
+## Timeout Configs
+We can configure the existing tck test timeouts. With the following configurations, timeouts can be greatly
+reduced for use in local executions or in fast CI environments.
+
+The property is a multiplier applied to all timeouts linearly, namely @Timeout annotation values, workload simulations
+and test assertions.
+
+.TCK Timeout config
+|===
+|Property |Default |Unit
+
+|org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier
+|1.0
+|Dimensionless double
+|===
+
+The property can be set either with MP Config or System Properties.
+Example:

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
@@ -54,14 +54,13 @@ public class AsyncTimeoutTest extends Arquillian {
 
     private @Inject AsyncTimeoutClient clientForAsyncTimeout;
     private @Inject AsyncClassLevelTimeoutClient clientForClassLevelAsyncTimeout;
-    private @Inject TCKConfig tckConfig;
 
     // Used to detect Futures that return too slowly
-    private final Duration testFutureThreshold = Duration.ofMillis(tckConfig.getTimeoutInMillis(2000));
+    private final Duration testFutureThreshold = Duration.ofMillis(TCKConfig.getInstance().getTimeoutInMillis(2000));
     // The @Timeout specified on serviceA
-    private final Duration testTimeoutServicea = Duration.ofMillis(tckConfig.getTimeoutInMillis(2000));
+    private final Duration testTimeoutServicea = Duration.ofMillis(TCKConfig.getInstance().getTimeoutInMillis(2000));
     // One second unit
-    private final Duration testTimeUnit = Duration.ofMillis(tckConfig.getTimeoutInMillis(1000));
+    private final Duration testTimeUnit = Duration.ofMillis(TCKConfig.getInstance().getTimeoutInMillis(1000));
 
     @Deployment
     public static WebArchive deploy() {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
@@ -21,7 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 
 import org.eclipse.microprofile.fault.tolerance.tck.asynctimeout.clientserver.AsyncClassLevelTimeoutClient;
 import org.eclipse.microprofile.fault.tolerance.tck.asynctimeout.clientserver.AsyncTimeoutClient;
-import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotation;
+import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotationAsset;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Connection;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -68,7 +68,7 @@ public class AsyncTimeoutTest extends Arquillian {
     @Deployment
     public static WebArchive deploy() {
 
-        final Asset config = new ConfigAnnotation()
+        final Asset config = new ConfigAnnotationAsset()
             .setValue(AsyncTimeoutClient.class, "serviceA", Timeout.class, String.valueOf(TEST_TIMEOUT_SERVICEA.toMillis()))
             .setValue(AsyncTimeoutClient.class, "serviceB", Timeout.class, String.valueOf(TEST_TIMEOUT_SERVICEB.toMillis()))
             .setValue(AsyncClassLevelTimeoutClient.class, null, Timeout.class, getConfig().getTimeoutInStr(2000));

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
@@ -56,9 +56,12 @@ public class AsyncTimeoutTest extends Arquillian {
     private @Inject AsyncClassLevelTimeoutClient clientForClassLevelAsyncTimeout;
     private @Inject TCKConfig tckConfig;
 
-    private final Duration testFutureThreshold = Duration.ofMillis(tckConfig.getTimeoutInMillis(2000)); // Used to detect Futures that return too slowly
-    private final Duration testTimeoutServicea = Duration.ofMillis(tckConfig.getTimeoutInMillis(2000)); // The @Timeout specified on serviceA
-    private final Duration testTimeUnit = Duration.ofMillis(tckConfig.getTimeoutInMillis(1000)); // One second unit
+    // Used to detect Futures that return too slowly
+    private final Duration testFutureThreshold = Duration.ofMillis(tckConfig.getTimeoutInMillis(2000));
+    // The @Timeout specified on serviceA
+    private final Duration testTimeoutServicea = Duration.ofMillis(tckConfig.getTimeoutInMillis(2000));
+    // One second unit
+    private final Duration testTimeUnit = Duration.ofMillis(tckConfig.getTimeoutInMillis(1000));
 
     @Deployment
     public static WebArchive deploy() {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
@@ -297,8 +297,8 @@ public class CircuitBreakerRetryTest extends Arquillian {
         // Allow a margin of 250ms since there's a retry delay of 100ms
         MatcherAssert.assertThat("Call was successful but did not take the expected time",
             Duration.ofNanos(endTime - startTime),
-            DurationMatcher.closeTo(TCKConfig.getInstance().getTimeoutInDuration(1000),
-                TCKConfig.getInstance().getTimeoutInDuration(250)));
+            DurationMatcher.closeTo(TCKConfig.getConfig().getTimeoutInDuration(1000),
+                TCKConfig.getConfig().getTimeoutInDuration(250)));
     }
 
     /**
@@ -329,7 +329,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         // Check that the call took less than 200ms (i.e. we didn't delay and retry)
         MatcherAssert.assertThat("Call was successful but did not take the expected time",
                                  Duration.ofNanos(endTime - startTime),
-                                 lessThan(TCKConfig.getInstance().getTimeoutInDuration(200)));
+                                 lessThan(TCKConfig.getConfig().getTimeoutInDuration(200)));
     }
 
     /**
@@ -358,7 +358,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         // Check that the call took less than 200ms (i.e. we didn't delay and retry)
         MatcherAssert.assertThat("Call was successful but did not take the expected time",
                                  Duration.ofNanos(endTime - startTime),
-                                 lessThan(TCKConfig.getInstance().getTimeoutInDuration(200)));
+                                 lessThan(TCKConfig.getConfig().getTimeoutInDuration(200)));
     }
 
 
@@ -371,7 +371,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         int invokeCounter = 0;
         Future<Connection> result = clientForCBWithRetryAsync.serviceA();
         try {
-            result.get(TCKConfig.getInstance().getTimeoutInMillis(5000), TimeUnit.MILLISECONDS);
+            result.get(TCKConfig.getConfig().getTimeoutInMillis(5000), TimeUnit.MILLISECONDS);
 
             // serviceA should retry until the CB threshold is reached. At that point a CircuitBreakerOpenException
             // should be thrown. Assert if this does not happen.
@@ -413,7 +413,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         int invokeCounter = 0;
         Future<Connection> result = clientForCBWithRetryAsync.serviceB();
         try {
-            result.get(TCKConfig.getInstance().getTimeoutInMillis(5000), TimeUnit.MILLISECONDS);
+            result.get(TCKConfig.getConfig().getTimeoutInMillis(5000), TimeUnit.MILLISECONDS);
 
             // serviceB should retry until the CB threshold is reached. At that point a CircuitBreakerOpenException
             // should be thrown. Assert if this does not happen.
@@ -451,9 +451,9 @@ public class CircuitBreakerRetryTest extends Arquillian {
     @Test
     public void testCircuitOpenWithMultiTimeoutsAsync() {
         int invokeCounter = 0;
-        Future<Connection> result = clientForCBWithRetryAsync.serviceC(TCKConfig.getInstance().getTimeoutInMillis(1000));
+        Future<Connection> result = clientForCBWithRetryAsync.serviceC(TCKConfig.getConfig().getTimeoutInMillis(1000));
         try {
-            result.get(TCKConfig.getInstance().getTimeoutInMillis(10000), TimeUnit.MILLISECONDS); // Expected to finish after about 2 seconds
+            result.get(TCKConfig.getConfig().getTimeoutInMillis(10000), TimeUnit.MILLISECONDS); // Expected to finish after about 2 seconds
 
             // serviceC should retry until the CB threshold is reached. At that point a CircuitBreakerOpenException
             // should be thrown. Assert if this does not happen.
@@ -507,7 +507,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         long startTime = System.nanoTime();
         Future<String> result = clientForCBWithRetryAsync.serviceWithRetryOnCbOpen(false);
         try {
-            result.get(TCKConfig.getInstance().getTimeoutInMillis(10000), TimeUnit.MILLISECONDS);
+            result.get(TCKConfig.getConfig().getTimeoutInMillis(10000), TimeUnit.MILLISECONDS);
         }
         catch (TimeoutException e) {
             fail("Call to serviceWithRetryOnCbOpen did not succeed within 10 seconds");
@@ -524,8 +524,8 @@ public class CircuitBreakerRetryTest extends Arquillian {
         // Allow a margin of 250ms since there's a retry delay of 100ms
         MatcherAssert.assertThat("Call was successful but did not take the expected time",
             Duration.ofNanos(endTime - startTime),
-            DurationMatcher.closeTo(TCKConfig.getInstance().getTimeoutInDuration(1000),
-                TCKConfig.getInstance().getTimeoutInDuration(250)));
+            DurationMatcher.closeTo(TCKConfig.getConfig().getTimeoutInDuration(1000),
+                TCKConfig.getConfig().getTimeoutInDuration(250)));
     }
 
     /**
@@ -554,7 +554,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         // Check that the call took less than 200ms (i.e. we didn't delay and retry)
         MatcherAssert.assertThat("Call was successful but did not take the expected time",
                                  Duration.ofNanos(endTime - startTime),
-                                 lessThan(TCKConfig.getInstance().getTimeoutInDuration(200)));
+                                 lessThan(TCKConfig.getConfig().getTimeoutInDuration(200)));
     }
 
     /**
@@ -581,7 +581,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         // Check that the call took less than 200ms (i.e. we didn't delay and retry)
         MatcherAssert.assertThat("Call was successful but did not take the expected time",
                                  Duration.ofNanos(endTime - startTime),
-                                 lessThan(TCKConfig.getInstance().getTimeoutInDuration(200)));
+                                 lessThan(TCKConfig.getConfig().getTimeoutInDuration(200)));
     }
 
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
@@ -62,7 +62,6 @@ public class CircuitBreakerRetryTest extends Arquillian {
     private @Inject CircuitBreakerClientWithRetry clientForCBWithRetry;
     private @Inject CircuitBreakerClassLevelClientWithRetry clientForClassLevelCBWithRetry;
     private @Inject CircuitBreakerClientWithRetryAsync clientForCBWithRetryAsync;
-    private @Inject TCKConfig tckConfig;
 
     @Deployment
     public static WebArchive deploy() {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
@@ -297,8 +297,8 @@ public class CircuitBreakerRetryTest extends Arquillian {
         // Allow a margin of 250ms since there's a retry delay of 100ms
         MatcherAssert.assertThat("Call was successful but did not take the expected time",
             Duration.ofNanos(endTime - startTime),
-            DurationMatcher.closeTo(tckConfig.getTimeoutInDuration(1000),
-                tckConfig.getTimeoutInDuration(250)));
+            DurationMatcher.closeTo(TCKConfig.getInstance().getTimeoutInDuration(1000),
+                TCKConfig.getInstance().getTimeoutInDuration(250)));
     }
 
     /**
@@ -329,7 +329,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         // Check that the call took less than 200ms (i.e. we didn't delay and retry)
         MatcherAssert.assertThat("Call was successful but did not take the expected time",
                                  Duration.ofNanos(endTime - startTime),
-                                 lessThan(tckConfig.getTimeoutInDuration(200)));
+                                 lessThan(TCKConfig.getInstance().getTimeoutInDuration(200)));
     }
 
     /**
@@ -358,7 +358,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         // Check that the call took less than 200ms (i.e. we didn't delay and retry)
         MatcherAssert.assertThat("Call was successful but did not take the expected time",
                                  Duration.ofNanos(endTime - startTime),
-                                 lessThan(tckConfig.getTimeoutInDuration(200)));
+                                 lessThan(TCKConfig.getInstance().getTimeoutInDuration(200)));
     }
 
 
@@ -371,7 +371,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         int invokeCounter = 0;
         Future<Connection> result = clientForCBWithRetryAsync.serviceA();
         try {
-            result.get(tckConfig.getTimeoutInMillis(5000), TimeUnit.MILLISECONDS);
+            result.get(TCKConfig.getInstance().getTimeoutInMillis(5000), TimeUnit.MILLISECONDS);
 
             // serviceA should retry until the CB threshold is reached. At that point a CircuitBreakerOpenException
             // should be thrown. Assert if this does not happen.
@@ -413,7 +413,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         int invokeCounter = 0;
         Future<Connection> result = clientForCBWithRetryAsync.serviceB();
         try {
-            result.get(tckConfig.getTimeoutInMillis(5000), TimeUnit.MILLISECONDS);
+            result.get(TCKConfig.getInstance().getTimeoutInMillis(5000), TimeUnit.MILLISECONDS);
 
             // serviceB should retry until the CB threshold is reached. At that point a CircuitBreakerOpenException
             // should be thrown. Assert if this does not happen.
@@ -451,9 +451,9 @@ public class CircuitBreakerRetryTest extends Arquillian {
     @Test
     public void testCircuitOpenWithMultiTimeoutsAsync() {
         int invokeCounter = 0;
-        Future<Connection> result = clientForCBWithRetryAsync.serviceC(tckConfig.getTimeoutInMillis(1000));
+        Future<Connection> result = clientForCBWithRetryAsync.serviceC(TCKConfig.getInstance().getTimeoutInMillis(1000));
         try {
-            result.get(tckConfig.getTimeoutInMillis(10000), TimeUnit.MILLISECONDS); // Expected to finish after about 2 seconds
+            result.get(TCKConfig.getInstance().getTimeoutInMillis(10000), TimeUnit.MILLISECONDS); // Expected to finish after about 2 seconds
 
             // serviceC should retry until the CB threshold is reached. At that point a CircuitBreakerOpenException
             // should be thrown. Assert if this does not happen.
@@ -507,7 +507,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         long startTime = System.nanoTime();
         Future<String> result = clientForCBWithRetryAsync.serviceWithRetryOnCbOpen(false);
         try {
-            result.get(tckConfig.getTimeoutInMillis(10000), TimeUnit.MILLISECONDS);
+            result.get(TCKConfig.getInstance().getTimeoutInMillis(10000), TimeUnit.MILLISECONDS);
         }
         catch (TimeoutException e) {
             fail("Call to serviceWithRetryOnCbOpen did not succeed within 10 seconds");
@@ -524,8 +524,8 @@ public class CircuitBreakerRetryTest extends Arquillian {
         // Allow a margin of 250ms since there's a retry delay of 100ms
         MatcherAssert.assertThat("Call was successful but did not take the expected time",
             Duration.ofNanos(endTime - startTime),
-            DurationMatcher.closeTo(tckConfig.getTimeoutInDuration(1000),
-                tckConfig.getTimeoutInDuration(250)));
+            DurationMatcher.closeTo(TCKConfig.getInstance().getTimeoutInDuration(1000),
+                TCKConfig.getInstance().getTimeoutInDuration(250)));
     }
 
     /**
@@ -554,7 +554,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         // Check that the call took less than 200ms (i.e. we didn't delay and retry)
         MatcherAssert.assertThat("Call was successful but did not take the expected time",
                                  Duration.ofNanos(endTime - startTime),
-                                 lessThan(tckConfig.getTimeoutInDuration(200)));
+                                 lessThan(TCKConfig.getInstance().getTimeoutInDuration(200)));
     }
 
     /**
@@ -581,7 +581,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
         // Check that the call took less than 200ms (i.e. we didn't delay and retry)
         MatcherAssert.assertThat("Call was successful but did not take the expected time",
                                  Duration.ofNanos(endTime - startTime),
-                                 lessThan(tckConfig.getTimeoutInDuration(200)));
+                                 lessThan(TCKConfig.getInstance().getTimeoutInDuration(200)));
     }
 
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
@@ -25,6 +25,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClas
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClassLevelClientRetryOn;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientAbortOn;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientRetryOn;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -61,6 +62,7 @@ public class RetryConditionTest extends Arquillian {
     private @Inject RetryClassLevelClientRetryOn clientForClassLevelRetryOn;
     private @Inject RetryClassLevelClientAbortOn clientForClassLevelAbortOn;
     private @Inject AsyncRetryClient asyncRetryClient;
+    private @Inject TCKConfig tckConfig;
 
     @Deployment
     public static WebArchive deploy() {
@@ -348,7 +350,7 @@ public class RetryConditionTest extends Arquillian {
                                              final Class<? extends Throwable> exceptionClass,
                                              final String exceptionMessage) {
         try {
-            CompletableFutureHelper.toCompletableFuture(future).get(1000, TimeUnit.MILLISECONDS);
+            CompletableFutureHelper.toCompletableFuture(future).get(tckConfig.getTimeoutInMillis(), TimeUnit.MILLISECONDS);
             fail("We were expecting an exception: " + exceptionClass.getName() + " with message: " + exceptionMessage);
         }
         catch (InterruptedException | TimeoutException e) {
@@ -362,7 +364,7 @@ public class RetryConditionTest extends Arquillian {
 
     private void assertCompleteOk(final CompletionStage<String> future, final String expectedMessage) {
         try {
-            assertEquals(CompletableFutureHelper.toCompletableFuture(future).get(1000, TimeUnit.MILLISECONDS), expectedMessage);
+            assertEquals(CompletableFutureHelper.toCompletableFuture(future).get(tckConfig.getTimeoutInMillis(), TimeUnit.MILLISECONDS), expectedMessage);
         }
         catch (Exception e) {
             fail("Unexpected exception" + e);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
@@ -364,7 +364,9 @@ public class RetryConditionTest extends Arquillian {
 
     private void assertCompleteOk(final CompletionStage<String> future, final String expectedMessage) {
         try {
-            assertEquals(CompletableFutureHelper.toCompletableFuture(future).get(tckConfig.getTimeoutInMillis(), TimeUnit.MILLISECONDS), expectedMessage);
+            assertEquals(CompletableFutureHelper
+                .toCompletableFuture(future)
+                .get(tckConfig.getTimeoutInMillis(), TimeUnit.MILLISECONDS), expectedMessage);
         }
         catch (Exception e) {
             fail("Unexpected exception" + e);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
@@ -349,7 +349,7 @@ public class RetryConditionTest extends Arquillian {
                                              final Class<? extends Throwable> exceptionClass,
                                              final String exceptionMessage) {
         try {
-            CompletableFutureHelper.toCompletableFuture(future).get(TCKConfig.getInstance().getTimeoutInMillis(), TimeUnit.MILLISECONDS);
+            CompletableFutureHelper.toCompletableFuture(future).get(TCKConfig.getConfig().getTimeoutInMillis(), TimeUnit.MILLISECONDS);
             fail("We were expecting an exception: " + exceptionClass.getName() + " with message: " + exceptionMessage);
         }
         catch (InterruptedException | TimeoutException e) {
@@ -365,7 +365,7 @@ public class RetryConditionTest extends Arquillian {
         try {
             assertEquals(CompletableFutureHelper
                 .toCompletableFuture(future)
-                .get(TCKConfig.getInstance().getTimeoutInMillis(), TimeUnit.MILLISECONDS), expectedMessage);
+                .get(TCKConfig.getConfig().getTimeoutInMillis(), TimeUnit.MILLISECONDS), expectedMessage);
         }
         catch (Exception e) {
             fail("Unexpected exception" + e);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
@@ -349,7 +349,7 @@ public class RetryConditionTest extends Arquillian {
                                              final Class<? extends Throwable> exceptionClass,
                                              final String exceptionMessage) {
         try {
-            CompletableFutureHelper.toCompletableFuture(future).get(tckConfig.getTimeoutInMillis(), TimeUnit.MILLISECONDS);
+            CompletableFutureHelper.toCompletableFuture(future).get(TCKConfig.getInstance().getTimeoutInMillis(), TimeUnit.MILLISECONDS);
             fail("We were expecting an exception: " + exceptionClass.getName() + " with message: " + exceptionMessage);
         }
         catch (InterruptedException | TimeoutException e) {
@@ -365,7 +365,7 @@ public class RetryConditionTest extends Arquillian {
         try {
             assertEquals(CompletableFutureHelper
                 .toCompletableFuture(future)
-                .get(tckConfig.getTimeoutInMillis(), TimeUnit.MILLISECONDS), expectedMessage);
+                .get(TCKConfig.getInstance().getTimeoutInMillis(), TimeUnit.MILLISECONDS), expectedMessage);
         }
         catch (Exception e) {
             fail("Unexpected exception" + e);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
@@ -62,7 +62,6 @@ public class RetryConditionTest extends Arquillian {
     private @Inject RetryClassLevelClientRetryOn clientForClassLevelRetryOn;
     private @Inject RetryClassLevelClientAbortOn clientForClassLevelAbortOn;
     private @Inject AsyncRetryClient asyncRetryClient;
-    private @Inject TCKConfig tckConfig;
 
     @Deployment
     public static WebArchive deploy() {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTimeoutTest.java
@@ -19,12 +19,15 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck;
 
+import static org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig.getConfig;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotationAsset;
 import org.eclipse.microprofile.fault.tolerance.tck.retrytimeout.clientserver.RetryTimeoutClient;
+import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -47,10 +50,17 @@ public class RetryTimeoutTest extends Arquillian {
     
     @Deployment
     public static WebArchive deploy() {
+
+        final ConfigAnnotationAsset config = new ConfigAnnotationAsset()
+            .setValue(RetryTimeoutClient.class,"serviceA", Timeout.class,getConfig().getTimeoutInStr(500))
+            .setValue(RetryTimeoutClient.class,"serviceWithoutRetryOn", Timeout.class,getConfig().getTimeoutInStr(500))
+            .setValue(RetryTimeoutClient.class,"serviceWithAbortOn", Timeout.class,getConfig().getTimeoutInStr(500));
+
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftRetryTimeout.jar")
                 .addClasses(RetryTimeoutClient.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsManifestResource(config, "microprofile-config.properties")
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);
 
         WebArchive war = ShrinkWrap

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutTest.java
@@ -21,18 +21,23 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotationAsset;
 import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.DefaultTimeoutClient;
 import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.ShorterTimeoutClient;
 import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.TimeoutClient;
+import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig.getConfig;
 
 /**
  * Tests to exercise Fault Tolerance Timeouts.
@@ -48,6 +53,12 @@ public class TimeoutTest extends Arquillian {
 
     @Deployment
     public static WebArchive deploy() {
+        final Asset config = new ConfigAnnotationAsset()
+            .setValue(TimeoutClient.class,"serviceA", Timeout.class, getConfig().getTimeoutInStr())
+            .setValue(TimeoutClient.class,"serviceB", Timeout.class, getConfig().getTimeoutInStr(2000))
+            .setValue(TimeoutClient.class,"serviceC", Timeout.class, getConfig().getTimeoutInStr(500));
+        // serviceD uses SECONDS time unit and will not be configured
+
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftTimeout.jar")
                 .addClasses(TimeoutClient.class, DefaultTimeoutClient.class, ShorterTimeoutClient.class)
@@ -188,7 +199,7 @@ public class TimeoutTest extends Arquillian {
     @Test
     public void testSecondsTimeout() {
         try {
-            clientForTimeout.serviceD(2500);
+            clientForTimeout.serviceD(2500);// timeout will not be dynamically configured
             Assert.fail("serviceD should throw a TimeoutException in testSecondsTimeout");
         } 
         catch (TimeoutException ex) {
@@ -210,7 +221,7 @@ public class TimeoutTest extends Arquillian {
     @Test
     public void testSecondsNoTimeout() {
         try {
-            clientForTimeout.serviceD(1500);
+            clientForTimeout.serviceD(1500);// timeout will not be dynamically configured
             Assert.fail("serviceD should throw a RuntimeException in testSecondsNoTimeout");
         } 
         catch (TimeoutException ex) {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynchronous/AsyncClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynchronous/AsyncClient.java
@@ -27,8 +27,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.util.Connection;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 
 /**
@@ -39,6 +41,8 @@ import org.eclipse.microprofile.faulttolerance.Asynchronous;
  */
 @RequestScoped
 public class AsyncClient {
+
+    private @Inject TCKConfig tckConfig;
 
     /**
      * service 1 second in normal operation.
@@ -91,7 +95,7 @@ public class AsyncClient {
 
         Throwable exception = null;
         try {
-            waitCondition.get(1000, TimeUnit.SECONDS);
+            waitCondition.get(tckConfig.getTimeoutInMillis(), TimeUnit.SECONDS);
         }
         catch (ExecutionException e) {
             exception = e.getCause();

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynchronous/AsyncClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynchronous/AsyncClient.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import javax.enterprise.context.RequestScoped;
-import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.util.Connection;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
@@ -93,7 +92,7 @@ public class AsyncClient {
 
         Throwable exception = null;
         try {
-            waitCondition.get(tckConfig.getTimeoutInMillis(), TimeUnit.SECONDS);
+            waitCondition.get(TCKConfig.getInstance().getTimeoutInMillis(), TimeUnit.SECONDS);
         }
         catch (ExecutionException e) {
             exception = e.getCause();

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynchronous/AsyncClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynchronous/AsyncClient.java
@@ -42,8 +42,6 @@ import org.eclipse.microprofile.faulttolerance.Asynchronous;
 @RequestScoped
 public class AsyncClient {
 
-    private @Inject TCKConfig tckConfig;
-
     /**
      * service 1 second in normal operation.
      *

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynchronous/AsyncClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynchronous/AsyncClient.java
@@ -52,7 +52,7 @@ public class AsyncClient {
 
         Connection conn = new Connection() {
             {
-                Thread.sleep(1000);
+                Thread.sleep(TCKConfig.getConfig().getTimeoutInMillis(1000));
             }
 
             @Override
@@ -92,7 +92,7 @@ public class AsyncClient {
 
         Throwable exception = null;
         try {
-            waitCondition.get(TCKConfig.getInstance().getTimeoutInMillis(), TimeUnit.SECONDS);
+            waitCondition.get(TCKConfig.getConfig().getTimeoutInMillis(), TimeUnit.SECONDS);
         }
         catch (ExecutionException e) {
             exception = e.getCause();

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynctimeout/clientserver/AsyncClassLevelTimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynctimeout/clientserver/AsyncClassLevelTimeoutClient.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 
 import javax.enterprise.context.RequestScoped;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Connection;
@@ -50,7 +51,7 @@ public class AsyncClassLevelTimeoutClient {
 
         Connection conn = new Connection() {
             {
-                Thread.sleep(5000);
+                Thread.sleep(TCKConfig.getConfig().getTimeoutInMillis(5000));
             }
             
             @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynctimeout/clientserver/AsyncTimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynctimeout/clientserver/AsyncTimeoutClient.java
@@ -37,8 +37,8 @@ import org.eclipse.microprofile.fault.tolerance.tck.util.Connection;
  */
 @RequestScoped
 public class AsyncTimeoutClient {
-    
-    
+
+
     /**
      * serviceA is a slow running service that will take 5 seconds in normal operation. Here it is
      * configured to time out after 2 seconds.
@@ -51,7 +51,7 @@ public class AsyncTimeoutClient {
 
         Connection conn = new Connection() {
             {
-                Thread.sleep(TCKConfig.getInstance().getTimeoutInMillis(5000));
+                Thread.sleep(TCKConfig.getConfig().getTimeoutInMillis(5000));
             }
             
             @Override
@@ -75,7 +75,7 @@ public class AsyncTimeoutClient {
 
         Connection conn = new Connection() {
             {
-                Thread.sleep(TCKConfig.getInstance().getTimeoutInMillis(500));
+                Thread.sleep(TCKConfig.getConfig().getTimeoutInMillis(500));
             }
             
             @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynctimeout/clientserver/AsyncTimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asynctimeout/clientserver/AsyncTimeoutClient.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 
 import javax.enterprise.context.RequestScoped;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Connection;
@@ -50,7 +51,7 @@ public class AsyncTimeoutClient {
 
         Connection conn = new Connection() {
             {
-                Thread.sleep(5000);
+                Thread.sleep(TCKConfig.getInstance().getTimeoutInMillis(5000));
             }
             
             @Override
@@ -74,7 +75,7 @@ public class AsyncTimeoutClient {
 
         Connection conn = new Connection() {
             {
-                Thread.sleep(500);
+                Thread.sleep(TCKConfig.getInstance().getTimeoutInMillis(500));
             }
             
             @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/ConfigAnnotation.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/ConfigAnnotation.java
@@ -1,0 +1,82 @@
+package org.eclipse.microprofile.fault.tolerance.tck.config;/*
+ *******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+import org.jboss.shrinkwrap.api.asset.Asset;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.util.Properties;
+
+public class ConfigAnnotation implements Asset {
+
+    private final Properties props = new Properties();
+
+    @Override
+    public InputStream openStream() {
+        try {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            props.store(os, null);
+            return new ByteArrayInputStream(os.toByteArray());
+        }
+        catch (IOException e) {
+            // Shouldn't happen since we're only using in memory streams
+            throw new RuntimeException("Unexpected error saving properties", e);
+        }
+    }
+
+    public ConfigAnnotation setValue(final Class<?> clazz, final String method,
+                                     final Class<? extends Annotation> annotation, final String value) {
+        props.put(keyFor(clazz, method, annotation, "value"), value);
+        return this;
+    }
+
+    /**
+     * Build config key used to enable an annotation for a class and method
+     * <p>
+     * E.g. {@code com.example.MyClass/myMethod/Retry/enabled}
+     *
+     * @param clazz      may be null
+     * @param method     may be null
+     * @param annotation required
+     * @return config key
+     */
+    private String keyFor(final Class<?> clazz, final String method, final Class<? extends Annotation> annotation,
+                          final String property) {
+        StringBuilder sb = new StringBuilder();
+        if (clazz != null) {
+            sb.append(clazz.getCanonicalName());
+            sb.append("/");
+        }
+
+        if (method != null) {
+            sb.append(method);
+            sb.append("/");
+        }
+
+        sb.append(annotation.getSimpleName());
+        sb.append("/");
+        sb.append(property);
+
+        return sb.toString();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/ConfigAnnotationAsset.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/ConfigAnnotationAsset.java
@@ -80,7 +80,8 @@ public class ConfigAnnotationAsset implements Asset {
         return sb.toString();
     }
 
-    public void mergeProperties(final Properties properties) {
+    public ConfigAnnotationAsset mergeProperties(final Properties properties) {
         this.props.putAll(properties);
+        return this;
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/ConfigAnnotationAsset.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/ConfigAnnotationAsset.java
@@ -27,7 +27,7 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.util.Properties;
 
-public class ConfigAnnotation implements Asset {
+public class ConfigAnnotationAsset implements Asset {
 
     private final Properties props = new Properties();
 
@@ -44,8 +44,8 @@ public class ConfigAnnotation implements Asset {
         }
     }
 
-    public ConfigAnnotation setValue(final Class<?> clazz, final String method,
-                                     final Class<? extends Annotation> annotation, final String value) {
+    public ConfigAnnotationAsset setValue(final Class<?> clazz, final String method,
+                                          final Class<? extends Annotation> annotation, final String value) {
         props.put(keyFor(clazz, method, annotation, "value"), value);
         return this;
     }
@@ -78,5 +78,9 @@ public class ConfigAnnotation implements Asset {
         sb.append(property);
 
         return sb.toString();
+    }
+
+    public void mergeProperties(final Properties properties) {
+        this.props.putAll(properties);
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationClient.java
@@ -27,6 +27,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.util.ConcurrentExecutionTracker;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
@@ -113,7 +114,7 @@ public class DisableAnnotationClient {
     @Timeout(500)
     public void failWithTimeout() {
         try {
-            Thread.sleep(2000);
+            Thread.sleep(TCKConfig.getConfig().getTimeoutInMillis(2000));
             throw new TestException();
         }
         catch (InterruptedException e) {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationGloballyEnableOnClassDisableOnMethod.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationGloballyEnableOnClassDisableOnMethod.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Future;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotationAsset;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
@@ -44,6 +45,8 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig.getConfig;
 
 /**
  * Test that annotations can be disabled globally, then enabled at the class level and then disabled at the method level.
@@ -83,11 +86,16 @@ public class DisableAnnotationGloballyEnableOnClassDisableOnMethod extends Arqui
                 .disable(DisableAnnotationClient.class, "failRetryOnceThenFallback", Fallback.class)
                 .disable(DisableAnnotationClient.class, "waitWithBulkhead", Bulkhead.class);
 
+        ConfigAnnotationAsset mpAnnotationConfig = new ConfigAnnotationAsset()
+            .setValue(DisableAnnotationClient.class,"failWithTimeout",Timeout.class,getConfig().getTimeoutInStr(500));
+
+         mpAnnotationConfig.mergeProperties(((DisableConfigAsset) config).getProps());
+
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftDisableGloballyEnableClassDisableMethod.jar")
             .addClasses(DisableAnnotationClient.class)
             .addPackage(Packages.UTILS)
-            .addAsManifestResource(config, "microprofile-config.properties")
+            .addAsManifestResource(mpAnnotationConfig, "microprofile-config.properties")
             .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
             .as(JavaArchive.class);
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationGloballyEnableOnClassDisableOnMethod.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationGloballyEnableOnClassDisableOnMethod.java
@@ -66,7 +66,7 @@ public class DisableAnnotationGloballyEnableOnClassDisableOnMethod extends Arqui
     @Deployment
     public static WebArchive deploy() {
         
-        Asset config = new DisableConfigAsset()
+        final Asset config = new DisableConfigAsset()
                 .disable(Retry.class)
                 .disable(CircuitBreaker.class)
                 .disable(Timeout.class)
@@ -86,10 +86,9 @@ public class DisableAnnotationGloballyEnableOnClassDisableOnMethod extends Arqui
                 .disable(DisableAnnotationClient.class, "failRetryOnceThenFallback", Fallback.class)
                 .disable(DisableAnnotationClient.class, "waitWithBulkhead", Bulkhead.class);
 
-        ConfigAnnotationAsset mpAnnotationConfig = new ConfigAnnotationAsset()
-            .setValue(DisableAnnotationClient.class,"failWithTimeout",Timeout.class,getConfig().getTimeoutInStr(500));
-
-         mpAnnotationConfig.mergeProperties(((DisableConfigAsset) config).getProps());
+        final ConfigAnnotationAsset mpAnnotationConfig = new ConfigAnnotationAsset()
+            .setValue(DisableAnnotationClient.class,"failWithTimeout",Timeout.class,getConfig().getTimeoutInStr(500))
+            .mergeProperties(((DisableConfigAsset) config).getProps());
 
         JavaArchive testJar = ShrinkWrap
             .create(JavaArchive.class, "ftDisableGloballyEnableClassDisableMethod.jar")

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableConfigAsset.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableConfigAsset.java
@@ -37,6 +37,10 @@ public class DisableConfigAsset implements Asset {
     
     private Properties props = new Properties();
 
+    public Properties getProps() {
+        return props;
+    }
+
     @Override
     public InputStream openStream() {
         try {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/BulkheadMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/BulkheadMetricTest.java
@@ -48,6 +48,8 @@ public class BulkheadMetricTest extends Arquillian {
 
     @Deployment
     public static WebArchive deploy() {
+
+
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricBulkhead.war")
                 .addClasses(BulkheadMetricBean.class)
                 .addPackage(Packages.UTILS)

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/TimeoutMetricBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/TimeoutMetricBean.java
@@ -27,18 +27,18 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
 public class TimeoutMetricBean {
     
     @Timeout(value = 500)
-    public void counterTestWorkForMillis(int millis) {
+    public void counterTestWorkForMillis(long millis) {
         doWork(millis);
     }
     
     @Timeout(value = 2000)
-    public void histogramTestWorkForMillis(int millis) {
+    public void histogramTestWorkForMillis(long millis) {
         doWork(millis);
     }
     
-    private void doWork(int millis) {
+    private void doWork(long millis) {
         try {
-            Thread.sleep(millis);
+            Thread.sleep(millis);//timeout config must be done in the caller.
         }
         catch (InterruptedException ex) {
             throw new RuntimeException("Test was interrupted", ex);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/util/MetricComparator.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/util/MetricComparator.java
@@ -19,10 +19,10 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.metrics.util;
 
-import static org.hamcrest.Matchers.closeTo;
-
 import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
 import org.hamcrest.Matcher;
+
+import static org.hamcrest.Matchers.closeTo;
 
 public class MetricComparator {
 
@@ -30,7 +30,7 @@ public class MetricComparator {
     private MetricComparator() {}
     
     /**
-     * Check that a nanosecond time is with 100ms of an expected time in milliseconds
+     * Check that a nanosecond time is withith 20% of an expected time in milliseconds
      * <p>
      * Note that this method does both the millseconds to nanoseconds conversion and creates a {@link Matcher} to do the check.
      * <p>
@@ -42,8 +42,9 @@ public class MetricComparator {
     public static Matcher<Double> approxMillis(final long originalMillis) {
 
         final long millis = TCKConfig.getConfig().getTimeoutInMillis(originalMillis);
+        final long margin = TCKConfig.getConfig().getTimeoutInMillis(Math.round(originalMillis * 0.2));
         long nanos = millis * 1_000_000;
-        return closeTo(nanos, 1_000_000 * 100);
+        return closeTo(nanos, 1_000_000 * margin);
     }
     
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/util/MetricComparator.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/util/MetricComparator.java
@@ -21,6 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.metrics.util;
 
 import static org.hamcrest.Matchers.closeTo;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
 import org.hamcrest.Matcher;
 
 public class MetricComparator {
@@ -35,10 +36,12 @@ public class MetricComparator {
      * <p>
      * Useful for checking the results from Histograms.
      * 
-     * @param millis the expected time in milliseconds
+     * @param originalMillis the expected time in milliseconds
      * @return a {@link Matcher} which matches against a time in milliseconds
      */
-    public static Matcher<Double> approxMillis(long millis) {
+    public static Matcher<Double> approxMillis(final long originalMillis) {
+
+        final long millis = TCKConfig.getConfig().getTimeoutInMillis(originalMillis);
         long nanos = millis * 1_000_000;
         return closeTo(nanos, 1_000_000 * 100);
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/TimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/TimeoutClient.java
@@ -87,7 +87,8 @@ public class TimeoutClient {
     
     /**
      * serviceD specifies a Timeout longer than the default, at 2 
-     * seconds 
+     * seconds.<br>
+     * Tests using this method will not have the timeout dynamically configured.
      * @param timeToSleepInMillis  How long should the execution take in millis
      * @return null or exception is raised
      */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TCKConfig.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TCKConfig.java
@@ -32,18 +32,28 @@ public class TCKConfig {
         return INSTANCE;
     }
 
-    private final long baseTimeout;
+    private long baseTimeout;
 
-    private final int baseMultiplier;
+    private int baseMultiplier;
 
     private TCKConfig() {
-        final Config config = ConfigProvider.getConfig();
-        baseTimeout = config
-            .getOptionalValue("org.eclipse.microprofile.fault.tolerance.basetimeout", Long.class)
-            .orElse(100L);
-        baseMultiplier = config
-            .getOptionalValue("org.eclipse.microprofile.fault.tolerance.basemultiplier", Integer.class)
-            .orElse(10);
+        // TODO catch exceptions and try to load from system properties.
+        try {
+            final Config config = ConfigProvider.getConfig();
+            baseTimeout = config
+                .getOptionalValue("org.eclipse.microprofile.fault.tolerance.basetimeout", Long.class)
+                .orElse(100L);
+            baseMultiplier = config
+                .getOptionalValue("org.eclipse.microprofile.fault.tolerance.basemultiplier", Integer.class)
+                .orElse(10);
+        }
+        catch (Exception e) {
+            System.out.println("Could not use microprofile config. Falling back to system properties. Problem:" + e.getMessage());
+            baseTimeout = Long.valueOf(
+                System.getProperty("org.eclipse.microprofile.fault.tolerance.basetimeout", "100"));
+            baseMultiplier = Integer.valueOf(
+                System.getProperty("org.eclipse.microprofile.fault.tolerance.basemultiplier", "10"));
+        }
     }
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TCKConfig.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TCKConfig.java
@@ -28,7 +28,7 @@ public class TCKConfig {
 
     private static final TCKConfig INSTANCE = new TCKConfig();
 
-    public static TCKConfig getInstance() {
+    public static TCKConfig getConfig() {
         return INSTANCE;
     }
 
@@ -52,6 +52,10 @@ public class TCKConfig {
      */
     public long getBaseTimeout() {
         return baseTimeout;
+    }
+
+    public String getTimeoutInStr(final int originalInMillis) {
+        return String.valueOf(getTimeoutInMillis(originalInMillis));
     }
 
     public long getTimeoutInMillis(final int originalInMillis) {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TCKConfig.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TCKConfig.java
@@ -77,6 +77,10 @@ public class TCKConfig {
     }
 
     public long getTimeoutInMillis(final int originalInMillis) {
+        return getTimeoutInMillis(Long.valueOf(originalInMillis));
+    }
+
+    public long getTimeoutInMillis(final long originalInMillis) {
         if (originalInMillis < baseTimeout) {
             throw new IllegalArgumentException("Timeout must be bigger than " + baseTimeout + "ms, the baseTimeout.");
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TCKConfig.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TCKConfig.java
@@ -37,7 +37,6 @@ public class TCKConfig {
     private int baseMultiplier;
 
     private TCKConfig() {
-        // TODO catch exceptions and try to load from system properties.
         try {
             final Config config = ConfigProvider.getConfig();
             baseTimeout = config
@@ -62,6 +61,15 @@ public class TCKConfig {
      */
     public long getBaseTimeout() {
         return baseTimeout;
+    }
+
+    /**
+     * Should be the Timeout default
+     *
+     * @return
+     */
+    public String getTimeoutInStr() {
+        return String.valueOf(getTimeoutInMillis(1000));
     }
 
     public String getTimeoutInStr(final int originalInMillis) {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TCKConfig.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TCKConfig.java
@@ -1,0 +1,68 @@
+package org.eclipse.microprofile.fault.tolerance.tck.util;/*
+ *******************************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import java.time.Duration;
+
+@ApplicationScoped
+public class TCKConfig {
+
+    /**
+     * The base timeout serves as the base multiplier for all timeouts and is expressed in milliseconds.
+     * Must not be less than 10ms.
+     */
+    @Inject
+    @ConfigProperty(name = "org.eclipse.microprofile.fault.tolerance.basetimeout", defaultValue = "100")
+    private long baseTimeout;
+
+    @Inject
+    @ConfigProperty(name = "org.eclipse.microprofile.fault.tolerance.basemultiplier", defaultValue = "10")
+    private int baseMultiplier;
+
+    public long getBaseTimeout() {
+        return baseTimeout;
+    }
+
+    public long getTimeoutInMillis(final int originalInMillis) {
+        if (originalInMillis < baseTimeout) {
+            throw new IllegalArgumentException("Timeout must be bigger than " + baseTimeout + "ms, the baseTimeout.");
+        }
+        final float offset = Float.valueOf(originalInMillis) / 1000;
+        return Math.round(getTimeoutInMillis() * offset);
+    }
+
+    public Duration getTimeoutInDuration(final int originalInMillis) {
+        return Duration.ofMillis(getTimeoutInMillis(originalInMillis));
+    }
+
+    /**
+     * Reference value is 1000ms
+     *
+     * @return
+     */
+    public long getTimeoutInMillis() {
+        return baseTimeout * baseMultiplier;
+    }
+
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TCKConfig.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/TCKConfig.java
@@ -18,27 +18,38 @@ package org.eclipse.microprofile.fault.tolerance.tck.util;/*
  * limitations under the License.
  *******************************************************************************/
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.config.Config;
+import org.eclipse.microprofile.config.ConfigProvider;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 import java.time.Duration;
 
-@ApplicationScoped
+
 public class TCKConfig {
+
+    private static final TCKConfig INSTANCE = new TCKConfig();
+
+    public static TCKConfig getInstance() {
+        return INSTANCE;
+    }
+
+    private final long baseTimeout;
+
+    private final int baseMultiplier;
+
+    private TCKConfig() {
+        final Config config = ConfigProvider.getConfig();
+        baseTimeout = config
+            .getOptionalValue("org.eclipse.microprofile.fault.tolerance.basetimeout", Long.class)
+            .orElse(100L);
+        baseMultiplier = config
+            .getOptionalValue("org.eclipse.microprofile.fault.tolerance.basemultiplier", Integer.class)
+            .orElse(10);
+    }
 
     /**
      * The base timeout serves as the base multiplier for all timeouts and is expressed in milliseconds.
      * Must not be less than 10ms.
      */
-    @Inject
-    @ConfigProperty(name = "org.eclipse.microprofile.fault.tolerance.basetimeout", defaultValue = "100")
-    private long baseTimeout;
-
-    @Inject
-    @ConfigProperty(name = "org.eclipse.microprofile.fault.tolerance.basemultiplier", defaultValue = "10")
-    private int baseMultiplier;
-
     public long getBaseTimeout() {
         return baseTimeout;
     }
@@ -63,6 +74,5 @@ public class TCKConfig {
     public long getTimeoutInMillis() {
         return baseTimeout * baseMultiplier;
     }
-
 
 }


### PR DESCRIPTION
Signed-off-by: brunobat <bbaptista@tomitribe.com>

This is related to issue #399 

First approach to the configurable timeouts problem. 
Missing: 
- Not all classes were changed
- Make the configuration timeout more fine grained by using regular expressions. 
- Fix checkstyle issues
- explore to use a TestNG runner to override the `@Test` timeout attributes