### PR TITLE
Use separate methods in CircuitBreakerExceptionHierarchyTest

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerExceptionHierarchyTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerExceptionHierarchyTest.java
@@ -240,18 +240,18 @@ public class CircuitBreakerExceptionHierarchyTest extends Arquillian {
         assertEquals(invoke(service::serviceC9, new Error()), CircuitState.CLOSED);
     }
 
-    private CircuitState invoke(ServiceInvocation invocation, Throwable exception) {
+    private CircuitState invoke(ServiceMethod method, Throwable exception) {
         try {
-            invocation.invoke(exception);
-            throw new AssertionError("Exception not thrown from serviceC");
+            method.invoke(exception);
+            throw new AssertionError("Exception not thrown from service method");
         }
         catch (Throwable ex) {
             assertEquals(ex, exception);
         }
         
         try {
-            invocation.invoke(exception);
-            throw new AssertionError("Exception not thrown from serviceC");
+            method.invoke(exception);
+            throw new AssertionError("Exception not thrown from service method");
         }
         catch (CircuitBreakerOpenException ex) {
             return CircuitState.OPEN;
@@ -263,7 +263,7 @@ public class CircuitBreakerExceptionHierarchyTest extends Arquillian {
     }
     
     @FunctionalInterface
-    private static interface ServiceInvocation {
+    private static interface ServiceMethod {
         void invoke(Throwable t) throws Throwable;
     }
     

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerExceptionHierarchyTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerExceptionHierarchyTest.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,7 +22,6 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 
 import static org.testng.Assert.assertEquals;
 
-import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.exception.hierarchy.CircuitBreakerService;
@@ -39,8 +38,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -63,24 +60,8 @@ public class CircuitBreakerExceptionHierarchyTest extends Arquillian {
     }
 
     @Inject
-    private Instance<CircuitBreakerService> serviceInstance;
-    
     private CircuitBreakerService service;
     
-    @BeforeMethod
-    public void setup() {
-        if (serviceInstance != null) {
-            service = serviceInstance.get();
-        }
-    }
-    
-    @AfterMethod
-    public void teardown() {
-        if (serviceInstance != null) {
-            serviceInstance.destroy(service);
-        }
-    }
-
     // the <: symbol denotes the subtyping relation (Foo <: Bar means "Foo is a subtype of Bar")
     // note that subtyping is reflexive (Foo <: Foo)
 
@@ -96,77 +77,55 @@ public class CircuitBreakerExceptionHierarchyTest extends Arquillian {
     @Test
     public void serviceAthrowsException() {
         // serviceA doesn't mention Exception (nor any of its superclasses) neither in failOn nor skipOn
-        assertEquals(invokeServiceA(new Exception()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceA1, new Exception()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceAthrowsE0() {
         // serviceA directly mentions E0 in failOn
-        assertEquals(invokeServiceA(new E0()), CircuitState.OPEN);
+        assertEquals(invoke(service::serviceA2, new E0()), CircuitState.OPEN);
     }
 
     @Test
     public void serviceAthrowsE1() {
         // serviceA directly mentions E1 in skipOn
-        assertEquals(invokeServiceA(new E1()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceA3, new E1()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceAthrowsE2() {
         // serviceA directly mentions E2 in failOn, but it also mentions E1 in skipOn and E2 <: E1
-        assertEquals(invokeServiceA(new E2()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceA4, new E2()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceAthrowsE2S() {
         // serviceA mentions E2 in failOn and E2S <: E2, but it also mentions E1 in skipOn and E2S <: E1
-        assertEquals(invokeServiceA(new E2S()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceA5, new E2S()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceAthrowsE1S() {
         // serviceA mentions E1 in skipOn and E1S <: E1
-        assertEquals(invokeServiceA(new E1S()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceA6, new E1S()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceAthrowsE0S() {
         // serviceA mentions E0 in failOn and E0S <: E0
-        assertEquals(invokeServiceA(new E0S()), CircuitState.OPEN);
+        assertEquals(invoke(service::serviceA7, new E0S()), CircuitState.OPEN);
     }
 
     @Test
     public void serviceAthrowsRuntimeException() {
         // serviceA doesn't mention RuntimeException (nor any of its superclasses) neither in failOn nor skipOn
-        assertEquals(invokeServiceA(new RuntimeException()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceA8, new RuntimeException()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceAthrowsError() {
         // serviceA doesn't mention Error (nor any of its superclasses) neither in failOn nor skipOn
-        assertEquals(invokeServiceA(new Error()), CircuitState.CLOSED);
-    }
-
-    private CircuitState invokeServiceA(Throwable exception) {
-        try {
-            service.serviceA(exception);
-            throw new AssertionError("Exception not thrown from serviceA");
-        }
-        catch (Throwable ex) {
-            assertEquals(ex, exception);
-        }
-        
-        try {
-            service.serviceA(exception);
-            throw new AssertionError("Exception not thrown from serviceA");
-        }
-        catch (CircuitBreakerOpenException ex) {
-            return CircuitState.OPEN;
-        }
-        catch (Throwable ex) {
-            assertEquals(ex, exception);
-            return CircuitState.CLOSED;
-        }
+        assertEquals(invoke(service::serviceA9, new Error()), CircuitState.CLOSED);
     }
 
     // serviceB: @CircuitBreaker(failOn = {Exception.class, E1.class}, skipOn = {E0.class, E2.class})
@@ -174,77 +133,55 @@ public class CircuitBreakerExceptionHierarchyTest extends Arquillian {
     @Test
     public void serviceBthrowsException() {
         // serviceB directly mentions Exception in failOn
-        assertEquals(invokeserviceB(new Exception()), CircuitState.OPEN);
+        assertEquals(invoke(service::serviceB1, new Exception()), CircuitState.OPEN);
     }
 
     @Test
     public void serviceBthrowsE0() {
         // serviceB directly mentions E0 in skipOn
-        assertEquals(invokeserviceB(new E0()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceB2, new E0()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceBthrowsE1() {
         // serviceB directly mentions E1 in failOn, but it also mentions E0 in skipOn and E1 <: E0
-        assertEquals(invokeserviceB(new E1()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceB3, new E1()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceBthrowsE2() {
         // serviceB directly mentions E2 in skipOn
-        assertEquals(invokeserviceB(new E2()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceB4, new E2()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceBthrowsE2S() {
         // serviceB mentions E2 in skipOn and E2S <: E2
-        assertEquals(invokeserviceB(new E2S()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceB5, new E2S()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceBthrowsE1S() {
         // serviceB mentions E1 in failOn and E1S <: E1, but it also mentions E0 in skipOn and E1S <: E0
-        assertEquals(invokeserviceB(new E1S()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceB6, new E1S()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceBthrowsE0S() {
         // serviceB mentions E0 in skipOn and E0S <: E0
-        assertEquals(invokeserviceB(new E0S()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceB7, new E0S()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceBthrowsRuntimeException() {
         // serviceB mentions Exception in failOn and RuntimeException <: Exception
-        assertEquals(invokeserviceB(new RuntimeException()), CircuitState.OPEN);
+        assertEquals(invoke(service::serviceB8, new RuntimeException()), CircuitState.OPEN);
     }
 
     @Test
     public void serviceBthrowsError() {
         // serviceB doesn't mention Error (nor any of its superclasses) neither in failOn nor skipOn
-        assertEquals(invokeServiceA(new Error()), CircuitState.CLOSED);
-    }
-
-    private CircuitState invokeserviceB(Throwable exception) {
-        try {
-            service.serviceB(exception);
-            throw new AssertionError("Exception not thrown from serviceB");
-        }
-        catch (Throwable ex) {
-            assertEquals(ex, exception);
-        }
-        
-        try {
-            service.serviceB(exception);
-            throw new AssertionError("Exception not thrown from serviceB");
-        }
-        catch (CircuitBreakerOpenException ex) {
-            return CircuitState.OPEN;
-        }
-        catch (Throwable ex) {
-            assertEquals(ex, exception);
-            return CircuitState.CLOSED;
-        }
+        assertEquals(invoke(service::serviceB9, new Error()), CircuitState.CLOSED);
     }
 
     // serviceC: @CircuitBreaker(failOn = {E1.class, E2.class}, skipOn = E0.class)
@@ -252,60 +189,60 @@ public class CircuitBreakerExceptionHierarchyTest extends Arquillian {
     @Test
     public void serviceCthrowsException() {
         // serviceC doesn't mention Exception (nor any of its superclasses) neither in failOn nor skipOn
-        assertEquals(invokeServiceC(new Exception()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceC1, new Exception()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceCthrowsE0() {
         // serviceC directly mentions E0 in skipOn
-        assertEquals(invokeServiceC(new E0()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceC2, new E0()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceCthrowsE1() {
         // serviceC directly mentions E1 in failOn, but it also mentions E0 in skipOn and E1 <: E0
-        assertEquals(invokeServiceC(new E1()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceC3, new E1()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceCthrowsE2() {
         // serviceC directly mentions E2 in failOn, but it also mentions E0 in skipOn and E1 <: E0
-        assertEquals(invokeServiceC(new E2()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceC4, new E2()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceCthrowsE2S() {
         // serviceC mentions E2 in failOn and E2S <: E2, but it also mentions E0 in skipOn and E2S <: E0
-        assertEquals(invokeServiceC(new E2S()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceC5, new E2S()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceCthrowsE1S() {
         // serviceC mentions E1 in failOn and E1S <: E1, but it also mentions E0 in skipOn and E1S <: E0
-        assertEquals(invokeServiceC(new E1S()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceC6, new E1S()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceCthrowsE0S() {
         // serviceC mentions E0 in skipOn and E0S <: E0
-        assertEquals(invokeServiceC(new E0S()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceC7, new E0S()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceCthrowsRuntimeException() {
         // serviceC doesn't mention RuntimeException (nor any of its superclasses) neither in failOn nor skipOn
-        assertEquals(invokeServiceC(new RuntimeException()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceC8, new RuntimeException()), CircuitState.CLOSED);
     }
 
     @Test
     public void serviceCthrowsError() {
         // serviceC doesn't mention Error (nor any of its superclasses) neither in failOn nor skipOn
-        assertEquals(invokeServiceC(new Error()), CircuitState.CLOSED);
+        assertEquals(invoke(service::serviceC9, new Error()), CircuitState.CLOSED);
     }
 
-    private CircuitState invokeServiceC(Throwable exception) {
+    private CircuitState invoke(ServiceInvocation invocation, Throwable exception) {
         try {
-            service.serviceC(exception);
+            invocation.invoke(exception);
             throw new AssertionError("Exception not thrown from serviceC");
         }
         catch (Throwable ex) {
@@ -313,7 +250,7 @@ public class CircuitBreakerExceptionHierarchyTest extends Arquillian {
         }
         
         try {
-            service.serviceC(exception);
+            invocation.invoke(exception);
             throw new AssertionError("Exception not thrown from serviceC");
         }
         catch (CircuitBreakerOpenException ex) {
@@ -323,6 +260,11 @@ public class CircuitBreakerExceptionHierarchyTest extends Arquillian {
             assertEquals(ex, exception);
             return CircuitState.CLOSED;
         }
+    }
+    
+    @FunctionalInterface
+    private static interface ServiceInvocation {
+        void invoke(Throwable t) throws Throwable;
     }
     
     private enum CircuitState {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/exception/hierarchy/CircuitBreakerService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/exception/hierarchy/CircuitBreakerService.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,28 +20,176 @@
 
 package org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.exception.hierarchy;
 
-import javax.enterprise.context.Dependent;
+import javax.enterprise.context.ApplicationScoped;
 
 import org.eclipse.microprofile.fault.tolerance.tck.exception.hierarchy.E0;
 import org.eclipse.microprofile.fault.tolerance.tck.exception.hierarchy.E1;
 import org.eclipse.microprofile.fault.tolerance.tck.exception.hierarchy.E2;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 
-@Dependent
+/**
+ * Contains three circuit breaker configurations for testing the interaction between failOn and skipOn
+ * <p>
+ * Each test service is replicated several times so that each test uses a separate circuit breaker
+ */
+@ApplicationScoped
 public class CircuitBreakerService {
     
+    /* --------------------
+     * serviceA
+     * --------------------
+     * failOn = E0, E2
+     * skipOn = E1
+     */
+    
     @CircuitBreaker(failOn = {E0.class, E2.class}, skipOn = E1.class, requestVolumeThreshold = 1, delay = 20000)
-    public void serviceA(Throwable exception) throws Throwable {
+    public void serviceA1(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {E0.class, E2.class}, skipOn = E1.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceA2(Throwable exception) throws Throwable {
+        throw exception;
+    }
+
+    @CircuitBreaker(failOn = {E0.class, E2.class}, skipOn = E1.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceA3(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {E0.class, E2.class}, skipOn = E1.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceA4(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {E0.class, E2.class}, skipOn = E1.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceA5(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {E0.class, E2.class}, skipOn = E1.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceA6(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {E0.class, E2.class}, skipOn = E1.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceA7(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {E0.class, E2.class}, skipOn = E1.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceA8(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {E0.class, E2.class}, skipOn = E1.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceA9(Throwable exception) throws Throwable {
+        throw exception;
+    }
+
+    
+    /* --------------------
+     * serviceB
+     * --------------------
+     * failOn = Exception, E1
+     * skipOn = E0, E2
+     */
+    
+    @CircuitBreaker(failOn = {Exception.class, E1.class}, skipOn = {E0.class, E2.class}, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceB1(Throwable exception) throws Throwable {
         throw exception;
     }
     
     @CircuitBreaker(failOn = {Exception.class, E1.class}, skipOn = {E0.class, E2.class}, requestVolumeThreshold = 1, delay = 20000)
-    public void serviceB(Throwable exception) throws Throwable {
+    public void serviceB2(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {Exception.class, E1.class}, skipOn = {E0.class, E2.class}, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceB3(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {Exception.class, E1.class}, skipOn = {E0.class, E2.class}, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceB4(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {Exception.class, E1.class}, skipOn = {E0.class, E2.class}, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceB5(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {Exception.class, E1.class}, skipOn = {E0.class, E2.class}, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceB6(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {Exception.class, E1.class}, skipOn = {E0.class, E2.class}, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceB7(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {Exception.class, E1.class}, skipOn = {E0.class, E2.class}, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceB8(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {Exception.class, E1.class}, skipOn = {E0.class, E2.class}, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceB9(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    /* --------------------
+     * serviceC
+     * --------------------
+     * failOn = E1, E2
+     * skipOn = E0
+     */
+    
+    @CircuitBreaker(failOn = {E1.class, E2.class}, skipOn = E0.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceC1(Throwable exception) throws Throwable {
         throw exception;
     }
     
     @CircuitBreaker(failOn = {E1.class, E2.class}, skipOn = E0.class, requestVolumeThreshold = 1, delay = 20000)
-    public void serviceC(Throwable exception) throws Throwable {
+    public void serviceC2(Throwable exception) throws Throwable {
         throw exception;
     }
+
+    @CircuitBreaker(failOn = {E1.class, E2.class}, skipOn = E0.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceC3(Throwable exception) throws Throwable {
+        throw exception;
+    }
+
+    @CircuitBreaker(failOn = {E1.class, E2.class}, skipOn = E0.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceC4(Throwable exception) throws Throwable {
+        throw exception;
+    }
+
+    @CircuitBreaker(failOn = {E1.class, E2.class}, skipOn = E0.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceC5(Throwable exception) throws Throwable {
+        throw exception;
+    }
+
+    @CircuitBreaker(failOn = {E1.class, E2.class}, skipOn = E0.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceC6(Throwable exception) throws Throwable {
+        throw exception;
+    }
+
+    @CircuitBreaker(failOn = {E1.class, E2.class}, skipOn = E0.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceC7(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {E1.class, E2.class}, skipOn = E0.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceC8(Throwable exception) throws Throwable {
+        throw exception;
+    }
+    
+    @CircuitBreaker(failOn = {E1.class, E2.class}, skipOn = E0.class, requestVolumeThreshold = 1, delay = 20000)
+    public void serviceC9(Throwable exception) throws Throwable {
+        throw exception;
+    }
+
 }


### PR DESCRIPTION
Change the CircuitBreakerExceptionHierarchyTest to use a different
service method for each test.

This requires the service method to be replicated lots of times, but
allows the lifetime of the circuit breaker to be tied to the method
itself rather than to the bean instance.

Signed-off-by: Andrew Rouse <anrouse@uk.ibm.com>