### PR TITLE
IncompatibleFallbackPolicies should @Inject FallbackClientWithBothFal…

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackPolicies.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/illegalConfig/IncompatibleFallbackPolicies.java
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
 public class IncompatibleFallbackPolicies extends Arquillian {
     private
     @Inject
-    FallbackClient fallbackClient;
+    FallbackClientWithBothFallbacks fallbackClient;
 
     @Deployment
     @ShouldThrowException(value = FaultToleranceDefinitionException.class)


### PR DESCRIPTION
…lbacks.

I think the test is wrong in trying to inject `FallbackClient` but to the `@Deployment` it adds `FallbackClientWithBothFallbacks` instead. Changing it like i did in this PR gave me the correct exception.