### PR TITLE
Further timeout configuration improvements

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ConfigTest.java
@@ -141,7 +141,7 @@ public class ConfigTest extends Arquillian {
      * Test the configuration of maxDuration on a specific method. 
      * 
      * The serviceA is annotated with maxDuration=3000 but a configuration property overrides it with a value of 1000,
-     * so serviceA should be executed less than 11 times.
+     * so serviceA should be executed 11 or less times.
      * 
      * The test assumes that the container has been configured with the property,
      * org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClient/serviceC/Retry/maxDuration=1000
@@ -157,16 +157,17 @@ public class ConfigTest extends Arquillian {
         }
 
         //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms, 
-        //the max invocation should be less than 10
+        //the max invocation should be 11 or less
+        //(minimum time for 10 invocations is 1000ms, that leaves the possibility of starting the 11th invocation just as we hit the maxDuration)
         int count = clientForConfig.getRetryCountForWritingService();
-        Assert.assertTrue(count< 11, "The max retry counter should be less than 11");
+        Assert.assertTrue(count <= 11, "The max retry counter should be 11 or less");
     }
 
     /**
      * Test the configuration of maxDuration on a class. 
      * 
      * The class is annotated with maxDuration=3000 but a configuration property overrides it with a value of 1000
-     * so serviceA should be executed less than 11 times.
+     * so serviceA should be executed 11 or less times.
      * 
      * The test assumes that the container has been configured with the property,
      * org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClassLevelMaxDurationClient/Retry/maxDuration=1000
@@ -182,8 +183,9 @@ public class ConfigTest extends Arquillian {
         }
 
         //The writing service invocation takes 100ms plus a jitter of 0-200ms with the max duration of 1000ms, 
-        //the max invocation should be less than 10
-        int retryCountforWritingService = clientForClassLevelMaxDurationConfig.getRetryCountForWritingService();        
-        Assert.assertTrue(retryCountforWritingService< 11, "The max retry counter should be less than 11");
+        //the max invocation should be 11 or less
+        //(minimum time for 10 invocations is 1000ms, that leaves the possibility of starting the 11th invocation just as we hit the maxDuration)
+        int retryCountforWritingService = clientForClassLevelMaxDurationConfig.getRetryCountForWritingService();
+        Assert.assertTrue(retryCountforWritingService <= 11, "The max retry counter should be 11 or less");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
@@ -157,9 +157,6 @@ public class RetryTest extends Arquillian {
         Assert.assertTrue(retryCountForConnectionService > 8 && retryCountForConnectionService < 100,
             "The max number of execution should be between 8 and 100 but it was " + retryCountForConnectionService +
                 ". Too many retries mean jitter is not being applied.");
-
-        Assert.assertTrue(retryClientWithNoDelayAndJitter.isDelayInRange(),
-            "The delay between each retry should be 0-400ms");
     }
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutTest.java
@@ -21,23 +21,18 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotationAsset;
 import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.DefaultTimeoutClient;
 import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.ShorterTimeoutClient;
 import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.TimeoutClient;
-import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import static org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig.getConfig;
 
 /**
  * Tests to exercise Fault Tolerance Timeouts.
@@ -53,12 +48,6 @@ public class TimeoutTest extends Arquillian {
 
     @Deployment
     public static WebArchive deploy() {
-        final Asset config = new ConfigAnnotationAsset()
-            .setValue(TimeoutClient.class,"serviceA", Timeout.class, getConfig().getTimeoutInStr(1000))
-            .setValue(TimeoutClient.class,"serviceB", Timeout.class, getConfig().getTimeoutInStr(2000))
-            .setValue(TimeoutClient.class,"serviceC", Timeout.class, getConfig().getTimeoutInStr(500));
-        // serviceD uses SECONDS time unit and will not be configured
-
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftTimeout.jar")
                 .addClasses(TimeoutClient.class, DefaultTimeoutClient.class, ShorterTimeoutClient.class)
@@ -199,7 +188,7 @@ public class TimeoutTest extends Arquillian {
     @Test
     public void testSecondsTimeout() {
         try {
-            clientForTimeout.serviceD(2500);// timeout will not be dynamically configured
+            clientForTimeout.serviceD(2500);
             Assert.fail("serviceD should throw a TimeoutException in testSecondsTimeout");
         } 
         catch (TimeoutException ex) {
@@ -221,7 +210,7 @@ public class TimeoutTest extends Arquillian {
     @Test
     public void testSecondsNoTimeout() {
         try {
-            clientForTimeout.serviceD(1500);// timeout will not be dynamically configured
+            clientForTimeout.serviceD(1500);
             Assert.fail("serviceD should throw a RuntimeException in testSecondsNoTimeout");
         } 
         catch (TimeoutException ex) {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/clientserver/ConfigClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/clientserver/ConfigClient.java
@@ -37,13 +37,6 @@ public class ConfigClient {
 
     @Retry(maxRetries = 5)
     public Connection serviceA() {
-        try {
-            Thread.sleep(100);
-        }
-        catch (InterruptedException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        }
         return connectionService();
     }
     
@@ -56,7 +49,8 @@ public class ConfigClient {
     @Retry(maxRetries = 90, maxDuration= 3000)
     public void serviceC() {
         writingService();
-    }    
+    }
+    
     private Connection connectionService() {
         counterForInvokingConnenectionService++;
         throw new RuntimeException("Connection failed");

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/TimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/TimeoutClient.java
@@ -87,8 +87,8 @@ public class TimeoutClient {
     
     /**
      * serviceD specifies a Timeout longer than the default, at 2 
-     * seconds.<br>
-     * Tests using this method will not have the timeout dynamically configured.
+     * seconds.
+     * 
      * @param timeToSleepInMillis  How long should the execution take in millis
      * @return null or exception is raised
      */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/UninterruptableTimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/UninterruptableTimeoutClient.java
@@ -54,7 +54,7 @@ public class UninterruptableTimeoutClient {
      * @param waitMs the time to wait
      */
     @Timeout(value = 500, unit = ChronoUnit.MILLIS)
-    public void serviceTimeout(int waitMs) {
+    public void serviceTimeout(long waitMs) {
         long waitNs = Duration.ofMillis(waitMs).toNanos();
         long startTime = System.nanoTime();
         


### PR DESCRIPTION
* Remove inactive config code from `TimeoutTest`
* Corrections in `ConfigTest`
* Add configuration to TimeoutInterruptableTest`
* relax timing checks in `testRetryWithNoDelayAndJitter`