### PR TITLE
#409 fix thread ordering in BulkheadAsynchRetryTest.testRetriesJoinBackOfQueue

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadAsynchRetryTest.java
@@ -405,15 +405,14 @@ public class BulkheadAsynchRetryTest extends Arquillian {
     public void testRetriesJoinBackOfQueue() throws InterruptedException, ExecutionException, TimeoutException {
         AsyncBulkheadTask taskA = newTask();
         Future resultA = retryQueueAsyncBean.test(taskA);
+        taskA.assertStarting(resultA);
         
         AsyncBulkheadTask taskB = newTask();
         Future resultB = retryQueueAsyncBean.test(taskB);
+        taskB.assertNotStarting();
         
         AsyncBulkheadTask taskC = newTask();
         Future resultC = retryQueueAsyncBean.test(taskC);
-        
-        taskA.assertStarting(resultA);
-        taskB.assertNotStarting();
         taskC.assertNotStarting();
         
         taskA.completeExceptionally(new TestException()); // fail A, causes instant retry which puts taskA on the back of the queue


### PR DESCRIPTION
Signed-off-by: Ladislav Thon <lthon@redhat.com>