### PR TITLE
specify the meaning of overlapping retryOn and abortOn

### DIFF
--- a/spec/src/main/asciidoc/retry.asciidoc
+++ b/spec/src/main/asciidoc/retry.asciidoc
@@ -1,7 +1,8 @@
 //
-// Copyright (c) 2016-2018 Eclipse Microprofile Contributors:
+// Copyright (c) 2016-2019 Eclipse Microprofile Contributors:
 // Emily Jiang
 // Andrew Rouse
+// Ladislav Thon
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +39,29 @@ The `Retry` policy allows to configure :
 If applied to a class, it means the all methods in the class will have the `@Retry` policy applied.
 If applied to a method, it means  that method will have `@Retry` policy applied.
 If the `@Retry` policy applied on a class level and on a method level within that class, the method level `@Retry` will override the class-level `@Retry` policy for that particular method.
+
+When a method returns and the retry policy is present, the following rules are applied:
+
+* If the method returns normally (doesn't throw), the result is simply returned.
+* Otherwise, if the thrown object is assignable to any value in the `abortOn` parameter, the thrown object is rethrown.
+* Otherwise, if the thrown object is assignable to any value in the `retryOn` parameter, the method call is retried.
+* Otherwise the thrown object is rethrown.
+
+For example, to retry on all exceptions except for IO exceptions, one would write:
+
+[source,java]
+----
+    /**
+     * In case the underlying service throws an exception, it will be retried,
+     * unless the thrown exception was an IO exception.
+     */
+    @Retry(retryOn = Exception.class, abortOn = IOException.class)
+    public void service() {
+        underlyingService();
+    }
+----
+
+If a method throws a `Throwable` which is not an `Error` or `Exception`, non-portable behavior results.
 
 [source, java]
 ----


### PR DESCRIPTION
This is already specified in the `@Retry` javadoc. This commit
adds the same wording to the specification text.

Signed-off-by: Ladislav Thon <lthon@redhat.com>