### PR TITLE
Add scope to beans to allow tests to pass in environments with implic…

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/beans/FallbackMethodGenericAbstractBeanA.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/beans/FallbackMethodGenericAbstractBeanA.java
@@ -20,6 +20,9 @@
 
 package org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.beans;
 
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
 public class FallbackMethodGenericAbstractBeanA extends FallbackMethodGenericAbstractBeanB<Long> {
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/beans/FallbackMethodSubclassBeanB.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallbackmethod/beans/FallbackMethodSubclassBeanB.java
@@ -22,11 +22,15 @@ package org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.beans;
 
 import org.eclipse.microprofile.faulttolerance.Fallback;
 
+import javax.enterprise.inject.Vetoed;
+
+// bean is vetoed to avoid accidentally picking it up and execution validation
+@Vetoed
 public class FallbackMethodSubclassBeanB {
 
     @Fallback(fallbackMethod = "fallback")
     public String method(int a, Long b) {
         throw new RuntimeException("test");
     }
-    
+
 }


### PR DESCRIPTION
…it bean archives.

I came across this while trying to run FT tests in Quarkus.

Functionally this doesn't change anything. It merely makes the relevant tests pass in a CDI environment that operates on [implicit bean archive](https://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#bean_archive). In the current master, these classes are automatically picked as beans anyway, the PR only adds a bean defining annotation on them.

There might be more tests needing similar changes but so far I've only seen these.