### PR TITLE
Add a clarifying note on running retries on the same thread

### DIFF
--- a/spec/src/main/asciidoc/retry.asciidoc
+++ b/spec/src/main/asciidoc/retry.asciidoc
@@ -86,4 +86,4 @@ The `@Retry` annotation can be used together with `@Fallback`, `@CircuitBreaker`
 
 A `@Fallback` can be specified and it will be invoked if the method still fails after any retires have been run.
 
-If `@Retry` is used with `@Asynchronous` and a retry is required, the new retry attempt may be run on the same thread as the previous attempt, or on a different thread.
+If `@Retry` is used with `@Asynchronous` and a retry is required, the new retry attempt may be run on the same thread as the previous attempt, or on a different thread. (However, note that if `@Retry` is used with `@Timeout` and `@Asynchronous`, it's required to run retries caused by a `TimeoutException` on a different thread. See <<timeout-usage>>.) 

--- a/spec/src/main/asciidoc/retry.asciidoc
+++ b/spec/src/main/asciidoc/retry.asciidoc
@@ -86,4 +86,4 @@ The `@Retry` annotation can be used together with `@Fallback`, `@CircuitBreaker`
 
 A `@Fallback` can be specified and it will be invoked if the method still fails after any retires have been run.
 
-If `@Retry` is used with `@Asynchronous` and a retry is required, the new retry attempt may be run on the same thread as the previous attempt, or on a different thread. (However, note that if `@Retry` is used with `@Timeout` and `@Asynchronous`, it's required to run retries caused by a `TimeoutException` on a different thread. See <<timeout-usage>>.) 
+If `@Retry` is used with `@Asynchronous` and a retry is required, the new retry attempt may be run on the same thread as the previous attempt, or on a different thread. (However, note that if `@Retry` is used with `@Timeout` and `@Asynchronous`, and a `TimeoutException` results in a new retry attempt, the new retry attempt must start after the configured delay period, even if the previous retry attempt has not finished. See <<timeout-usage>>.)

--- a/spec/src/main/asciidoc/timeout.asciidoc
+++ b/spec/src/main/asciidoc/timeout.asciidoc
@@ -56,7 +56,6 @@ In the above situations, it is impossible to suspend the execution. The executio
 
 If a timeout occurs, the thread interrupted status must be cleared when the method returns.
 
-[[timeout-async]]
 If `@Timeout` is used with `@Asynchronous`, then a separate thread will be spawned to perform the work in the annotated method or methods, while a `Future` or `CompletionStage` is returned on the main thread. If the work on the spawned thread does time out, then a get() call to the `Future` on the main thread will throw an `ExecutionException` that wraps a fault tolerance `TimeoutException`.
 
 If `@Timeout` is used with `@Fallback` then the fallback method or handler will be invoked if a `TimeoutException` is thrown (unless the exception is handled by another fault tolerance component).

--- a/spec/src/main/asciidoc/timeout.asciidoc
+++ b/spec/src/main/asciidoc/timeout.asciidoc
@@ -24,6 +24,7 @@
 `Timeout` prevents from the execution from waiting forever.
 It is recommended that a microservice invocation should have timeout associated with.
 
+[[timeout-usage]]
 === Timeout Usage
 
 A method or a class can be annotated with `@Timeout`, which means the method or the methods under the class will have Timeout policy applied.
@@ -55,6 +56,7 @@ In the above situations, it is impossible to suspend the execution. The executio
 
 If a timeout occurs, the thread interrupted status must be cleared when the method returns.
 
+[[timeout-async]]
 If `@Timeout` is used with `@Asynchronous`, then a separate thread will be spawned to perform the work in the annotated method or methods, while a `Future` or `CompletionStage` is returned on the main thread. If the work on the spawned thread does time out, then a get() call to the `Future` on the main thread will throw an `ExecutionException` that wraps a fault tolerance `TimeoutException`.
 
 If `@Timeout` is used with `@Fallback` then the fallback method or handler will be invoked if a `TimeoutException` is thrown (unless the exception is handled by another fault tolerance component).


### PR DESCRIPTION
Avoid giving the impression that running retries on the same thread is
valid in all cases.

Fixes #424