### PR TITLE
Updated AllMetricsBean

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsBean.java
@@ -37,7 +37,7 @@ public class AllMetricsBean {
     
     @Retry(maxRetries = 5)
     @Bulkhead(3)
-    @Timeout(value = 1000, unit = ChronoUnit.MILLIS)
+    @Timeout(value = 1, unit = ChronoUnit.MINUTES)
     @CircuitBreaker(failureRatio = 1.0, requestVolumeThreshold = 20)
     @Fallback(fallbackMethod = "doFallback")
     @Asynchronous

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsBean.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotationAsset;
 import org.eclipse.microprofile.fault.tolerance.tck.metrics.util.MetricGetter;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -42,11 +43,17 @@ public class AllMetricsTest extends Arquillian {
 
     @Deployment
     public static WebArchive deploy() {
+
+        // Scales the following method's annotation values by the TCKConfig baseMultiplier
+        ConfigAnnotationAsset allMetricsBeanConfig = new ConfigAnnotationAsset()
+                .autoscaleMethod(AllMetricsBean.class, "doWork");
+
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricAll.war")
                 .addClasses(AllMetricsBean.class)
                 .addPackage(Packages.UTILS)
                 .addPackage(Packages.METRIC_UTILS)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(allMetricsBeanConfig, "microprofile-config.properties");
         
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsTest.java
@@ -33,6 +33,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.testng.annotations.Test;
 
@@ -48,13 +49,16 @@ public class AllMetricsTest extends Arquillian {
         ConfigAnnotationAsset allMetricsBeanConfig = new ConfigAnnotationAsset()
                 .autoscaleMethod(AllMetricsBean.class, "doWork");
 
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricAll.war")
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ftMetricAll.jar")
                 .addClasses(AllMetricsBean.class)
                 .addPackage(Packages.UTILS)
                 .addPackage(Packages.METRIC_UTILS)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsManifestResource(allMetricsBeanConfig, "microprofile-config.properties");
-        
+
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "ftMetricAll.war")
+                .addAsLibrary(jar);
+
         return war;
     }
     


### PR DESCRIPTION
Fixes #519 

Updated AllMetricsBean: 
* Increased the Timeout duration to 1 minute
* Scaled all the FT values  with the the TCKConfig baseMultiplier using the autoscaleMethod