### PR TITLE
Typo and grammar corrections

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/Asynchronous.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/Asynchronous.java
@@ -58,9 +58,9 @@ import javax.interceptor.InterceptorBinding;
  * Once the execution on Thread B is complete, the Future or CompletionStage returned in Thread A behaves differently
  * depending on whether the execution in Thread B threw an exception:
  * <ul>
- * <li>If the execution threw an exception, the Future or CompletionStage will be completed with that exception</li>
+ * <li>If the execution threw an exception, the Future or CompletionStage will be completed with that exception.</li>
  * <li>If the execution returned normally, the Future or CompletionStage returned in Thread A will behave in the same
- * way as the Future or CompletionStage returned from the execution in Thread B, i.e. it can be
+ * way as the Future or CompletionStage returned from the execution in Thread B, i.e. it can be:
  * <ul>
  * <li>not complete yet</li>
  * <li>completed successfully with a return value</li>
@@ -83,7 +83,7 @@ import javax.interceptor.InterceptorBinding;
  * <ul>
  * <li>If the method declares {@link java.util.concurrent.Future} as the return type,
  * calling {@link java.util.concurrent.Future#get()} on the Future returned in Thread A will throw an
- * {@link java.util.concurrent.ExecutionException} wrapping the original exception</li>
+ * {@link java.util.concurrent.ExecutionException} wrapping the original exception.</li>
  * <li>If the method declares {@link java.util.concurrent.CompletionStage} as the return type,
  * the CompletionStage returned in Thread A is completed exceptionally with the exception.</li>
  * </ul>

--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/Bulkhead.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/Bulkhead.java
@@ -56,6 +56,7 @@ public @interface Bulkhead {
     /**
      * Specify the maximum number of concurrent calls to an instance. The value must be greater than 0.
      * Otherwise, {@link org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException} occurs.
+     * 
      * @return the limit of the concurrent calls
      */
     @Nonbinding
@@ -64,6 +65,7 @@ public @interface Bulkhead {
      * Specify the waiting task queue. This setting only takes effect on asynchronous invocation, achieved by using {@code Asynchronous}.
      * The value must be greater than 0.
      * Otherwise, {@link org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException} occurs.
+     * 
      * @return the waiting queue size
      */
     @Nonbinding

--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/CircuitBreaker.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/CircuitBreaker.java
@@ -62,7 +62,7 @@ import javax.interceptor.InterceptorBinding;
  * When a method returns a result, the following rules are applied to determine whether the result is a success or a failure:
  * <ul>
  * <li>If the method does not throw a {@link Throwable}, it is considered a success
- * <li>Otherwise, if the thrown object is assignable to any value in the {@link #skipOn()} parameter, is is considered a success
+ * <li>Otherwise, if the thrown object is assignable to any value in the {@link #skipOn()} parameter, it is considered a success
  * <li>Otherwise, if the thrown object is assignable to any value in the {@link #failOn()} parameter, it is considered a failure
  * <li>Otherwise it is considered a success
  * </ul>
@@ -78,7 +78,7 @@ import javax.interceptor.InterceptorBinding;
 public @interface CircuitBreaker {
 
     /**
-     * The list of exception types which should be considered failures
+     * The list of exception types which should be considered failures.
      * <p>
      * Note that if a method throws a {@link Throwable} which is not an {@link Error} or {@link Exception}, non-portable behavior
      * results.
@@ -89,9 +89,9 @@ public @interface CircuitBreaker {
     Class<? extends Throwable>[] failOn() default {Throwable.class};
     
     /**
-     * The list of exception types which should not be considered failures
+     * The list of exception types which should not be considered failures.
      * <p>
-     * This list takes priority over the types listed in {@link #failOn}
+     * This list takes priority over the types listed in {@link #failOn}.
      * <p>
      * Note that if a method throws a {@link Throwable} which is not an {@link Error} or {@link Exception}, non-portable behavior results.
      *
@@ -107,7 +107,7 @@ public @interface CircuitBreaker {
      * The amount of delay is taken from this delay value and the {@code delayUnit}, and defaults to five seconds. The
      * value must be greater than or equal to {@code 0}. {@code 0} means no delay.
      *
-     * @return The delay time after which an open circuit transitions to half-open state
+     * @return the delay time after which an open circuit transitions to half-open state
      */
     @Nonbinding
     long delay() default 5000;
@@ -127,7 +127,7 @@ public @interface CircuitBreaker {
      * The circuit breaker will trip if the number of failures exceed the {@code failureRatio} within the rolling window
      * of consecutive requests. The value must be greater than or equal to {@code 1}.
      *
-     * @return The number of the consecutive requests in a rolling window
+     * @return the number of the consecutive requests in a rolling window
      */
     @Nonbinding
     int requestVolumeThreshold() default 20;
@@ -140,7 +140,7 @@ public @interface CircuitBreaker {
      * is {@code .50}, ten or more failures in 20 consecutive requests will trigger the circuit to open. The value must
      * be between {@code 0} and {@code 1} inclusive.
      *
-     * @return The failure ratio threshold
+     * @return the failure ratio threshold
      */
     @Nonbinding
     double failureRatio() default .50;
@@ -152,7 +152,7 @@ public @interface CircuitBreaker {
      * If a failure occurs while in half-open state the circuit is immediately opened again. The value must be greater
      * than or equal to {@code 1}.
      *
-     * @return The success threshold to fully close the circuit
+     * @return the success threshold to fully close the circuit
      */
     @Nonbinding
     int successThreshold() default 1;

--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/ExecutionContext.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/ExecutionContext.java
@@ -29,23 +29,22 @@ import java.lang.reflect.Method;
 public interface ExecutionContext {
 
      /**
-     * Returns the method being executed
+     * Returns the method being executed.
      * 
      * @return the method
      */
     public Method getMethod();
 
     /**
-     * Returns the parameter values being passed to the method 
+     * Returns the parameter values being passed to the method.
      * 
      * @return the parameter values, as an array
-     * 
-     * 
      */
     public Object[] getParameters();
     
     /**
-     * Returns the failure of the method execution
+     * Returns the failure of the method execution.
+     * 
      * @return the failure of the method execution
      */
     public Throwable getFailure();

--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/Fallback.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/Fallback.java
@@ -30,19 +30,19 @@ import javax.interceptor.InterceptorBinding;
 
 /**
  * The fallback annotation to define the fallback handler class so that
- * a failure can be handled properly. Below is the criteria:
+ * a failure can be handled properly. The criteria are as follows:
  * <ol>
  * <li>If value is specified, use {@link FallbackHandler#handle(ExecutionContext)} on the specified handler to execute the fallback.</li>
  * <li>If fallbackMethod is specified, invoke the method specified by the fallbackMethod on the same class.</li>
  * <li>If both are specified, the {@link org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException} must be thrown.</li>
  * </ol>
  * <p>
- * When a method returns and the Fallback policy is present, the following rules are applied:
+ * When a method returns and the fallback policy is present, the following rules are applied:
  * <ol>
  * <li>If the method returns normally (doesn't throw), the result is simply returned.
  * <li>Otherwise, if the thrown object is assignable to any value in the {@link #skipOn()} parameter, the thrown object will be rethrown.
  * <li>Otherwise, if the thrown object is assignable to any value in the {@link #applyOn()} parameter, 
- * the Fallback policy, detailed above, will be applied.
+ * the fallback policy, detailed above, will be applied.
  * <li>Otherwise the thrown object will be rethrown.
  * </ol>
  * If a method throws a {@link Throwable} which is not an {@link Error} or {@link Exception}, non-portable behavior results.
@@ -68,7 +68,7 @@ public @interface Fallback {
         }
     }
     /**
-     * Specify the fallback class to be used. An new instance of the fallback class
+     * Specify the fallback class to be used. A new instance of the fallback class
      * is returned. The instance is unmanaged. The type parameter of the fallback class must be assignable to the
      * return type of the annotated method. 
      * Otherwise, {@link org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException} occurs.
@@ -79,9 +79,9 @@ public @interface Fallback {
     Class<? extends FallbackHandler<?>> value() default DEFAULT.class;
     
     /**
-    * Specify the method name to be fallbacked to. This method belongs
+    * Specify the method name to fallback to. This method belongs
     * to the same class as the method to fallback.
-    * The method must have the exactly same arguments as the method being annotated.
+    * The method must have the exact same arguments as the method being annotated.
     * The method return type must be assignable to the return type of the method the fallback is for. 
     * Otherwise, {@link org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException} must be thrown.
     * 

--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/FallbackHandler.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/FallbackHandler.java
@@ -56,6 +56,7 @@ public interface FallbackHandler<T>{
      * or perform any alternative operations.
      * 
      * @param context the execution context
+     * 
      * @return the result of the fallback 
      */
     T handle(ExecutionContext context);

--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/Retry.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/Retry.java
@@ -30,7 +30,7 @@ import javax.enterprise.util.Nonbinding;
 import javax.interceptor.InterceptorBinding;
 
 /**
- * The Retry annotation to define the number of the retries. Any invalid config value causes
+ * The retry annotation to define the number of retries. Any invalid config value causes
  * {@link org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException}.
  * <p>
  * When a method returns and the retry policy is present, the following rules are applied:
@@ -53,7 +53,8 @@ public @interface Retry {
 
     /**
      * The max number of the retries.
-     * @return The max number of retries. -1 means retry forever. The value must be greater than or equal to -1.
+     * 
+     * @return the max number of retries. -1 means retry forever. The value must be greater than or equal to -1.
      *
      */
     @Nonbinding
@@ -61,6 +62,7 @@ public @interface Retry {
 
     /**
      * The delay between retries. Defaults to 0. The value must be greater than or equal to 0.
+     * 
      * @return the delay time
      */
     @Nonbinding
@@ -68,6 +70,7 @@ public @interface Retry {
 
     /**
      * The unit for {@link #delay}. Defaults to {@link java.time.temporal.ChronoUnit#MILLIS} if not set.
+     * 
      * @return the delay unit
      */
     @Nonbinding
@@ -75,13 +78,15 @@ public @interface Retry {
 
     /**
      * The max duration. The max duration must be greater than the delay duration if set. 0 means not set.
-     * @return the maximum duration to perform retries for.
+     * 
+     * @return the maximum duration to perform retries for
      */
     @Nonbinding
     long maxDuration() default 180000;
 
     /**
      * The duration unit for {@link #maxDuration}. Defaults to {@link java.time.temporal.ChronoUnit#MILLIS} if not set. 
+     * 
      * @return the duration unit
      */
     @Nonbinding
@@ -102,8 +107,9 @@ public @interface Retry {
     long jitter() default 200;
 
     /**
-     * The delay unit for {@link #jitter}. Defaults to {@link java.time.temporal.ChronoUnit#MILLIS} if not set. 
-     * @return the jitter delay unit.
+     * The delay unit for {@link #jitter}. Defaults to {@link java.time.temporal.ChronoUnit#MILLIS} if not set.
+     * 
+     * @return the jitter delay unit
      */
     @Nonbinding
     ChronoUnit jitterDelayUnit() default ChronoUnit.MILLIS;

--- a/api/src/main/java/org/eclipse/microprofile/faulttolerance/Timeout.java
+++ b/api/src/main/java/org/eclipse/microprofile/faulttolerance/Timeout.java
@@ -44,6 +44,7 @@ public @interface Timeout {
     /**
      * The timeout value. The value must be greater than or equal to 0. 0 means no timeout configured.
      * Otherwise, {@link org.eclipse.microprofile.faulttolerance.exceptions.FaultToleranceDefinitionException} occurs.
+     * 
      * @return the timeout value
      */
     @Nonbinding
@@ -51,6 +52,7 @@ public @interface Timeout {
 
     /**
      * The timeout unit. Defaults to {@link java.time.temporal.ChronoUnit#MILLIS}.
+     * 
      * @return the timeout unit
      */
     @Nonbinding


### PR DESCRIPTION
Some of these changes will be up for discussion, as some are preferences rather than corrections.

I've tried to follow some standards, such as:
* no capitals after @return's
* colons before listed items
*  consistent full stops, excluding:
    *  listed items which are not sentences
    * sentences following @return's