### PR TITLE
Make CircuitBreakerClientWithSyncBulkhead Dependent

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithSyncBulkhead.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithSyncBulkhead.java
@@ -21,19 +21,19 @@ package org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver
 
 import java.util.concurrent.Future;
 
+import javax.enterprise.context.Dependent;
+
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BackendTestDelegate;
 import org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver.BulkheadTestBackend;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
-
-import javax.enterprise.context.RequestScoped;
 
 /**
  * Client bean with CircuitBreaker and Bulkhead
  */
 @CircuitBreaker(requestVolumeThreshold = 3, failureRatio = 1.0)
 @Bulkhead(value = 1, waitingTaskQueue = 1)
-@RequestScoped
+@Dependent
 public class CircuitBreakerClientWithSyncBulkhead implements BulkheadTestBackend {
 
     public Future test(BackendTestDelegate action) throws InterruptedException {


### PR DESCRIPTION
This bean is called asynchronously and there's no requirement for the
request scope to be active on an async thread.

Signed-off-by: Andrew Rouse <anrouse@uk.ibm.com>