### PR TITLE
Assume transparent Future implementation

### DIFF
--- a/spec/src/main/asciidoc/asynchronous.asciidoc
+++ b/spec/src/main/asciidoc/asynchronous.asciidoc
@@ -36,7 +36,7 @@ When a method annotated with `@Asynchronous` is invoked, it immediately returns 
 
 * Until the execution has finished, the `Future` or `CompletionStage` which was returned will be incomplete.
 * If the execution throws an exception, the `Future` or `CompletionStage` will be completed with that exception. (I.e. `Future.get()` will throw an `ExecutionException` which wraps the thrown exception and any functions passed to `CompletionStage.exceptionally()` will run.)
-* If the execution completes normally and returns a value, the `Future` or `CompletionStage` will then delegate to the returned value.
+* If the execution completes normally and returns a value, the `Future` or `CompletionStage` also completes normally providing the same value.
 
 [source, java]
 ----

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/BulkheadFutureTest.java
@@ -19,6 +19,11 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.bulkhead;
 
+import static org.junit.Assert.assertNotNull;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -50,7 +55,6 @@ import org.testng.annotations.Test;
 public class BulkheadFutureTest extends Arquillian {
 
     private static final int SHORT_TIME = 100;
-    private static final int LONG_TIME = 3000;
     @Inject
     private BulkheadMethodAsynchronousDefaultBean bhBeanMethodAsynchronousDefault;
     @Inject
@@ -87,19 +91,18 @@ public class BulkheadFutureTest extends Arquillian {
             result = bhBeanMethodAsynchronousDefault.test(fc);
         }
         catch (InterruptedException e1) {
-            Assert.fail("Unexpected interruption", e1);
+            fail("Unexpected interruption", e1);
         }
 
-        Assert.assertFalse(result.isDone(), "Future reporting Done when not");
+        assertFalse(result.isDone(), "Future reporting Done when not");
         try {
-            String r;
-            Assert.assertTrue("GET.".equals(r = result.get()), r);
-            Assert.assertTrue("GET.GET_TO.".equals(r = result.get(1, TimeUnit.SECONDS)), r);
+            assertNotNull(result.get());
+            assertNotNull(result.get(1, TimeUnit.SECONDS));
         }
-        catch (Throwable t) {
-            Assert.assertNull(t);
+        catch (Exception e) {
+            throw new AssertionError("Unexpected exception: ", e);
         }
-        Assert.assertTrue(result.isDone(), "Future done not reporting true");
+        assertTrue(result.isDone(), "Future done not reporting true");
     }
 
     /**
@@ -116,10 +119,10 @@ public class BulkheadFutureTest extends Arquillian {
             result = bhBeanMethodAsynchronousDefault.test(fc);
         }
         catch (InterruptedException e1) {
-            Assert.fail("Unexpected interruption", e1);
+            fail("Unexpected interruption", e1);
         }
 
-        Assert.assertFalse(result.isDone(), "Future reporting Done when not");
+        assertFalse(result.isDone(), "Future reporting Done when not");
         try {
             Thread.sleep(SHORT_TIME + SHORT_TIME);
             // Usually, we will not enter the loop, 
@@ -129,10 +132,10 @@ public class BulkheadFutureTest extends Arquillian {
                 Thread.sleep(SHORT_TIME);
             }
         }
-        catch (Throwable t) {
-            Assert.assertNull(t);
+        catch (Exception e) {
+            throw new AssertionError("Unexpected exception: ", e);
         }
-        Assert.assertTrue(result.isDone(), "Future done not reporting true");
+        assertTrue(result.isDone(), "Future done not reporting true");
     }
   
     /**
@@ -151,18 +154,17 @@ public class BulkheadFutureTest extends Arquillian {
             result = bhBeanClassAsynchronousDefault.test(fc);
         }
         catch (InterruptedException e1) {
-            Assert.fail("Unexpected interruption", e1);
+            fail("Unexpected interruption", e1);
         }
 
-        Assert.assertFalse(result.isDone(), "Future reporting Done when not");
+        assertFalse(result.isDone(), "Future reporting Done when not");
         try {
-            String r;
-            Assert.assertTrue("GET_TO.".equals(r = result.get(1, TimeUnit.SECONDS)), r);
-            Assert.assertTrue("GET_TO.GET.".equals(r = result.get()), r);
+            assertNotNull(result.get(1, TimeUnit.SECONDS));
+            assertNotNull(result.get());
 
         }
-        catch (Throwable t) {
-            Assert.assertNull(t);
+        catch (Exception e) {
+            throw new AssertionError("Unexpected exception: ", e);
         }
         Assert.assertTrue(result.isDone(), "Future done not reporting true");
     }
@@ -181,9 +183,9 @@ public class BulkheadFutureTest extends Arquillian {
             result = bhBeanMethodAsynchronousDefault.test(fc);
         }
         catch (InterruptedException e1) {
-            Assert.fail("Unexpected interruption", e1);
+            fail("Unexpected interruption", e1);
         }
-        Assert.assertFalse(result.isDone(), "Future reporting Done when not");
+        assertFalse(result.isDone(), "Future reporting Done when not");
         try {
             Thread.sleep(SHORT_TIME + SHORT_TIME);
             // Usually, we will not enter the loop, 
@@ -193,10 +195,10 @@ public class BulkheadFutureTest extends Arquillian {
                 Thread.sleep(SHORT_TIME);
             }
         }
-        catch (Throwable t) {
-            Assert.assertNull(t);
+        catch (Exception e) {
+            throw new AssertionError("Unexpected exception: ", e);
         }
-        Assert.assertTrue(result.isDone(), "Future done not reporting true");
+        assertTrue(result.isDone(), "Future done not reporting true");
     }
 
 }


### PR DESCRIPTION
In the spec section on _Asynchronous Usage_ it is stated that the returned `Future` or `CompletionStage` should _delegate_ to the result obtained asynchronously from the annotated method. 

I think this is a overly specific demand on the actual implementation that defies the purpose of abstraction.  The caller should only care about semantically correct behaviour. 

In this particular tests it was assumed that `Future.get()` and `Future.get(long, TimeUnit)` have different results. While it is possible to implement a `Future` like this it is semantically incorrect to do so and an implementation should not be limited by such an assumption. In the same way we need to make sure that `a.equals(b)` is consistent with `b.equals(a)` it should also be true that `future.get(Long.MAX_VALUE, TimeUnit.DAYS)` is practically the same as and consistent with `future.get()`. Given that being true there are other ways than delegation that provide the caller with a `Future` that makes the value available as soon as it is computed. Which way is chosen should be transparent.

The suggested change to the spec is only provided as a basis for improvement and for lack of a better phrasing. I think the overall passage on _execution_ is unclear to the extend that it does not make clear if execution or computation means computation of the methods result or the value of the results future.
Some sentences only make sense when applied to the lazily computed value, others seem to refer to the `Future` wrapper as a vehicle of computation. 

Instead of asserting a particular result the tests now only assert a non-null result which is plenty good for the purpose of the test as indicated by their names.

In the PR I also changed the catch blocks to not catch `Throwable` as this would also catch the `AssertionError` thrown within the try block what makes the provided error message less helpful than it could be.