### PR TITLE
Weld cannot find beans because of missing annotation

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/FallbackHandlerA.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/FallbackHandlerA.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,6 +23,9 @@ package org.eclipse.microprofile.fault.tolerance.tck.config;
 import org.eclipse.microprofile.faulttolerance.ExecutionContext;
 import org.eclipse.microprofile.faulttolerance.FallbackHandler;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class FallbackHandlerA implements FallbackHandler<String> {
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/FallbackHandlerB.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/FallbackHandlerB.java
@@ -1,6 +1,6 @@
 /*
  *******************************************************************************
- * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -23,6 +23,9 @@ package org.eclipse.microprofile.fault.tolerance.tck.config;
 import org.eclipse.microprofile.faulttolerance.ExecutionContext;
 import org.eclipse.microprofile.faulttolerance.FallbackHandler;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class FallbackHandlerB implements FallbackHandler<String> {
 
     @Override


### PR DESCRIPTION
Relates to this https://github.com/helidon-io/helidon/pull/5830

Weld requires some annotations to know the beans