### PR TITLE
Necessary changes to allows build the spec's projects with java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>microprofile-fault-tolerance-parent</artifactId>
     <version>2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
-    
+
     <name>MicroProfile Fault Tolerance</name>
     <description>Eclipse MicroProfile Fault Tolerance Feature :: Parent POM</description>
 
@@ -28,8 +28,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
         <checkstyle.version>2.17</checkstyle.version>
         <!-- whether autorelease maven central staging repositories - default true to allow review and manually release repositories -->
@@ -104,7 +104,7 @@
         </dependencies>
     </dependencyManagement>
 
-   
+
     <build>
         <pluginManagement>
             <plugins>
@@ -142,7 +142,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -203,7 +203,7 @@
 
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
 
         <checkstyle.version>2.17</checkstyle.version>
         <!-- whether autorelease maven central staging repositories - default true to allow review and manually release repositories -->
@@ -142,7 +142,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>2.10.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -254,6 +254,46 @@
                                 <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>java11-compilation</id>
+            <properties>
+                <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
+                <checkstyle.version>2.17</checkstyle.version>
+                <autorelease>false</autorelease>
+                <keepStagingReposOnFailure>false</keepStagingReposOnFailure>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.1.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
compilation process successful with openjdk version "11.0.4" 2019-07-16
issue: https://github.com/eclipse/microprofile-fault-tolerance/issues/423

Signed-off-by: Carlos Andres De La Rosa <kusanagi12002@gmail.com>