### PR TITLE
Add TCK fixes 2.0.x

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutUninterruptableTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutUninterruptableTest.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -203,13 +203,14 @@ public class TimeoutUninterruptableTest extends Arquillian {
      * Test that the timeout timer is started when the execution is added to the queue
      * 
      * @throws InterruptedException if the test is interrupted
+     * @throws ExecutionException 
      */
     @Test
-    public void testTimeoutAsyncBulkheadQueueTimed() throws InterruptedException {
+    public void testTimeoutAsyncBulkheadQueueTimed() throws InterruptedException, ExecutionException {
         CompletableFuture<Void> waitingFutureA = newWaitingFuture();
         CompletableFuture<Void> waitingFutureB = newWaitingFuture();
         
-        client.serviceTimeoutAsyncBulkheadQueueTimed(waitingFutureA);
+        Future<Void> resultA = client.serviceTimeoutAsyncBulkheadQueueTimed(waitingFutureA);
         Thread.sleep(config.getTimeoutInMillis(100));
         
         long startTime = System.nanoTime();
@@ -219,6 +220,9 @@ public class TimeoutUninterruptableTest extends Arquillian {
         
         // Allow call A to finish, this should allow call B to start
         waitingFutureA.complete(null);
+        
+        // Assert there were no exceptions for call A
+        resultA.get();
         
         // Wait for call B to time out
         expect(TimeoutException.class, resultB);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/AllMetricsBean.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -37,7 +37,7 @@ public class AllMetricsBean {
     
     @Retry(maxRetries = 5)
     @Bulkhead(3)
-    @Timeout(value = 1000, unit = ChronoUnit.MILLIS)
+    @Timeout(value = 1, unit = ChronoUnit.MINUTES)
     @CircuitBreaker(failureRatio = 1.0, requestVolumeThreshold = 20)
     @Fallback(fallbackMethod = "doFallback")
     @Asynchronous

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/UninterruptableTimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/UninterruptableTimeoutClient.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,7 +19,7 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.enterprise.context.RequestScoped;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Bulkhead;
 import org.eclipse.microprofile.faulttolerance.Fallback;
@@ -41,6 +42,9 @@ import org.testng.Assert;
 
 @RequestScoped
 public class UninterruptableTimeoutClient {
+
+    // 3 seconds * baseMultiplier, in milliseconds
+    private final long WAITING_FUTURE_DURATION = TCKConfig.getConfig().getTimeoutInMillis(3L * 1000);
     
     /**
      * Waits for at least {@code waitms}, then returns
@@ -83,7 +87,7 @@ public class UninterruptableTimeoutClient {
     public Future<Void> serviceTimeoutAsync(Future<?> waitingFuture, CompletableFuture<Void> completion) {
         while (true) {
             try {
-                waitingFuture.get(5, SECONDS);
+                waitingFuture.get(WAITING_FUTURE_DURATION, MILLISECONDS);
                 completion.complete(null);
                 return CompletableFuture.completedFuture(null);
             }
@@ -94,7 +98,7 @@ public class UninterruptableTimeoutClient {
                 Assert.fail("Waiting future threw exception", e);
             }
             catch (TimeoutException e) {
-                return CompletableFuture.completedFuture(null);
+                Assert.fail("Waiting future timed out", e);
             }
         }
     }
@@ -150,7 +154,7 @@ public class UninterruptableTimeoutClient {
         timeoutAsyncBulkheadCounter.incrementAndGet();
         while (true) {
             try {
-                waitingFuture.get(5, SECONDS);
+                waitingFuture.get(WAITING_FUTURE_DURATION, MILLISECONDS);
                 return CompletableFuture.completedFuture(null);
             }
             catch (InterruptedException e) {
@@ -160,7 +164,7 @@ public class UninterruptableTimeoutClient {
                 Assert.fail("Waiting future threw exception", e);
             }
             catch (TimeoutException e) {
-                return CompletableFuture.completedFuture(null);
+                Assert.fail("Waiting future timed out", e);
             }
         }
     }
@@ -191,7 +195,7 @@ public class UninterruptableTimeoutClient {
     public Future<Void> serviceTimeoutAsyncBulkheadQueueTimed(Future<?> waitingFuture) {
         while (true) {
             try {
-                waitingFuture.get(5, SECONDS);
+                waitingFuture.get(WAITING_FUTURE_DURATION, MILLISECONDS);
                 return CompletableFuture.completedFuture(null);
             }
             catch (InterruptedException e) {
@@ -201,7 +205,7 @@ public class UninterruptableTimeoutClient {
                 Assert.fail("Waiting future threw exception", e);
             }
             catch (TimeoutException e) {
-                return CompletableFuture.completedFuture(null);
+                Assert.fail("Waiting future timed out", e);
             }
         }
     }
@@ -229,7 +233,7 @@ public class UninterruptableTimeoutClient {
         timeoutAsyncRetryCounter.incrementAndGet();
         while (true) {
             try {
-                waitingFuture.get(5, SECONDS);
+                waitingFuture.get(WAITING_FUTURE_DURATION, MILLISECONDS);
                 return CompletableFuture.completedFuture(null);
             }
             catch (InterruptedException e) {
@@ -239,7 +243,7 @@ public class UninterruptableTimeoutClient {
                 Assert.fail("Waiting future threw exception", e);
             }
             catch (TimeoutException e) {
-                return CompletableFuture.completedFuture(null);
+                Assert.fail("Waiting future timed out", e);
             }
         }
     }
@@ -273,7 +277,7 @@ public class UninterruptableTimeoutClient {
     public Future<String> serviceTimeoutAsyncFallback(Future<?> waitingFuture) {
         while (true) {
             try {
-                waitingFuture.get(5, SECONDS);
+                waitingFuture.get(WAITING_FUTURE_DURATION, MILLISECONDS);
                 return CompletableFuture.completedFuture("OK");
             }
             catch (InterruptedException e) {
@@ -283,7 +287,7 @@ public class UninterruptableTimeoutClient {
                 Assert.fail("Waiting future threw exception", e);
             }
             catch (TimeoutException e) {
-                return CompletableFuture.completedFuture("TIMEDOUT");
+                Assert.fail("Waiting future timed out", e);
             }
         }
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/ConcurrentExecutionTracker.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/util/ConcurrentExecutionTracker.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -48,7 +48,8 @@ public class ConcurrentExecutionTracker {
     // The Atomicness is not important, this is just an integer holder
     private final AtomicInteger executionCount = new AtomicInteger(0);
     
-    private static final long WAIT_TIMEOUT = 3L * 1000 * 1_000_000;
+    // 3 seconds * baseMultiplier, in nanoseconds
+    private static final long WAIT_TIMEOUT = TCKConfig.getConfig().getTimeoutInMillis(3L * 1000) * 1_000_000;
 
     /**
      * Wait for the given number of method executions to be running


### PR DESCRIPTION
Introduces the following PR's:
#520 - Updated AllMetricsBean
#517 - TimeoutUninterruptableTest scaling issue fix
#511 - Make concurrent execution tracker configurable

This branch did not work for Java 11 or 13 for me.

Only Java 8:
```
josephcass$ java -version
openjdk version "1.8.0_242"
OpenJDK Runtime Environment (build 1.8.0_242-b08)
Eclipse OpenJ9 VM (build openj9-0.18.1, JRE 1.8.0 Mac OS X amd64-64-Bit Compressed References 20200122_439 (JIT enabled, AOT enabled)
OpenJ9   - 51a5857d2
OMR      - 7a1b0239a
JCL      - 8cf8a30581 based on jdk8u242-b08)```