### PR TITLE
add bean-defining annotations to beans in TCK

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadCompletionStageBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/bulkhead/clientserver/BulkheadCompletionStageBean.java
@@ -25,8 +25,11 @@ import java.util.concurrent.CompletionStage;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 
+import javax.enterprise.context.Dependent;
+
+@Dependent
 public class BulkheadCompletionStageBean {
-    
+
     /**
      * Returns {@code stage} as the result
      * <p>
@@ -34,7 +37,7 @@ public class BulkheadCompletionStageBean {
      * <p>
      * As this is an async method, it won't be considered "complete" by Fault Tolerance
      * until {@code stage} completes.
-     * 
+     *
      * @param stage the CompletionStage to return as the result
      * @return {@code stage}
      */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/CircuitBreakerConfigBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/CircuitBreakerConfigBean.java
@@ -22,11 +22,11 @@ package org.eclipse.microprofile.fault.tolerance.tck.config;
 
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 
-/**
- * 
- */
+import javax.enterprise.context.Dependent;
+
+@Dependent
 public class CircuitBreakerConfigBean {
-    
+
     /**
      * Method throws TestConfigExceptionA which will result in CircuitBreakerOpenException on the third call, unless skipOn is configured
      */

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/FallbackConfigBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/FallbackConfigBean.java
@@ -22,9 +22,12 @@ package org.eclipse.microprofile.fault.tolerance.tck.config;
 
 import org.eclipse.microprofile.faulttolerance.Fallback;
 
+import javax.enterprise.context.Dependent;
+
 /**
  * Bean with methods to help test configuration of parameters of {@link Fallback}
  */
+@Dependent
 public class FallbackConfigBean {
 
     /**
@@ -34,7 +37,7 @@ public class FallbackConfigBean {
     public String applyOnMethod() {
         throw new TestConfigExceptionA();
     }
-    
+
     /**
      * TestConfigExceptionA will cause fallback to run, unless skipOn is configured
      */
@@ -42,7 +45,7 @@ public class FallbackConfigBean {
     public String skipOnMethod() {
         throw new TestConfigExceptionA();
     }
-    
+
     public String theFallback() {
         return "FALLBACK";
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/exception/hierarchy/FallbackService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/exception/hierarchy/FallbackService.java
@@ -24,7 +24,9 @@ import org.eclipse.microprofile.fault.tolerance.tck.exception.hierarchy.E1;
 import org.eclipse.microprofile.fault.tolerance.tck.exception.hierarchy.E2;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 
+import javax.enterprise.context.Dependent;
 
+@Dependent
 public class FallbackService {
     private String fallbackValue = "Fallback result";
     @Fallback(applyOn = {E0.class, E2.class}, skipOn = E1.class, fallbackMethod = "myFallback")
@@ -50,5 +52,4 @@ public class FallbackService {
         return fallbackValue;
     }
 
-    
 }


### PR DESCRIPTION
This is to make sure the TCK can pass on Quarkus, which requires
all beans to have bean-defining annotations.

Resolves #508.