### PR TITLE
Increase jakarta.enterprise.util OSGi Version Range to Encompass Jakarta EE 9.1 and 10

### DIFF
--- a/api/bnd.bnd
+++ b/api/bnd.bnd
@@ -1,7 +1,7 @@
 -exportcontents: \
     org.eclipse.microprofile.*
 Import-Package: \
-    jakarta.enterprise.util;version="[2.0,3)", \
+    jakarta.enterprise.util;version="[3.0,5)", \
     *
 Bundle-SymbolicName: org.eclipse.microprofile.fault.tolerance
 # For reproducible builds


### PR DESCRIPTION
This OSGi range as it is is for Jakarta EE 8.
This changes the version range to be usable with Jakarta EE 9.1 (3.x) and 10 (4.x)

Signed-off-by: Andrew Pielage <pandrex247@hotmail.com>