### PR TITLE
Add timeout config to RetryTest and CircuitBreakerTimeoutTest

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerTimeoutTest.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientWithTimeout;
+import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotationAsset;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Exceptions;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -41,11 +42,15 @@ public class CircuitBreakerTimeoutTest extends Arquillian {
     
     @Deployment
     public static WebArchive deploy() {
+        ConfigAnnotationAsset config = new ConfigAnnotationAsset()
+                .autoscaleMethod(CircuitBreakerClientWithTimeout.class, "serviceWithTimeout")
+                .autoscaleMethod(CircuitBreakerClientWithTimeout.class, "serviceWithTimeoutWithoutFailOn");
+        
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftCircuitBreakerTimeout.jar")
                                         .addClasses(CircuitBreakerClientWithTimeout.class)
                                         .addPackage(Packages.UTILS)
                                         .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                                        .as(JavaArchive.class);
+                                        .addAsManifestResource(config, "microprofile-config.properties");
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftCircuitBreakerTimeout.war")
                                    .addAsLibrary(testJar);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
@@ -21,6 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotationAsset;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClassLevelClientForMaxRetries;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientForMaxRetries;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientWithDelay;
@@ -50,6 +51,10 @@ public class RetryTest extends Arquillian {
     
     @Deployment
     public static WebArchive deploy() {
+        
+        ConfigAnnotationAsset config = new ConfigAnnotationAsset()
+                .autoscaleMethod(RetryClientWithDelay.class, "serviceA");
+        
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftRetry.jar")
                 .addClasses(RetryClientForMaxRetries.class,
@@ -57,7 +62,7 @@ public class RetryTest extends Arquillian {
                             RetryClassLevelClientForMaxRetries.class,
                             RetryClientWithNoDelayAndJitter.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .as(JavaArchive.class);
+                .addAsManifestResource(config, "microprofile-config.properties");
 
         WebArchive war = ShrinkWrap
                 .create(WebArchive.class, "ftRetry.war")
@@ -129,7 +134,7 @@ public class RetryTest extends Arquillian {
 
         Assert.assertTrue(retryCountForConnectionService > 4,
             "The max number of execution should be greater than 4 but it was " + retryCountForConnectionService);
-        Assert.assertTrue(clientForDelay.isDelayInRange(), "The delay between each retry should be 0-800ms");
+        clientForDelay.assertDelayInRange();
     }
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithTimeout.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithTimeout.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018-2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,6 +23,7 @@ import static org.testng.Assert.fail;
 
 import javax.enterprise.context.RequestScoped;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
@@ -38,10 +39,10 @@ public class CircuitBreakerClientWithTimeout {
      * @return should always throw TimeoutException, unless CircuitBreaker prevents execution
      */
     @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 2, failureRatio = 0.75, delay = 50000)
-    @Timeout(500)
+    @Timeout(500) // Adjusted by config
     public String serviceWithTimeout() {
         try {
-            Thread.sleep(1000);
+            Thread.sleep(TCKConfig.getConfig().getTimeoutInMillis(1000));
             fail("Thread not interrupted by timeout");
         }
         catch (InterruptedException e) {
@@ -60,10 +61,10 @@ public class CircuitBreakerClientWithTimeout {
      * @return should always throw TimeoutException
      */
     @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 2, failureRatio = 0.75, delay = 50000, failOn = BulkheadException.class)
-    @Timeout(500)
+    @Timeout(500) // Adjusted by config
     public String serviceWithTimeoutWithoutFailOn() {
         try {
-            Thread.sleep(1000);
+            Thread.sleep(TCKConfig.getConfig().getTimeoutInMillis(1000));
             fail("Thread not interrupted by timeout");
         }
         catch (InterruptedException e) {


### PR DESCRIPTION
While testing the latest RC, I saw a failure I hadn't seen before in `RetryTest` where the timing is fairly tight and the test wasn't using `TCKConfig`.

After fixing that, I had a look through to see if there were any more tests which should clearly be using `TCKConfig` but aren't and I found `CircuitBreakerTimeoutTest` so I've fixed that too.

Fixes #544 