### PR TITLE
Add skipOn to CircuitBreaker

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/package-info.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2016-2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2016-2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,6 +25,6 @@
  *
  * @author <a href="mailto:emijiang@uk.ibm.com">Emily Jiang</a>
  */
-@org.osgi.annotation.versioning.Version("1.1")
+@org.osgi.annotation.versioning.Version("1.2")
 package org.eclipse.microprofile.faulttolerance;
 

--- a/spec/src/main/asciidoc/circuitbreaker.asciidoc
+++ b/spec/src/main/asciidoc/circuitbreaker.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2016-2019 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -38,7 +38,16 @@ succeed before the circuit can be closed. After the specified number of successf
 before the successThreshold is reached the circuit will transition to open. 
 
 Note that circuit state transitions will reset the Circuit Breaker's records. For example, when the circuit transitions to closed a new
-rolling failure window is created with the configured requestVolumeThreshold and failureRatio. The circuit state will only be assessed when the rolling window reaches the `requestVolumeThreshold`. 
+rolling failure window is created with the configured requestVolumeThreshold and failureRatio. The circuit state will only be assessed when the rolling window reaches the `requestVolumeThreshold`.
+
+When a method returns a result, the following rules are applied to determine whether the result is a success or a failure:
+
+* If the method does not throw a `Throwable`, it is considered a success
+* Otherwise, if the thrown object is assignable to any value in the `skipOn` parameter, is is considered a success
+* Otherwise, if the thrown object is assignable to any value in the `failOn` parameter, it is considered a failure
+* Otherwise it is considered a success
+
+If a method throws a `Throwable` which is not a subclass of either `Error` or `Exception`, non-portable behavior results.
  
 [source, java]
 ----


### PR DESCRIPTION
Add the `skipOn` parameter to Circuit Breaker

Update the spec and javadoc to specify the meaning of `skipOn` and how `failOn` and `skipOn` interact.

We still need TCKs for this. I'll likely base them on @Ladicek's tests in #440.

For #418