### PR TITLE
Adding more retry tests to see how is working whitelist and blacklist together in the same annotation

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientRetryOn.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientRetryOn.java
@@ -24,6 +24,8 @@ import java.sql.Connection;
 
 import javax.enterprise.context.RequestScoped;
 
+import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.exceptions.RetryChildException;
+import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.exceptions.RetryParentException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 /**
  * A client to demonstrate the retryOn conditions
@@ -43,7 +45,29 @@ public class RetryClientRetryOn {
         counterForInvokingConnenectionService++;
         throw new RuntimeException("Connection failed");
     }
-    
+
+    /**
+     * Service that throws a child custom exception but in the retry on list is configured child's parent custom exception
+     * @return Connection
+     */
+    @Retry(retryOn = {RetryParentException.class})
+    public Connection serviceC() {
+        counterForInvokingConnenectionService++;
+        throw new RetryChildException("Connection failed");
+    }
+
+    /**
+     * Service that throws a child custom exception but in the retry on list is configured child's parent custom exception
+     * and is configured in the abort on list the child custom exception
+     * @return Connection
+     */
+    @Retry(retryOn = {RetryParentException.class}, abortOn = {RetryChildException.class})
+    public Connection serviceD() {
+        counterForInvokingConnenectionService++;
+        throw new RetryChildException("Connection failed");
+    }
+
+
     public int getRetryCountForConnectionService() {
         return counterForInvokingConnenectionService;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/exceptions/RetryChildException.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/exceptions/RetryChildException.java
@@ -1,0 +1,27 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.exceptions;
+
+public class RetryChildException extends RetryParentException {
+
+    public RetryChildException(String message) {
+        super(message);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/exceptions/RetryParentException.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/exceptions/RetryParentException.java
@@ -1,0 +1,27 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.exceptions;
+
+public class RetryParentException extends RuntimeException {
+
+    public RetryParentException (String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
configured 2 lists of exceptions retryOn(whitelist)
and abortOn(blacklist) in the same annotation in this case retry
https://github.com/eclipse/microprofile-fault-tolerance/issues/418

Signed-off-by: Carlos Andres De La Rosa <kusanagi12002@gmail.com>