### PR TITLE
move the note about naming/security context propagation to an extra section

### DIFF
--- a/spec/src/main/asciidoc/asynchronous.asciidoc
+++ b/spec/src/main/asciidoc/asynchronous.asciidoc
@@ -24,8 +24,6 @@
 == Asynchronous
 
 `Asynchronous` means the execution of the client request will be on a separate thread.
-This thread should have the correct security context or naming context associated with it.
-
 
 === Asynchronous Usage
 

--- a/spec/src/main/asciidoc/microprofile-fault-tolerance-spec.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-fault-tolerance-spec.asciidoc
@@ -64,5 +64,7 @@ include::metrics.asciidoc[]
 
 include::configuration.asciidoc[]
 
-include::release_notes.asciidoc[] 
+include::optional-container-integration.asciidoc[]
+
+include::release_notes.asciidoc[]
 

--- a/spec/src/main/asciidoc/optional-container-integration.asciidoc
+++ b/spec/src/main/asciidoc/optional-container-integration.asciidoc
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2020 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Contributors:
+// Ladislav Thon
+
+[[optional-container-integration]]
+
+== Recommendations for Optional Container Integration
+
+This section describes the expected behaviors when the implementation runs in a Java EE container.
+
+=== `@Asynchronous`
+
+Threads that are servicing `@Asynchronous` invocations should, for the duration of the invocation, have the correct security context and naming context associated.


### PR DESCRIPTION
This is because MicroProfile itself doesn't know anything about
naming or security context, and MicroProfile implementations
don't have to have anything like that. These terms only make sense
in a Java EE environment. Therefore, the requirement that naming
and security contexts are propagated should be present in an extra
section that only applies to Java EE container implementations.

Signed-off-by: Ladislav Thon <lthon@redhat.com>