### PR TITLE
clarify circuit breaker metrics

### DIFF
--- a/spec/src/main/asciidoc/metrics.asciidoc
+++ b/spec/src/main/asciidoc/metrics.asciidoc
@@ -102,15 +102,15 @@ Note that the sum of `ft.<name>.timeout.callsTimedOut.total` and `ft.<name>.time
 
 |`ft.<name>.circuitbreaker.callsSucceeded.total`
 | Counter | None
-| Number of calls allowed to run by the circuit breaker that returned successfully
+| Number of calls which were allowed to run and were considered a success by the circuit breaker
 
 |`ft.<name>.circuitbreaker.callsFailed.total`
 | Counter | None
-| Number of calls allowed to run by the circuit breaker that then failed
+| Number of calls which were allowed to run and were considered a failure by the circuit breaker
 
 |`ft.<name>.circuitbreaker.callsPrevented.total`
 | Counter | None
-| Number of calls prevented from running by an open circuit breaker
+| Number of calls which were prevented from running by the circuit breaker
 
 |`ft.<name>.circuitbreaker.open.total`
 | Gauge<Long> | Nanoseconds

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricBean.java
@@ -27,16 +27,19 @@ import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 @RequestScoped
 public class CircuitBreakerMetricBean {
 
-    public static enum Result {
+    public enum Result {
         PASS,
+        PASS_EXCEPTION,
         FAIL
     }
-    
-    @CircuitBreaker(requestVolumeThreshold = 2, failureRatio = 1.0D, delay = 1000, successThreshold = 2)
+
+    @CircuitBreaker(requestVolumeThreshold = 2, failureRatio = 1.0D, delay = 1000, successThreshold = 2, failOn = {TestException.class})
     public void doWork(Result result) {
         switch (result) {
         case PASS:
                 return;
+        case PASS_EXCEPTION:
+                throw new RuntimeException();
         case FAIL:
                 throw new TestException();
         default:

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricTest.java
@@ -18,6 +18,7 @@
  */
 package org.eclipse.microprofile.fault.tolerance.tck.metrics;
 
+import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expect;
 import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expectCbOpen;
 import static org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions.expectTestException;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -39,7 +40,7 @@ import org.testng.annotations.Test;
 
 public class CircuitBreakerMetricTest extends Arquillian {
     
-    private static final long CB_CLOSE_TIMEOUT = 5 * 1000 * 1_000_000;
+    private static final long CB_CLOSE_TIMEOUT = 5L * 1000 * 1_000_000;
 
     @Deployment
     public static WebArchive deploy() {
@@ -122,9 +123,17 @@ public class CircuitBreakerMetricTest extends Arquillian {
         assertThat("circuitbreaker calls failed", m.getCircuitBreakerCallsFailedDelta(), is(2L));
         assertThat("circuitbreaker calls prevented", m.getCircuitBreakerCallsPreventedDelta(), is(1L));
         assertThat("circuit breaker times opened", m.getCircuitBreakerOpenedDelta(), is(1L));
-        
+
+        // exception that is considered a success
+        expect(RuntimeException.class, () -> cbBean.doWork(Result.PASS_EXCEPTION));
+
+        assertThat("circuitbreaker calls succeeded", m.getCircuitBreakerCallsSucceededDelta(), is(3L));
+        assertThat("circuitbreaker calls failed", m.getCircuitBreakerCallsFailedDelta(), is(2L));
+        assertThat("circuitbreaker calls prevented", m.getCircuitBreakerCallsPreventedDelta(), is(1L));
+        assertThat("circuit breaker times opened", m.getCircuitBreakerOpenedDelta(), is(1L));
+
         // General metrics should be updated
-        assertThat("invocations", m.getInvocationsDelta(), is(5L));
-        assertThat("failed invocations", m.getInvocationsFailedDelta(), is(3L));
+        assertThat("invocations", m.getInvocationsDelta(), is(6L));
+        assertThat("failed invocations", m.getInvocationsFailedDelta(), is(4L));
     }
 }


### PR DESCRIPTION
Resolves #419

In case `@CircuitBreaker(failOn = {IllegalArgumentException.class})`
is defined and the guarded method throws e.g. `IllegalStateException`,
the circuit breaker treats it as success and therefore the
`circuitbreaker.callsSucceeded.total` metric needs to be incremented.

This commit adjusts the spec to make this clear, and also adds
a TCK test for this behavior.

Signed-off-by: Ladislav Thon <lthon@redhat.com>