### PR TITLE
Moving the "how to contribute" part to it's own file

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+== How to contribute
+
+Do you want to contribute to this project? Here is what you can do:
+
+* Fork the repository, make changes, then do a pull request.
+** Remember to https://help.github.com/articles/signing-commits/[sign your commits]
+** Make sure you have signed the https://www.eclipse.org/legal/ECA.php[Eclipse Contributor Agreement]
+* https://github.com/eclipse/microprofile-fault-tolerance/issues[Create or fix an issue].
+* https://gitter.im/eclipse/microprofile-fault-tolerance[Join us on Gitter to discuss this project].
+* Join our https://calendar.google.com/calendar/embed?src=gbnbc373ga40n0tvbl88nkc3r4%40group.calendar.google.com[weekly meeting] on Wednesdays at https://www.timeanddate.com/time/map/[14h00 GMT]. 
+** https://docs.google.com/document/d/12Tm_JP2Ws8W1fU5IIhhIbNHbrEIf27wgTbTIv80JoXY/edit[Minutes and Agenda].
+** https://eclipse.zoom.us/j/949859967[Meeting room].
+* Join the discussions on the https://groups.google.com/forum/#!forum/microprofile[MicroProfile Google Group]
+* https://microprofile.io/blog/[Contribute a blog post].
+
+Also see the https://wiki.eclipse.org/MicroProfile/ContributingGuidelines[MicroProfile Contributing Guidelines] on the https://wiki.eclipse.org/MicroProfile[Eclipse MicroProfile wiki page]

--- a/README.adoc
+++ b/README.adoc
@@ -20,24 +20,6 @@ image:https://badges.gitter.im/eclipse/microprofile-fault-tolerance.svg[link="ht
 
 # Fault Tolerance
 
-'''
-== How to contribute
-
-Do you want to contribute to this project? Here is what you can do:
-
-* Fork the repository, make changes, then do a pull request.
-** Remember to https://help.github.com/articles/signing-commits/[sign your commits]
-** Make sure you have signed the https://www.eclipse.org/legal/ECA.php[Eclipse Contributor Agreement]
-* https://github.com/eclipse/microprofile-fault-tolerance/issues[Create or fix an issue].
-* https://gitter.im/eclipse/microprofile-fault-tolerance[Join us on Gitter to discuss this project].
-* Join our https://calendar.google.com/calendar/embed?src=gbnbc373ga40n0tvbl88nkc3r4%40group.calendar.google.com[weekly meeting] on Wednesdays at https://www.timeanddate.com/time/map/[14h00 GMT]. 
-** https://docs.google.com/document/d/12Tm_JP2Ws8W1fU5IIhhIbNHbrEIf27wgTbTIv80JoXY/edit[Minutes and Agenda].
-** https://eclipse.zoom.us/j/949859967[Meeting room].
-* Join the discussions on the https://groups.google.com/forum/#!forum/microprofile[MicroProfile Google Group]
-* https://microprofile.io/blog/[Contribute a blog post].
-
-'''
-
 * Proposal: link:0004-FaultTolerance.md[MP-0004]
 * Authors: link:https://github.com/Emily-Jiang[Emily Jiang], link:https://github.com/jhalterman/[Jonathan Halterman], link:https://github.com/antoinesd[Antoine Sabot-Durand], link:https://github.com/johnament[John Ament]
 * Status: **v1.0 released**
@@ -152,3 +134,7 @@ n/a
 ## Alternatives considered
 
 n/a
+
+## Contributing
+
+Do you want to contribute to this project? link:CONTRIBUTING.adoc[Find out how you can help here].


### PR DESCRIPTION
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>

As discussed here: https://groups.google.com/forum/#!topic/microprofile/-o0Mqv4I2IY

Change the "How to contribute" to be in it's own file.