### PR TITLE
Specify behaviour of Async Bulkhead with CompletionStage

### DIFF
--- a/spec/src/main/asciidoc/asynchronous.asciidoc
+++ b/spec/src/main/asciidoc/asynchronous.asciidoc
@@ -80,7 +80,17 @@ If the method returns `CompletionStage`, the other specified Fault Tolerance ann
 
 * If the method invocation throws an exception, this will trigger other specified Fault Tolerance policies to be applied.
 
-* If the method returns a `CompletionStage`, then the method call is considered to be successful only if the `CompletionStage` completes successfully. If an exceptionally completed `CompletionStage` is returned, or if an incomplete `CompletionStage` is returned which later completes exceptionally, then this will cause other specified Fault Tolerance policies to be applied.
+* If the method returns a `CompletionStage`, then the method call is not considered to have completed until the returned `CompletionStage` completes.
+  ** The method is considered to be successful only if the `CompletionStage` completes successfully.
+  ** If an exceptionally completed `CompletionStage` is returned, or if an incomplete `CompletionStage` is returned which later completes exceptionally, then this will cause other specified Fault Tolerance policies to be applied.
+
+[TIP]
+====
+As a consequence of these rules:
+
+* `@Timeout` does not consider the method to have completed until the returned `CompletionStage` completes
+* `@Bulkhead` considers the method to still be running until the returned `CompletionStage` completes.
+====
 
 In the following example, the `Retry` will be triggered as the returned `CompletionStage` completes exceptionally.
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadCompletionStageBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadCompletionStageBean.java
@@ -1,0 +1,47 @@
+/*
+ *******************************************************************************
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+
+package org.eclipse.microprofile.fault.tolerance.tck.bulkhead.clientserver;
+
+import java.util.concurrent.CompletionStage;
+
+import org.eclipse.microprofile.faulttolerance.Asynchronous;
+import org.eclipse.microprofile.faulttolerance.Bulkhead;
+
+public class BulkheadCompletionStageBean {
+    
+    /**
+     * Returns {@code stage} as the result
+     * <p>
+     * Allows two concurrent executions and two queued.
+     * <p>
+     * As this is an async method, it won't be considered "complete" by Fault Tolerance
+     * until {@code stage} completes.
+     * 
+     * @param stage the CompletionStage to return as the result
+     * @return {@code stage}
+     */
+    @Asynchronous
+    @Bulkhead(value = 2, waitingTaskQueue = 2)
+    public CompletionStage<Void> serviceCS(CompletionStage<Void> stage) {
+        return stage;
+    }
+
+}


### PR DESCRIPTION
Update the spec to make clear that the Bulkhead doesn't consider the method to be complete until the returned completion stage completes.

Add TCK tests to assert this.

Fixes #484 