### PR TITLE
fix the timeout metrics test

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
@@ -66,7 +66,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
 
     @Deployment
     public static WebArchive deploy() {
-        
+
         ConfigAnnotationAsset config = new ConfigAnnotationAsset()
                 .autoscaleMethod(CircuitBreakerClientWithRetry.class, "serviceC")
                 .autoscaleMethod(CircuitBreakerClientWithRetry.class, "serviceWithRetryOnCbOpen")
@@ -76,14 +76,14 @@ public class CircuitBreakerRetryTest extends Arquillian {
                 .autoscaleMethod(CircuitBreakerClientWithRetryAsync.class, "serviceWithRetryOnCbOpen")
                 .autoscaleMethod(CircuitBreakerClientWithRetryAsync.class, "serviceWithRetryOnTimeout")
                 .autoscaleMethod(CircuitBreakerClientWithRetryAsync.class, "serviceWithRetryFailOnCbOpen");
-        
+
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftCircuitBreakerRetry.jar")
                         .addClasses(CircuitBreakerClientWithRetry.class,
                                     CircuitBreakerClassLevelClientWithRetry.class,
                                     CircuitBreakerClientWithRetryAsync.class)
                         .addPackage(Packages.UTILS)
                         .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                        .addAsResource(config, "META-INF/microprofile-config.properties")
+                        .addAsManifestResource(config, "microprofile-config.properties")
                         .as(JavaArchive.class);
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftCircuitBreakerRetry.war")
@@ -262,7 +262,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
 
         }
         catch (CircuitBreakerOpenException cboe) {
-            // Expected on iteration 4          
+            // Expected on iteration 4
             invokeCounter = clientForCBWithRetry.getCounterForInvokingServiceC();
             if (invokeCounter < 4) {
                 Assert.fail("serviceC should retry in testCircuitOpenWithMultiTimeouts on iteration "
@@ -481,7 +481,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
                                      executionException.getCause(),
                                      instanceOf(CircuitBreakerOpenException.class));
 
-            // Expected on iteration 4          
+            // Expected on iteration 4
             invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceC();
             if (invokeCounter < 4) {
                 Assert.fail("serviceC should retry in testCircuitOpenWithMultiTimeouts on iteration "

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/TimeoutMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/TimeoutMetricTest.java
@@ -41,6 +41,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -52,49 +53,52 @@ public class TimeoutMetricTest extends Arquillian {
             .setValue(TimeoutMetricBean.class,"counterTestWorkForMillis", Timeout.class,getConfig().getTimeoutInStr(500))
             .setValue(TimeoutMetricBean.class,"histogramTestWorkForMillis", Timeout.class,getConfig().getTimeoutInStr(2000));
 
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricTimeout.war")
-                .addClasses(TimeoutMetricBean.class)
-                .addPackage(Packages.UTILS)
-                .addPackage(Packages.METRIC_UTILS)
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ftMetricTimeout.jar")
+            .addClasses(TimeoutMetricBean.class)
+            .addPackage(Packages.UTILS)
+            .addPackage(Packages.METRIC_UTILS)
             .addAsManifestResource(config, "microprofile-config.properties")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricTimeout.war")
+            .addAsLibrary(jar);
         return war;
     }
-    
+
     @Inject
     private TimeoutMetricBean timeoutBean;
-    
+
     @Test
     public void testTimeoutMetric() {
         MetricGetter m = new MetricGetter(TimeoutMetricBean.class, "counterTestWorkForMillis");
         m.baselineCounters();
-        
+
         expectTimeout(() -> timeoutBean.counterTestWorkForMillis(getConfig().getTimeoutInMillis(2000))); // Should timeout
         expectTimeout(() -> timeoutBean.counterTestWorkForMillis(getConfig().getTimeoutInMillis(2000))); // Should timeout
         timeoutBean.counterTestWorkForMillis(getConfig().getTimeoutInMillis(100)); // Should not timeout
-        
+
         assertThat("calls timed out", m.getTimeoutCallsTimedOutDelta(), is(2L));
         assertThat("calls not timed out", m.getTimeoutCallsNotTimedOutDelta(), is(1L));
-        
+
         assertThat("invocations", m.getInvocationsDelta(), is(3L));
         assertThat("failed invocations", m.getInvocationsFailedDelta(), is(2L));
     }
-    
+
     @Test
     @SuppressWarnings("unchecked")
     public void testTimeoutHistogram() {
         MetricGetter m = new MetricGetter(TimeoutMetricBean.class, "histogramTestWorkForMillis");
-        
+
         timeoutBean.histogramTestWorkForMillis(getConfig().getTimeoutInMillis(300));
         expectTimeout(() -> timeoutBean.histogramTestWorkForMillis(getConfig().getTimeoutInMillis(5000))); // Will timeout after 2000
-        
+
         Histogram histogram = m.getTimeoutExecutionDuration().get();
         Snapshot snapshot = histogram.getSnapshot();
         List<Long> values = Arrays.stream(snapshot.getValues()).boxed().sorted().collect(toList());
-        
+
         assertThat("Histogram count", histogram.getCount(), is(2L));
         assertThat("SnapshotValues", values, contains(MetricComparator.approxMillis(300),
                                                       MetricComparator.approxMillis(2000)));
     }
-    
+
 }


### PR DESCRIPTION
When the `microprofile-config.properties` file, generated by
`ConfigAnnotationAsset`, is put into `META-INF`, the archive
needs to be a JAR. That JAR can then be put into a WAR.
All tests that use `ConfigAnnotationAsset` follow this pattern,
except `TimeoutMetricTest`, where the file is put directly
into the WAR. From there, it can't be read, as `META-INF`
inside a WAR is not on classpath.

This commit fixes `TimeoutMetricTest` to follow the same
pattern: put everything into a JAR, and that JAR into a WAR.

Signed-off-by: Ladislav Thon <lthon@redhat.com>

Resolves #496.