### PR TITLE
This PR replaces all expected RuntimeExceptions with TestException. T…

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
@@ -34,6 +34,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.asynctimeout.clientserver.As
 import org.eclipse.microprofile.fault.tolerance.tck.asynctimeout.clientserver.AsyncTimeoutClient;
 import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotationAsset;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Connection;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -78,7 +79,8 @@ public class AsyncTimeoutTest extends Arquillian {
 
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftAsyncTimeout.jar")
-                .addClasses(AsyncTimeoutClient.class, AsyncClassLevelTimeoutClient.class, Connection.class)
+                .addClasses(AsyncTimeoutClient.class, AsyncClassLevelTimeoutClient.class, Connection.class,
+                        TestException.class)
                 .addAsManifestResource(config, "microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/AsyncTimeoutTest.java
@@ -34,7 +34,6 @@ import org.eclipse.microprofile.fault.tolerance.tck.asynctimeout.clientserver.As
 import org.eclipse.microprofile.fault.tolerance.tck.asynctimeout.clientserver.AsyncTimeoutClient;
 import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotationAsset;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Connection;
-import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -79,8 +78,7 @@ public class AsyncTimeoutTest extends Arquillian {
 
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftAsyncTimeout.jar")
-                .addClasses(AsyncTimeoutClient.class, AsyncClassLevelTimeoutClient.class, Connection.class,
-                        TestException.class)
+                .addClasses(AsyncTimeoutClient.class, AsyncClassLevelTimeoutClient.class, Connection.class)
                 .addAsManifestResource(config, "microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerInitialSuccessTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerInitialSuccessTest.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 import static org.eclipse.microprofile.fault.tolerance.tck.Misc.Ints.contains;
 
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientDefaultSuccessThreshold;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -49,7 +50,8 @@ public class CircuitBreakerInitialSuccessTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftCircuitBreakerInitialSuccess.jar")
                 .addClasses(CircuitBreakerClientDefaultSuccessThreshold.class,
-                        Misc.class)
+                        Misc.class,
+                        TestException.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);
 
@@ -63,12 +65,12 @@ public class CircuitBreakerInitialSuccessTest extends Arquillian {
      * 
      * With requestVolumeThreshold = 4, failureRatio=0.75 and successThreshold = 1 the expected behaviour is,
      *
-     * Execution Behaviour ========= ========= 1 SUCCESS 2 RunTimeException 3 RunTimeException 4 RunTimeException 5
+     * Execution Behaviour ========= ========= 1 SUCCESS 2 TestException 3 TestException 4 TestException 5
      * CircuitBreakerOpenException Pause for longer than CircuitBreaker delay, so that it transitions to half-open 6
      * SUCCEED (CircuitBreaker will be re-closed as successThreshold is 1. The impact of the success of the service and
      * the closure of the Circuit is to reset the rolling failure window to an empty state. Therefore another 4 requests
-     * need to be made - of which at least 3 need to fail - for the Circuit to open again) 7 SUCCESS 8 RunTimeException
-     * 9 RunTimeException 10 RuntimeException 11 CircuitBreakerOpenException
+     * need to be made - of which at least 3 need to fail - for the Circuit to open again) 7 SUCCESS 8 TestException 9
+     * TestException 10 TestException 11 CircuitBreakerOpenException
      *
      */
     @Test
@@ -97,15 +99,15 @@ public class CircuitBreakerInitialSuccessTest extends Arquillian {
                         e.printStackTrace();
                     }
                 }
-            } catch (RuntimeException ex) {
+            } catch (TestException ex) {
                 // Expected
                 if (!contains(new int[]{2, 3, 4, 8, 9, 10}, i)) {
-                    Assert.fail("serviceA should not throw a RuntimeException on iteration " + i);
+                    Assert.fail("serviceA should not throw a TestException on iteration " + i);
                 }
             } catch (Exception ex) {
                 // Not Expected
                 Assert.fail(
-                        "serviceA should throw a RuntimeException or CircuitBreakerOpenException in testCircuitDefaultSuccessThreshold "
+                        "serviceA should throw a TestException or CircuitBreakerOpenException in testCircuitDefaultSuccessThreshold "
                                 + "on iteration " + i);
             }
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerLateSuccessTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerLateSuccessTest.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 import static org.eclipse.microprofile.fault.tolerance.tck.Misc.Ints.contains;
 
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientDefaultSuccessThreshold;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -49,7 +50,8 @@ public class CircuitBreakerLateSuccessTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftCircuitBreakerLateSuccess.jar")
                 .addClasses(CircuitBreakerClientDefaultSuccessThreshold.class,
-                        Misc.class)
+                        Misc.class,
+                        TestException.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);
 
@@ -99,10 +101,10 @@ public class CircuitBreakerLateSuccessTest extends Arquillian {
                         e.printStackTrace();
                     }
                 }
-            } catch (RuntimeException ex) {
+            } catch (TestException ex) {
                 // Expected
                 if (!contains(new int[]{1, 2, 3, 7, 8, 9}, i)) {
-                    Assert.fail("serviceA should not throw a RuntimeException on iteration " + i);
+                    Assert.fail("serviceA should not throw a RuntimeException on iteration " + i, ex);
                 }
             } catch (Exception ex) {
                 // Not Expected

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/CircuitBreakerRetryTest.java
@@ -81,7 +81,8 @@ public class CircuitBreakerRetryTest extends Arquillian {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftCircuitBreakerRetry.jar")
                 .addClasses(CircuitBreakerClientWithRetry.class,
                         CircuitBreakerClassLevelClientWithRetry.class,
-                        CircuitBreakerClientWithRetryAsync.class)
+                        CircuitBreakerClientWithRetryAsync.class,
+                        TestException.class)
                 .addPackage(Packages.UTILS)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsManifestResource(config, "microprofile-config.properties")
@@ -128,7 +129,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
 
     /**
      * A test to exercise Circuit Breaker thresholds with insufficient retries to open the Circuit so that the Circuit
-     * remains closed and a RuntimeException is caught.
+     * remains closed and a TestException is caught.
      */
     @Test
     public void testCircuitOpenWithFewRetries() {
@@ -145,10 +146,10 @@ public class CircuitBreakerRetryTest extends Arquillian {
             // Not Expected
             invokeCounter = clientForCBWithRetry.getCounterForInvokingServiceB();
             Assert.fail(
-                    "serviceB should retry or throw a RuntimeException (not a CBOE) in testCircuitOpenWithFewRetries on iteration "
+                    "serviceB should retry or throw a TestException (not a CBOE) in testCircuitOpenWithFewRetries on iteration "
                             + invokeCounter);
 
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Expected on iteration 3
             invokeCounter = clientForCBWithRetry.getCounterForInvokingServiceB();
             if (invokeCounter < 3) {
@@ -159,7 +160,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
             // Not Expected
             invokeCounter = clientForCBWithRetry.getCounterForInvokingServiceB();
             Assert.fail(
-                    "serviceB should retry or throw a RuntimeException in testCircuitOpenWithFewRetries on iteration "
+                    "serviceB should retry or throw a TestException in testCircuitOpenWithFewRetries on iteration "
                             + invokeCounter);
         }
 
@@ -220,10 +221,10 @@ public class CircuitBreakerRetryTest extends Arquillian {
             // Not Expected
             invokeCounter = clientForClassLevelCBWithRetry.getCounterForInvokingServiceB();
             Assert.fail(
-                    "serviceB should retry or throw a RuntimeException (not a CBOE) in testClassLevelCircuitOpenWithFewRetries on iteration "
+                    "serviceB should retry or throw a TestException (not a CBOE) in testClassLevelCircuitOpenWithFewRetries on iteration "
                             + invokeCounter);
 
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Expected on iteration 3
             invokeCounter = clientForClassLevelCBWithRetry.getCounterForInvokingServiceB();
             if (invokeCounter < 3) {
@@ -234,7 +235,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
             // Not Expected
             invokeCounter = clientForClassLevelCBWithRetry.getCounterForInvokingServiceB();
             Assert.fail(
-                    "serviceB should retry or throw a RuntimeException in testClassLevelCircuitOpenWithFewRetries on iteration "
+                    "serviceB should retry or throw a TestException in testClassLevelCircuitOpenWithFewRetries on iteration "
                             + invokeCounter);
         }
 
@@ -407,7 +408,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
 
     /**
      * A test to exercise Circuit Breaker thresholds with insufficient retries to open the Circuit so that the Circuit
-     * remains closed and a RuntimeException is caught when using an Asynchronous call.
+     * remains closed and a TestException is caught when using an Asynchronous call.
      */
     @Test
     public void testCircuitOpenWithFewRetriesAsync() {
@@ -437,7 +438,7 @@ public class CircuitBreakerRetryTest extends Arquillian {
             // Not Expected
             invokeCounter = clientForCBWithRetryAsync.getCounterForInvokingServiceB();
             Assert.fail(
-                    "serviceB should retry or throw a RuntimeException in testCircuitOpenWithFewRetries on iteration "
+                    "serviceB should retry or throw a TestException in testCircuitOpenWithFewRetries on iteration "
                             + invokeCounter);
         }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/ConfigTest.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 import org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClassLevelClient;
 import org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClassLevelMaxDurationClient;
 import org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClient;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -53,7 +54,8 @@ public class ConfigTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftConfig.jar")
-                .addClasses(ConfigClient.class, ConfigClassLevelClient.class, ConfigClassLevelMaxDurationClient.class)
+                .addClasses(ConfigClient.class, ConfigClassLevelClient.class, ConfigClassLevelMaxDurationClient.class,
+                        TestException.class)
                 .addAsManifestResource(new StringAsset(
                         "org.eclipse.microprofile.fault.tolerance.tck.config.clientserver.ConfigClient/serviceA/Retry/maxRetries=3"
                                 +
@@ -86,8 +88,8 @@ public class ConfigTest extends Arquillian {
         try {
             clientForConfig.serviceA();
 
-            Assert.fail("serviceA should throw a RuntimeException in testConfigMaxRetries");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceA should throw a TestException in testConfigMaxRetries");
+        } catch (TestException ex) {
             // Expected
         }
         int count = clientForConfig.getCounterForInvokingConnectionService();
@@ -108,8 +110,8 @@ public class ConfigTest extends Arquillian {
         try {
             clientForClassLevelConfig.serviceA();
 
-            Assert.fail("serviceA should throw a RuntimeException in testClassLevelConfigMaxRetries");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceA should throw a TestException in testClassLevelConfigMaxRetries");
+        } catch (TestException ex) {
             // Expected
         }
         int count = clientForClassLevelConfig.getCounterForInvokingConnectionService();
@@ -130,8 +132,8 @@ public class ConfigTest extends Arquillian {
         try {
             clientForClassLevelConfig.serviceB();
 
-            Assert.fail("serviceB should throw a RuntimeException in testClassLevelConfigMethodOverrideMaxRetries");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceB should throw a TestException in testClassLevelConfigMethodOverrideMaxRetries");
+        } catch (TestException ex) {
             // Expected
         }
         int count = clientForClassLevelConfig.getCounterForInvokingConnectionService();
@@ -151,8 +153,8 @@ public class ConfigTest extends Arquillian {
     public void testConfigMaxDuration() {
         try {
             clientForConfig.serviceC();
-            Assert.fail("serviceC should throw a RuntimeException in testConfigMaxDuration");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceC should throw a TestException in testConfigMaxDuration");
+        } catch (TestException ex) {
             // Expected
         }
 
@@ -177,8 +179,8 @@ public class ConfigTest extends Arquillian {
     public void testClassLevelConfigMaxDuration() {
         try {
             clientForClassLevelMaxDurationConfig.serviceA();
-            Assert.fail("serviceB should throw a RuntimeException in testClassLevelConfigMaxDuration");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceB should throw a TestException in testClassLevelConfigMaxDuration");
+        } catch (TestException ex) {
             // Expected
         }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/FallbackTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/FallbackTest.java
@@ -83,7 +83,7 @@ public class FallbackTest extends Arquillian {
             Assert.assertTrue(result.contains("serviceA"),
                     "The message should be \"fallback for serviceA\"");
         } catch (TestException ex) {
-            Assert.fail("serviceA should not throw a RuntimeException in testFallbackSuccess", ex);
+            Assert.fail("serviceA should not throw a TestException in testFallbackSuccess", ex);
         }
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceA(), 2,
                 "The execution count should be 2 (1 retry + 1)");
@@ -92,7 +92,7 @@ public class FallbackTest extends Arquillian {
             Assert.assertTrue(result.contains("serviceB"),
                     "The message should be \"fallback for serviceB\"");
         } catch (TestException ex) {
-            Assert.fail("serviceB should not throw a RuntimeException in testFallbackSuccess", ex);
+            Assert.fail("serviceB should not throw a TestException in testFallbackSuccess", ex);
         }
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceB(), 3,
                 "The execution count should be 3 (2 retries + 1)");
@@ -115,7 +115,7 @@ public class FallbackTest extends Arquillian {
             Assert.assertTrue(result.contains("34"),
                     "The message should be \"fallback for serviceA myBean.getCount()=34\"");
         } catch (TestException ex) {
-            Assert.fail("serviceA should not throw a RuntimeException in testFallbackWithBeanSuccess", ex);
+            Assert.fail("serviceA should not throw a TestException in testFallbackWithBeanSuccess", ex);
         }
         Assert.assertEquals(fallbackWithBeanClient.getCounterForInvokingServiceA(), 2,
                 "The execution count should be 2 (1 retry + 1)");
@@ -128,7 +128,7 @@ public class FallbackTest extends Arquillian {
             Assert.assertTrue(result.contains("35"),
                     "The message should be \"fallback for serviceB myBean.getCount()=35\"");
         } catch (TestException ex) {
-            Assert.fail("serviceB should not throw a RuntimeException in testFallbackWithBeanSuccess", ex);
+            Assert.fail("serviceB should not throw a TestException in testFallbackWithBeanSuccess", ex);
         }
         Assert.assertEquals(fallbackWithBeanClient.getCounterForInvokingServiceB(), 3,
                 "The execution count should be 3 (2 retries + 1)");
@@ -146,7 +146,7 @@ public class FallbackTest extends Arquillian {
             Assert.assertTrue(result.contains("serviceA"),
                     "The message should be \"fallback for serviceA\"");
         } catch (TestException ex) {
-            Assert.fail("serviceA should not throw a RuntimeException in testFallbackSuccess", ex);
+            Assert.fail("serviceA should not throw a TestException in testFallbackSuccess", ex);
         }
         Assert.assertEquals(fallbackClassLevelClient.getCounterForInvokingServiceA(), 2,
                 "The execution count should be 2 (1 retry + 1)");
@@ -158,7 +158,7 @@ public class FallbackTest extends Arquillian {
                     "The message should be " + TestException.class.getName());
 
         } catch (TestException ex) {
-            Assert.fail("serviceB should not throw a RuntimeException in testFallbackSuccess", ex);
+            Assert.fail("serviceB should not throw a TestException in testFallbackSuccess", ex);
         }
         Assert.assertEquals(fallbackClassLevelClient.getCounterForInvokingServiceB(), 3,
                 "The execution count should be 3 (2 retries + 1)");
@@ -181,7 +181,7 @@ public class FallbackTest extends Arquillian {
             Assert.fail("serviceC should not throw a TimeoutException in testFallbacktNoTimeout");
         } catch (TestException ex) {
             // Not expected
-            Assert.fail("serviceC should not throw a RuntimeException in testFallbacktNoTimeout", ex);
+            Assert.fail("serviceC should not throw a TestException in testFallbacktNoTimeout", ex);
         }
 
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceC(), 2,
@@ -205,7 +205,7 @@ public class FallbackTest extends Arquillian {
             Assert.fail("serviceC should not throw a TimeoutException in testFallbackTimeout");
         } catch (TestException ex) {
             // Not Expected
-            Assert.fail("serviceC should not throw a RuntimeException in testFallbackTimeout", ex);
+            Assert.fail("serviceC should not throw a TestException in testFallbackTimeout", ex);
         }
 
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceC(), 2,

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/FallbackTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/FallbackTest.java
@@ -27,6 +27,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.MyBean
 import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.SecondStringFallbackHandler;
 import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.StringFallbackHandler;
 import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.StringFallbackHandlerWithBean;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -59,7 +60,7 @@ public class FallbackTest extends Arquillian {
                         FallbackClassLevelClient.class, StringFallbackHandler.class,
                         SecondStringFallbackHandler.class,
                         StringFallbackHandlerWithBean.class, MyBean.class,
-                        FallbackOnlyClient.class)
+                        FallbackOnlyClient.class, TestException.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);
 
@@ -81,8 +82,8 @@ public class FallbackTest extends Arquillian {
             String result = fallbackClient.serviceA();
             Assert.assertTrue(result.contains("serviceA"),
                     "The message should be \"fallback for serviceA\"");
-        } catch (RuntimeException ex) {
-            Assert.fail("serviceA should not throw a RuntimeException in testFallbackSuccess");
+        } catch (TestException ex) {
+            Assert.fail("serviceA should not throw a RuntimeException in testFallbackSuccess", ex);
         }
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceA(), 2,
                 "The execution count should be 2 (1 retry + 1)");
@@ -90,8 +91,8 @@ public class FallbackTest extends Arquillian {
             String result = fallbackClient.serviceB();
             Assert.assertTrue(result.contains("serviceB"),
                     "The message should be \"fallback for serviceB\"");
-        } catch (RuntimeException ex) {
-            Assert.fail("serviceB should not throw a RuntimeException in testFallbackSuccess");
+        } catch (TestException ex) {
+            Assert.fail("serviceB should not throw a RuntimeException in testFallbackSuccess", ex);
         }
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceB(), 3,
                 "The execution count should be 3 (2 retries + 1)");
@@ -113,8 +114,8 @@ public class FallbackTest extends Arquillian {
             // MyBean should be injected to the fallbackA
             Assert.assertTrue(result.contains("34"),
                     "The message should be \"fallback for serviceA myBean.getCount()=34\"");
-        } catch (RuntimeException ex) {
-            Assert.fail("serviceA should not throw a RuntimeException in testFallbackWithBeanSuccess");
+        } catch (TestException ex) {
+            Assert.fail("serviceA should not throw a RuntimeException in testFallbackWithBeanSuccess", ex);
         }
         Assert.assertEquals(fallbackWithBeanClient.getCounterForInvokingServiceA(), 2,
                 "The execution count should be 2 (1 retry + 1)");
@@ -126,8 +127,8 @@ public class FallbackTest extends Arquillian {
             // so the same instance should be injected to the fallback handler
             Assert.assertTrue(result.contains("35"),
                     "The message should be \"fallback for serviceB myBean.getCount()=35\"");
-        } catch (RuntimeException ex) {
-            Assert.fail("serviceB should not throw a RuntimeException in testFallbackWithBeanSuccess");
+        } catch (TestException ex) {
+            Assert.fail("serviceB should not throw a RuntimeException in testFallbackWithBeanSuccess", ex);
         }
         Assert.assertEquals(fallbackWithBeanClient.getCounterForInvokingServiceB(), 3,
                 "The execution count should be 3 (2 retries + 1)");
@@ -144,8 +145,8 @@ public class FallbackTest extends Arquillian {
             String result = fallbackClassLevelClient.serviceA();
             Assert.assertTrue(result.contains("serviceA"),
                     "The message should be \"fallback for serviceA\"");
-        } catch (RuntimeException ex) {
-            Assert.fail("serviceA should not throw a RuntimeException in testFallbackSuccess");
+        } catch (TestException ex) {
+            Assert.fail("serviceA should not throw a RuntimeException in testFallbackSuccess", ex);
         }
         Assert.assertEquals(fallbackClassLevelClient.getCounterForInvokingServiceA(), 2,
                 "The execution count should be 2 (1 retry + 1)");
@@ -153,11 +154,11 @@ public class FallbackTest extends Arquillian {
             String result = fallbackClassLevelClient.serviceB();
             Assert.assertTrue(result.contains("second fallback for serviceB"),
                     "The message should be \"second fallback for serviceB\"");
-            Assert.assertTrue(result.contains(RuntimeException.class.getName()),
-                    "The message should be " + RuntimeException.class.getName());
+            Assert.assertTrue(result.contains(TestException.class.getName()),
+                    "The message should be " + TestException.class.getName());
 
-        } catch (RuntimeException ex) {
-            Assert.fail("serviceB should not throw a RuntimeException in testFallbackSuccess");
+        } catch (TestException ex) {
+            Assert.fail("serviceB should not throw a RuntimeException in testFallbackSuccess", ex);
         }
         Assert.assertEquals(fallbackClassLevelClient.getCounterForInvokingServiceB(), 3,
                 "The execution count should be 3 (2 retries + 1)");
@@ -178,9 +179,9 @@ public class FallbackTest extends Arquillian {
         } catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceC should not throw a TimeoutException in testFallbacktNoTimeout");
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not expected
-            Assert.fail("serviceC should not throw a RuntimeException in testFallbacktNoTimeout");
+            Assert.fail("serviceC should not throw a RuntimeException in testFallbacktNoTimeout", ex);
         }
 
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceC(), 2,
@@ -202,9 +203,9 @@ public class FallbackTest extends Arquillian {
         } catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceC should not throw a TimeoutException in testFallbackTimeout");
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not Expected
-            Assert.fail("serviceC should not throw a RuntimeException in testFallbackTimeout");
+            Assert.fail("serviceC should not throw a RuntimeException in testFallbackTimeout", ex);
         }
 
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceC(), 2,
@@ -224,8 +225,8 @@ public class FallbackTest extends Arquillian {
             String result = fallbackClient.serviceD();
             Assert.assertTrue(result.contains("method for serviceD"),
                     "The message should be \"fallback method for serviceD\"");
-        } catch (RuntimeException ex) {
-            Assert.fail("serviceD should not throw a RuntimeException in testFallbackMethodSuccess");
+        } catch (TestException ex) {
+            Assert.fail("serviceD should not throw a RuntimeException in testFallbackMethodSuccess", ex);
         }
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceD(), 2,
                 "The execution count should be 2 (1 retry + 1)");
@@ -245,8 +246,8 @@ public class FallbackTest extends Arquillian {
             String result = fallbackClient.serviceE("serviceE", 42);
             Assert.assertTrue(result.contains("method for serviceE"),
                     "The message should be \"fallback method for serviceE\"");
-        } catch (RuntimeException ex) {
-            Assert.fail("serviceE should not throw a RuntimeException in testFallbackMethodWithArgsSuccess");
+        } catch (TestException ex) {
+            Assert.fail("serviceE should not throw a RuntimeException in testFallbackMethodWithArgsSuccess", ex);
         }
         Assert.assertEquals(fallbackClient.getCounterForInvokingServiceE(), 2,
                 "The execution count should be 2 (1 retry + 1)");
@@ -264,8 +265,8 @@ public class FallbackTest extends Arquillian {
             String result = fallbackOnlyClient.serviceA();
             Assert.assertTrue(result.contains("serviceA"),
                     "The message should be \"fallback for serviceA\"");
-        } catch (RuntimeException ex) {
-            Assert.fail("serviceA should not throw a RuntimeException in testStandaloneClassLevelFallback");
+        } catch (TestException ex) {
+            Assert.fail("serviceA should not throw a RuntimeException in testStandaloneClassLevelFallback", ex);
         }
         Assert.assertEquals(fallbackOnlyClient.getCounterForInvokingServiceA(), 1,
                 "The getCounterForInvokingServiceA should be 1");
@@ -282,8 +283,8 @@ public class FallbackTest extends Arquillian {
             String result = fallbackOnlyClient.serviceB();
             Assert.assertTrue(result.contains("serviceB"),
                     "The message should be \"fallback method for serviceB\"");
-        } catch (RuntimeException ex) {
-            Assert.fail("serviceB should not throw a RuntimeException in testStandaloneMethodFallback");
+        } catch (TestException ex) {
+            Assert.fail("serviceB should not throw a RuntimeException in testStandaloneMethodFallback", ex);
         }
         Assert.assertEquals(fallbackOnlyClient.getCounterForInvokingServiceB(), 1,
                 "The getCounterForInvokingServiceB should be 1");

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryConditionTest.java
@@ -63,8 +63,8 @@ import jakarta.inject.Inject;
  */
 public class RetryConditionTest extends Arquillian {
 
-    private final static String SIMULATED_EXCEPTION_MESSAGE = "Simulated error";
-    private final static String SIMULATED_RUNTIME_EXCEPTION_MESSAGE = "Test Exception - Simulated error";
+    public final static String SIMULATED_EXCEPTION_MESSAGE = "Simulated error";
+    public final static String SIMULATED_RUNTIME_EXCEPTION_MESSAGE = "Test Exception - Simulated error";
 
     private @Inject RetryClientRetryOn clientForRetryOn;
     private @Inject RetryClientAbortOn clientForAbortOn;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTest.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClas
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientForMaxRetries;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientWithDelay;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.RetryClientWithNoDelayAndJitter;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -60,7 +61,8 @@ public class RetryTest extends Arquillian {
                 .addClasses(RetryClientForMaxRetries.class,
                         RetryClientWithDelay.class,
                         RetryClassLevelClientForMaxRetries.class,
-                        RetryClientWithNoDelayAndJitter.class)
+                        RetryClientWithNoDelayAndJitter.class,
+                        TestException.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsManifestResource(config, "microprofile-config.properties");
 
@@ -79,8 +81,8 @@ public class RetryTest extends Arquillian {
     public void testRetryMaxRetries() {
         try {
             clientForMaxRetry.serviceA();
-            Assert.fail("serviceA should throw a RuntimeException in testRetryMaxRetries");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceA should throw a TestException in testRetryMaxRetries");
+        } catch (TestException ex) {
             // Expected
         }
         Assert.assertEquals(clientForMaxRetry.getRetryCountForConnectionService(), 6,
@@ -91,8 +93,8 @@ public class RetryTest extends Arquillian {
     public void testRetryMaxDuration() {
         try {
             clientForMaxRetry.serviceB();
-            Assert.fail("serviceB should throw a RuntimeException in testRetryMaxDuration");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceB should throw a TestException in testRetryMaxDuration");
+        } catch (TestException ex) {
             // Expected
         }
 
@@ -106,8 +108,8 @@ public class RetryTest extends Arquillian {
     public void testRetryMaxDurationSeconds() {
         try {
             clientForMaxRetry.serviceC();
-            Assert.fail("serviceC should throw a RuntimeException in testRetryMaxDuration");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceC should throw a TestException in testRetryMaxDuration");
+        } catch (TestException ex) {
             // Expected
         }
 
@@ -122,8 +124,8 @@ public class RetryTest extends Arquillian {
     public void testRetryWithDelay() {
         try {
             clientForDelay.serviceA();
-            Assert.fail("serviceA should throw a RuntimeException in testRetryWithDelay");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceA should throw a TestException in testRetryWithDelay");
+        } catch (TestException ex) {
             // Expected
         }
 
@@ -144,8 +146,8 @@ public class RetryTest extends Arquillian {
     public void testRetryWithNoDelayAndJitter() {
         try {
             retryClientWithNoDelayAndJitter.serviceA();
-            Assert.fail("serviceA should throw a RuntimeException in testRetryWithDelay");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceA should throw a TestException in testRetryWithDelay");
+        } catch (TestException ex) {
             // Expected
         }
 
@@ -169,8 +171,8 @@ public class RetryTest extends Arquillian {
     public void testClassLevelRetryMaxRetries() {
         try {
             clientForClassLevelMaxRetry.serviceA();
-            Assert.fail("serviceA should throw a RuntimeException in testClassLevelRetryMaxRetries");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceA should throw a TestException in testClassLevelRetryMaxRetries");
+        } catch (TestException ex) {
             // Expected
         }
 
@@ -189,8 +191,8 @@ public class RetryTest extends Arquillian {
     public void testClassLevelRetryMaxDuration() {
         try {
             clientForClassLevelMaxRetry.serviceB();
-            Assert.fail("serviceB should throw a RuntimeException in testClassLevelRetryMaxDuration");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceB should throw a TestException in testClassLevelRetryMaxDuration");
+        } catch (TestException ex) {
             // Expected
         }
 
@@ -216,8 +218,8 @@ public class RetryTest extends Arquillian {
     public void testClassLevelRetryMaxDurationSeconds() {
         try {
             clientForClassLevelMaxRetry.serviceC();
-            Assert.fail("serviceC should throw a RuntimeException in testClassLevelRetryMaxDurationSeconds");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceC should throw a TestException in testClassLevelRetryMaxDurationSeconds");
+        } catch (TestException ex) {
             // Expected
         }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/RetryTimeoutTest.java
@@ -26,6 +26,7 @@ import static org.testng.Assert.fail;
 import org.eclipse.microprofile.fault.tolerance.tck.config.ConfigAnnotationAsset;
 import org.eclipse.microprofile.fault.tolerance.tck.retrytimeout.clientserver.RetryTimeoutClient;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -64,7 +65,7 @@ public class RetryTimeoutTest extends Arquillian {
 
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftRetryTimeout.jar")
-                .addClasses(RetryTimeoutClient.class)
+                .addClasses(RetryTimeoutClient.class, TestException.class)
                 .addAsManifestResource(config, "microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);
@@ -88,9 +89,9 @@ public class RetryTimeoutTest extends Arquillian {
             String result = clientForRetryTimeout.serviceA(config.getTimeoutInMillis(1000));
         } catch (TimeoutException ex) {
             // Expected
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not Expected
-            Assert.fail("serviceA should not throw a RuntimeException in testRetryTimeout");
+            Assert.fail("serviceA should not throw a RuntimeException in testRetryTimeout", ex);
         }
 
         Assert.assertEquals(clientForRetryTimeout.getCounterForInvokingServiceA(), 2,
@@ -112,7 +113,7 @@ public class RetryTimeoutTest extends Arquillian {
         } catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceA should not throw a TimeoutException in testRetrytNoTimeout");
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Expected
         }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutGlobalConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutGlobalConfigTest.java
@@ -20,6 +20,7 @@
 package org.eclipse.microprofile.fault.tolerance.tck;
 
 import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.TimeoutClient;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -44,7 +45,7 @@ public class TimeoutGlobalConfigTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftTimeout.jar")
-                .addClasses(TimeoutClient.class)
+                .addClasses(TimeoutClient.class, TestException.class)
                 .addAsManifestResource(new StringAsset(
                         "Timeout/value=200"), "microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);
@@ -64,9 +65,9 @@ public class TimeoutGlobalConfigTest extends Arquillian {
             Assert.fail("serviceA should throw a TimeoutException in testTimeout");
         } catch (TimeoutException ex) {
             // Expected
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not Expected
-            Assert.fail("serviceA should throw a TimeoutException in testTimeout not a RuntimeException");
+            Assert.fail("serviceA should throw a TimeoutException in testTimeout not a RuntimeException", ex);
         }
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutMethodConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutMethodConfigTest.java
@@ -20,6 +20,7 @@
 package org.eclipse.microprofile.fault.tolerance.tck;
 
 import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.TimeoutClient;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -44,7 +45,7 @@ public class TimeoutMethodConfigTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftTimeout.jar")
-                .addClasses(TimeoutClient.class)
+                .addClasses(TimeoutClient.class, TestException.class)
                 .addAsManifestResource(new StringAsset(
                         "org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.TimeoutClient/" +
                                 "serviceA/Timeout/value=200"),
@@ -66,9 +67,9 @@ public class TimeoutMethodConfigTest extends Arquillian {
             Assert.fail("serviceA should throw a TimeoutException in testTimeout");
         } catch (TimeoutException ex) {
             // Expected
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not Expected
-            Assert.fail("serviceA should throw a TimeoutException in testTimeout not a RuntimeException");
+            Assert.fail("serviceA should throw a TimeoutException in testTimeout not a RuntimeException", ex);
         }
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/TimeoutTest.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck;
 import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.DefaultTimeoutClient;
 import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.ShorterTimeoutClient;
 import org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver.TimeoutClient;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -50,7 +51,8 @@ public class TimeoutTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftTimeout.jar")
-                .addClasses(TimeoutClient.class, DefaultTimeoutClient.class, ShorterTimeoutClient.class)
+                .addClasses(TimeoutClient.class, DefaultTimeoutClient.class, ShorterTimeoutClient.class,
+                        TestException.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").as(JavaArchive.class);
 
         WebArchive war = ShrinkWrap.create(WebArchive.class, "ftTimeout.war").addAsLibrary(testJar);
@@ -69,9 +71,9 @@ public class TimeoutTest extends Arquillian {
             Assert.fail("serviceA should throw a TimeoutException in testTimeout");
         } catch (TimeoutException ex) {
             // Expected
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not Expected
-            Assert.fail("serviceA should throw a TimeoutException in testTimeout not a RuntimeException");
+            Assert.fail("serviceA should throw a TimeoutException in testTimeout not a RuntimeException", ex);
         }
     }
 
@@ -88,7 +90,7 @@ public class TimeoutTest extends Arquillian {
         } catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceB should throw a RuntimeException in testNoTimeout not a TimeoutException");
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Expected
         }
     }
@@ -104,9 +106,9 @@ public class TimeoutTest extends Arquillian {
             Assert.fail("serviceB should throw a TimeoutException in testGTDefaultTimeout");
         } catch (TimeoutException ex) {
             // Expected
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not Expected
-            Assert.fail("serviceB should throw a TimeoutException in testGTDefaultTimeout not a RuntimeException");
+            Assert.fail("serviceB should throw a TimeoutException in testGTDefaultTimeout not a RuntimeException", ex);
         }
     }
 
@@ -123,8 +125,9 @@ public class TimeoutTest extends Arquillian {
             Assert.fail("serviceB should throw a RuntimeException in testGTDefaultNoTimeout");
         } catch (TimeoutException ex) {
             // Not Expected
-            Assert.fail("serviceB should throw a RuntimeException in testGTDefaultNoTimeout not a TimeoutException");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceB should throw a RuntimeException in testGTDefaultNoTimeout not a TimeoutException",
+                    ex);
+        } catch (TestException ex) {
             // Expected
         }
     }
@@ -140,9 +143,9 @@ public class TimeoutTest extends Arquillian {
             Assert.fail("serviceC should throw a TimeoutException in testLTDefaultTimeout");
         } catch (TimeoutException ex) {
             // Expected
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not Expected
-            Assert.fail("serviceC should throw a TimeoutException in testLTDefaultTimeout not a RuntimeException");
+            Assert.fail("serviceC should throw a TimeoutException in testLTDefaultTimeout not a RuntimeException", ex);
         }
     }
 
@@ -158,8 +161,9 @@ public class TimeoutTest extends Arquillian {
             Assert.fail("serviceC should throw a RuntimeException in testLTDefaultNoTimeout");
         } catch (TimeoutException ex) {
             // Not Expected
-            Assert.fail("serviceC should throw a RuntimeException in testLTDefaultNoTimeout not a TimeoutException");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceC should throw a RuntimeException in testLTDefaultNoTimeout not a TimeoutException",
+                    ex);
+        } catch (TestException ex) {
             // Expected
         }
     }
@@ -176,9 +180,9 @@ public class TimeoutTest extends Arquillian {
             Assert.fail("serviceD should throw a TimeoutException in testSecondsTimeout");
         } catch (TimeoutException ex) {
             // Expected
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not Expected
-            Assert.fail("serviceD should throw a TimeoutException in testSecondsTimeout not a RuntimeException");
+            Assert.fail("serviceD should throw a TimeoutException in testSecondsTimeout not a RuntimeException", ex);
         }
     }
 
@@ -195,8 +199,8 @@ public class TimeoutTest extends Arquillian {
             Assert.fail("serviceD should throw a RuntimeException in testSecondsNoTimeout");
         } catch (TimeoutException ex) {
             // Not Expected
-            Assert.fail("serviceD should throw a RuntimeException in testSecondsNoTimeout not a TimeoutException");
-        } catch (RuntimeException ex) {
+            Assert.fail("serviceD should throw a RuntimeException in testSecondsNoTimeout not a TimeoutException", ex);
+        } catch (TestException ex) {
             // Expected
         }
     }
@@ -213,9 +217,9 @@ public class TimeoutTest extends Arquillian {
             Assert.fail("serviceA should throw a TimeoutException in testTimeout");
         } catch (TimeoutException ex) {
             // Expected
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not Expected
-            Assert.fail("serviceA should throw a TimeoutException in testTimeout not a RuntimeException");
+            Assert.fail("serviceA should throw a TimeoutException in testTimeout not a RuntimeException", ex);
         }
     }
 
@@ -233,7 +237,7 @@ public class TimeoutTest extends Arquillian {
         } catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceB should throw a RuntimeException in testNoTimeoutClassLevel not a TimeoutException");
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Expected
         }
     }
@@ -250,9 +254,9 @@ public class TimeoutTest extends Arquillian {
             Assert.fail("serviceB should throw a TimeoutException in testGTDefaultTimeout");
         } catch (TimeoutException ex) {
             // Expected
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not Expected
-            Assert.fail("serviceB should throw a TimeoutException in testGTDefaultTimeout not a RuntimeException");
+            Assert.fail("serviceB should throw a TimeoutException in testGTDefaultTimeout not a RuntimeException", ex);
         }
     }
 
@@ -270,7 +274,7 @@ public class TimeoutTest extends Arquillian {
         } catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceB should throw a RuntimeException in testGTDefaultNoTimeout not a TimeoutException");
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Expected
         }
     }
@@ -286,10 +290,11 @@ public class TimeoutTest extends Arquillian {
             Assert.fail("serviceA should throw a TimeoutException in testLTDefaultTimeoutClassLevel");
         } catch (TimeoutException ex) {
             // Expected
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not Expected
             Assert.fail(
-                    "serviceA should throw a TimeoutException in testLTDefaultTimeoutClassLevel not a RuntimeException");
+                    "serviceA should throw a TimeoutException in testLTDefaultTimeoutClassLevel not a RuntimeException",
+                    ex);
         }
     }
 
@@ -306,8 +311,9 @@ public class TimeoutTest extends Arquillian {
         } catch (TimeoutException ex) {
             // Not Expected
             Assert.fail(
-                    "serviceA should throw a RuntimeException in testLTDefaultNoTimeoutClassLevel not a TimeoutException");
-        } catch (RuntimeException ex) {
+                    "serviceA should throw a RuntimeException in testLTDefaultNoTimeoutClassLevel not a TimeoutException",
+                    ex);
+        } catch (TestException ex) {
             // Expected
         }
     }
@@ -324,10 +330,11 @@ public class TimeoutTest extends Arquillian {
             Assert.fail("serviceB should throw a TimeoutException in testGTShorterTimeoutOverride");
         } catch (TimeoutException ex) {
             // Expected
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Not Expected
             Assert.fail(
-                    "serviceB should throw a TimeoutException in testGTShorterTimeoutOverride not a RuntimeException");
+                    "serviceB should throw a TimeoutException in testGTShorterTimeoutOverride not a RuntimeException",
+                    ex);
         }
     }
 
@@ -345,8 +352,9 @@ public class TimeoutTest extends Arquillian {
         } catch (TimeoutException ex) {
             // Not Expected
             Assert.fail(
-                    "serviceB should throw a RuntimeException in testGTShorterNoTimeoutOverride not a TimeoutException");
-        } catch (RuntimeException ex) {
+                    "serviceB should throw a RuntimeException in testGTShorterNoTimeoutOverride not a TimeoutException",
+                    ex);
+        } catch (TestException ex) {
             // Expected
         }
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asyncretry/clientserver/AsyncRetryClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asyncretry/clientserver/AsyncRetryClient.java
@@ -9,7 +9,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest;
-
 /*
  *******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
@@ -84,7 +83,8 @@ public class AsyncRetryClient {
     public CompletionStage<String> serviceBFailExceptionally(final CompletionStage future) {
         countInvocationsServBFailExceptionally++;
         // always fail
-        future.toCompletableFuture().completeExceptionally(new IOException(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE));
+        future.toCompletableFuture()
+                .completeExceptionally(new IOException(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE));
         return future;
     }
 
@@ -135,7 +135,8 @@ public class AsyncRetryClient {
         if (countInvocationsServD < 3) {
             // fail 2 first invocations
             return CompletableFuture.supplyAsync(doTask(null), executor)
-                    .thenCompose(s -> CompletableFuture.supplyAsync(doTask(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE), executor));
+                    .thenCompose(s -> CompletableFuture
+                            .supplyAsync(doTask(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE), executor));
         } else {
             return CompletableFuture.supplyAsync(doTask(null), executor)
                     .thenCompose(s -> CompletableFuture.supplyAsync(doTask(null), executor));
@@ -155,7 +156,8 @@ public class AsyncRetryClient {
 
         // always fail
         return CompletableFuture.supplyAsync(doTask(null), executor)
-                .thenCompose(s -> CompletableFuture.supplyAsync(doTask(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE), executor));
+                .thenCompose(s -> CompletableFuture.supplyAsync(doTask(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE),
+                        executor));
     }
 
     /**
@@ -172,7 +174,9 @@ public class AsyncRetryClient {
         if (countInvocationsServF < 3) {
             // fail 2 first invocations
             return CompletableFuture.supplyAsync(doTask(null), executor)
-                    .thenCombine(CompletableFuture.supplyAsync(doTask(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE), executor),
+                    .thenCombine(
+                            CompletableFuture.supplyAsync(doTask(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE),
+                                    executor),
                             (s, s2) -> s + " then " + s2);
         } else {
             return CompletableFuture.supplyAsync(doTask(null), executor)
@@ -194,7 +198,8 @@ public class AsyncRetryClient {
         countInvocationsServG++;
         // always fail
         return CompletableFuture.supplyAsync(doTask(null), executor)
-                .thenCombine(CompletableFuture.supplyAsync(doTask(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE), executor),
+                .thenCombine(
+                        CompletableFuture.supplyAsync(doTask(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE), executor),
                         (s, s2) -> s + " then " + s2);
 
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asyncretry/clientserver/AsyncRetryClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asyncretry/clientserver/AsyncRetryClient.java
@@ -29,6 +29,7 @@ import java.util.function.Supplier;
  *******************************************************************************/
 import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCallerExecutor;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
@@ -94,7 +95,7 @@ public class AsyncRetryClient {
     public CompletionStage<String> serviceBFailException(final CompletionStage future) {
         countInvocationsServBFailException++;
         // always fail
-        throw new RuntimeException("Simulated error");
+        throw new TestException("Simulated error");
     }
 
     /**
@@ -207,7 +208,7 @@ public class AsyncRetryClient {
         countInvocationsServH++;
         // fails twice
         if (countInvocationsServH < 3) {
-            throw new RuntimeException("Simulated error");
+            throw new TestException("Simulated error");
         }
 
         CompletableFuture<String> future = new CompletableFuture<>();
@@ -257,10 +258,10 @@ public class AsyncRetryClient {
                 // simulate some processing.
                 TimeUnit.MILLISECONDS.sleep(config.getTimeoutInMillis(50));
             } catch (InterruptedException e) {
-                throw new RuntimeException("Unplanned error: " + e);
+                throw new TestException("Unplanned error: " + e);
             }
             if (nonNull(errorMessage)) {
-                throw new RuntimeException(errorMessage);
+                throw new TestException(errorMessage);
             } else {
                 return "Success";
             }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asyncretry/clientserver/AsyncRetryClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/asyncretry/clientserver/AsyncRetryClient.java
@@ -8,6 +8,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import org.eclipse.microprofile.fault.tolerance.tck.RetryConditionTest;
+
 /*
  *******************************************************************************
  * Copyright (c) 2018 Contributors to the Eclipse Foundation
@@ -69,7 +71,7 @@ public class AsyncRetryClient {
         countInvocationsServA++;
         // always fail
         CompletableFuture<String> future = new CompletableFuture<>();
-        future.completeExceptionally(new IOException("Simulated error"));
+        future.completeExceptionally(new IOException(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE));
         return future;
     }
 
@@ -82,7 +84,7 @@ public class AsyncRetryClient {
     public CompletionStage<String> serviceBFailExceptionally(final CompletionStage future) {
         countInvocationsServBFailExceptionally++;
         // always fail
-        future.toCompletableFuture().completeExceptionally(new IOException("Simulated error"));
+        future.toCompletableFuture().completeExceptionally(new IOException(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE));
         return future;
     }
 
@@ -95,7 +97,7 @@ public class AsyncRetryClient {
     public CompletionStage<String> serviceBFailException(final CompletionStage future) {
         countInvocationsServBFailException++;
         // always fail
-        throw new TestException("Simulated error");
+        throw new TestException(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -112,7 +114,7 @@ public class AsyncRetryClient {
 
         if (countInvocationsServC < 3) {
             // fail 2 first invocations
-            future.completeExceptionally(new IOException("Simulated error"));
+            future.completeExceptionally(new IOException(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE));
         } else {
             future.complete("Success");
         }
@@ -133,7 +135,7 @@ public class AsyncRetryClient {
         if (countInvocationsServD < 3) {
             // fail 2 first invocations
             return CompletableFuture.supplyAsync(doTask(null), executor)
-                    .thenCompose(s -> CompletableFuture.supplyAsync(doTask("Simulated error"), executor));
+                    .thenCompose(s -> CompletableFuture.supplyAsync(doTask(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE), executor));
         } else {
             return CompletableFuture.supplyAsync(doTask(null), executor)
                     .thenCompose(s -> CompletableFuture.supplyAsync(doTask(null), executor));
@@ -153,7 +155,7 @@ public class AsyncRetryClient {
 
         // always fail
         return CompletableFuture.supplyAsync(doTask(null), executor)
-                .thenCompose(s -> CompletableFuture.supplyAsync(doTask("Simulated error"), executor));
+                .thenCompose(s -> CompletableFuture.supplyAsync(doTask(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE), executor));
     }
 
     /**
@@ -170,7 +172,7 @@ public class AsyncRetryClient {
         if (countInvocationsServF < 3) {
             // fail 2 first invocations
             return CompletableFuture.supplyAsync(doTask(null), executor)
-                    .thenCombine(CompletableFuture.supplyAsync(doTask("Simulated error"), executor),
+                    .thenCombine(CompletableFuture.supplyAsync(doTask(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE), executor),
                             (s, s2) -> s + " then " + s2);
         } else {
             return CompletableFuture.supplyAsync(doTask(null), executor)
@@ -192,7 +194,7 @@ public class AsyncRetryClient {
         countInvocationsServG++;
         // always fail
         return CompletableFuture.supplyAsync(doTask(null), executor)
-                .thenCombine(CompletableFuture.supplyAsync(doTask("Simulated error"), executor),
+                .thenCombine(CompletableFuture.supplyAsync(doTask(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE), executor),
                         (s, s2) -> s + " then " + s2);
 
     }
@@ -208,7 +210,7 @@ public class AsyncRetryClient {
         countInvocationsServH++;
         // fails twice
         if (countInvocationsServH < 3) {
-            throw new TestException("Simulated error");
+            throw new TestException(RetryConditionTest.SIMULATED_EXCEPTION_MESSAGE);
         }
 
         CompletableFuture<String> future = new CompletableFuture<>();

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/CircuitBreakerConfigGlobalTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/CircuitBreakerConfigGlobalTest.java
@@ -23,6 +23,7 @@ import static org.eclipse.microprofile.fault.tolerance.tck.Misc.Ints.contains;
 
 import org.eclipse.microprofile.fault.tolerance.tck.Misc;
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientDefaultSuccessThreshold;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -48,7 +49,8 @@ public class CircuitBreakerConfigGlobalTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftCircuitBreaker.jar")
                 .addClasses(CircuitBreakerClientDefaultSuccessThreshold.class,
-                        Misc.class)
+                        Misc.class,
+                        TestException.class)
                 .addAsManifestResource(new StringAsset(
                         "CircuitBreaker/delay=200"), "microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
@@ -88,15 +90,15 @@ public class CircuitBreakerConfigGlobalTest extends Arquillian {
                         e.printStackTrace();
                     }
                 }
-            } catch (RuntimeException ex) {
+            } catch (TestException ex) {
                 // Expected
                 if (!contains(new int[]{1, 2, 3, 4, 7, 8, 9, 10}, i)) {
-                    Assert.fail("serviceA should not throw a RuntimeException on iteration " + i);
+                    Assert.fail("serviceA should not throw a TestException on iteration " + i);
                 }
             } catch (Exception ex) {
                 // Not Expected
                 Assert.fail(
-                        "serviceA should throw a RuntimeException or CircuitBreakerOpenException in testCircuitDefaultSuccessThreshold "
+                        "serviceA should throw a TestException or CircuitBreakerOpenException in testCircuitDefaultSuccessThreshold "
                                 + "on iteration " + i);
             }
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/CircuitBreakerConfigOnMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/CircuitBreakerConfigOnMethodTest.java
@@ -23,6 +23,7 @@ import static org.eclipse.microprofile.fault.tolerance.tck.Misc.Ints.contains;
 
 import org.eclipse.microprofile.fault.tolerance.tck.Misc;
 import org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver.CircuitBreakerClientDefaultSuccessThreshold;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -48,7 +49,8 @@ public class CircuitBreakerConfigOnMethodTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap.create(JavaArchive.class, "ftCircuitBreaker.jar")
                 .addClasses(CircuitBreakerClientDefaultSuccessThreshold.class,
-                        Misc.class)
+                        Misc.class,
+                        TestException.class)
                 .addAsManifestResource(new StringAsset(
                         "org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker" +
                                 ".clientserver.CircuitBreakerClientDefaultSuccessThreshold/serviceA/CircuitBreaker/delay=200"),
@@ -89,15 +91,15 @@ public class CircuitBreakerConfigOnMethodTest extends Arquillian {
                         e.printStackTrace();
                     }
                 }
-            } catch (RuntimeException ex) {
+            } catch (TestException ex) {
                 // Expected
                 if (!contains(new int[]{1, 2, 3, 4, 7, 8, 9, 10}, i)) {
-                    Assert.fail("serviceA should not throw a RuntimeException on iteration " + i);
+                    Assert.fail("serviceA should not throw a TestException on iteration " + i);
                 }
             } catch (Exception ex) {
                 // Not Expected
                 Assert.fail(
-                        "serviceA should throw a RuntimeException or CircuitBreakerOpenException in testCircuitDefaultSuccessThreshold "
+                        "serviceA should throw a TestException or CircuitBreakerOpenException in testCircuitDefaultSuccessThreshold "
                                 + "on iteration " + i);
             }
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClassLevelClientWithDelay.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClassLevelClientWithDelay.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver
 import java.io.Serializable;
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -88,7 +89,7 @@ public class CircuitBreakerClassLevelClientWithDelay implements Serializable {
     // simulate a backend service
     private Connection connectionService() {
         if (counterForInvokingService < 5) {
-            throw new RuntimeException("Connection failed");
+            throw new TestException("Connection failed");
         }
         return null;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClassLevelClientWithRetry.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClassLevelClientWithRetry.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver
 import java.io.Serializable;
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
@@ -67,6 +68,6 @@ public class CircuitBreakerClassLevelClientWithRetry implements Serializable {
 
     // simulate a backend service
     private Connection connectionService() {
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientDefaultSuccessThreshold.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientDefaultSuccessThreshold.java
@@ -24,6 +24,7 @@ import static org.eclipse.microprofile.fault.tolerance.tck.Misc.Ints.contains;
 import java.io.Serializable;
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -60,7 +61,7 @@ public class CircuitBreakerClientDefaultSuccessThreshold implements Serializable
     private Connection connectionService(int[] successSet) {
         // Determine if execution succeeds
         if (!contains(successSet, counterForInvokingServiceA)) {
-            throw new RuntimeException("Connection failed");
+            throw new TestException("Connection failed");
         }
 
         return null;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientHigherSuccessThreshold.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientHigherSuccessThreshold.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver
 import java.io.Serializable;
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -57,7 +58,7 @@ public class CircuitBreakerClientHigherSuccessThreshold implements Serializable 
     // simulate a backend service
     private Connection connectionService() {
         if (counterForInvokingServiceA < 5 || counterForInvokingServiceA > 6) {
-            throw new RuntimeException("Connection failed");
+            throw new TestException("Connection failed");
         }
 
         return null;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientNoDelay.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientNoDelay.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver
 import java.io.Serializable;
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -56,7 +57,7 @@ public class CircuitBreakerClientNoDelay implements Serializable {
     // simulate a backend service
     private Connection connectionService() {
         if (counterForInvokingServiceA < 5) {
-            throw new RuntimeException("Connection failed");
+            throw new TestException("Connection failed");
         }
         return null;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientRollingWindow.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientRollingWindow.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver
 import java.io.Serializable;
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -60,7 +61,7 @@ public class CircuitBreakerClientRollingWindow implements Serializable {
     // Throw exception for the 2nd and 3rd request.
     private Connection connectionService1() {
         if ((counterForInvokingService1 == 2) || (counterForInvokingService1 == 3)) {
-            throw new RuntimeException("Connection failed");
+            throw new TestException("Connection failed");
         }
         return null;
 
@@ -80,7 +81,7 @@ public class CircuitBreakerClientRollingWindow implements Serializable {
     // Throw exception for the 2nd and 5th request.
     private Connection connectionService2() {
         if ((counterForInvokingService2 == 2) || (counterForInvokingService2 == 5)) {
-            throw new RuntimeException("Connection failed");
+            throw new TestException("Connection failed");
         }
         return null;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithDelay.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithDelay.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.circuitbreaker.clientserver
 import java.io.Serializable;
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -58,7 +59,7 @@ public class CircuitBreakerClientWithDelay implements Serializable {
     // simulate a backend service
     private Connection connectionService() {
         if (counterForInvokingServiceA < 5) {
-            throw new RuntimeException("Connection failed");
+            throw new TestException("Connection failed");
         }
         return null;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithRetry.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithRetry.java
@@ -57,7 +57,7 @@ public class CircuitBreakerClientWithRetry implements Serializable {
     }
 
     @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 4, failureRatio = 0.75, delay = 50000)
-    @Retry(retryOn = {RuntimeException.class}, maxRetries = 7)
+    @Retry(retryOn = {TestException.class}, maxRetries = 7)
     public Connection serviceA() {
         Connection conn = null;
         counterForInvokingServiceA++;
@@ -66,7 +66,7 @@ public class CircuitBreakerClientWithRetry implements Serializable {
     }
 
     @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 4, failureRatio = 0.75, delay = 50000)
-    @Retry(retryOn = {RuntimeException.class}, maxRetries = 2)
+    @Retry(retryOn = {TestException.class}, maxRetries = 2)
     public Connection serviceB() {
         Connection conn = null;
         counterForInvokingServiceB++;
@@ -78,7 +78,7 @@ public class CircuitBreakerClientWithRetry implements Serializable {
      * Configured to always time out and Retry until CircuitBreaker is triggered on 4th call.
      */
     @CircuitBreaker(successThreshold = 2, requestVolumeThreshold = 4, failureRatio = 0.75, delay = 50000)
-    @Retry(retryOn = {RuntimeException.class, TimeoutException.class}, maxRetries = 7, maxDuration = 20000)
+    @Retry(retryOn = {TestException.class, TimeoutException.class}, maxRetries = 7, maxDuration = 20000)
     @Timeout(100) // Scaled via config
     public Connection serviceC() {
         Connection conn = null;
@@ -86,7 +86,7 @@ public class CircuitBreakerClientWithRetry implements Serializable {
 
         try {
             Thread.sleep(TCKConfig.getConfig().getTimeoutInMillis(5000));
-            throw new RuntimeException("Timeout did not interrupt");
+            throw new TestException("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }
@@ -151,6 +151,6 @@ public class CircuitBreakerClientWithRetry implements Serializable {
 
     // simulate a backend service
     private Connection connectionService() {
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithRetryAsync.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithRetryAsync.java
@@ -32,6 +32,7 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.faulttolerance.exceptions.CircuitBreakerOpenException;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
+import org.testng.Assert;
 
 import jakarta.enterprise.context.RequestScoped;
 
@@ -94,7 +95,7 @@ public class CircuitBreakerClientWithRetryAsync implements Serializable {
 
         try {
             Thread.sleep(TCKConfig.getConfig().getTimeoutInMillis(5000));
-            throw new TestException("Timeout did not interrupt");
+            Assert.fail("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithRetryAsync.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/circuitbreaker/clientserver/CircuitBreakerClientWithRetryAsync.java
@@ -94,7 +94,7 @@ public class CircuitBreakerClientWithRetryAsync implements Serializable {
 
         try {
             Thread.sleep(TCKConfig.getConfig().getTimeoutInMillis(5000));
-            throw new RuntimeException("Timeout did not interrupt");
+            throw new TestException("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }
@@ -105,7 +105,7 @@ public class CircuitBreakerClientWithRetryAsync implements Serializable {
      * Has a CircuitBreaker and Retries on CircuitBreakerOpenException
      * 
      * @param throwException
-     *            whether this method should throw a runtime exception to simulate an application failure
+     *            whether this method should throw a test exception to simulate an application failure
      * @return string "OK"
      */
     @CircuitBreaker(requestVolumeThreshold = 4, failureRatio = 0.75, delay = 1000)

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/clientserver/ConfigClassLevelClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/clientserver/ConfigClassLevelClient.java
@@ -21,6 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.config.clientserver;
 
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -60,7 +61,7 @@ public class ConfigClassLevelClient {
 
     private Connection connectionService() {
         counterForInvokingConnenectionService++;
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
     public int getCounterForInvokingConnectionService() {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/clientserver/ConfigClassLevelMaxDurationClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/clientserver/ConfigClassLevelMaxDurationClient.java
@@ -19,6 +19,7 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.config.clientserver;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -48,7 +49,7 @@ public class ConfigClassLevelMaxDurationClient {
         counterForInvokingWritingService++;
         try {
             Thread.sleep(100);
-            throw new RuntimeException("WritingService failed");
+            throw new TestException("WritingService failed");
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/clientserver/ConfigClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/config/clientserver/ConfigClient.java
@@ -21,6 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.config.clientserver;
 
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -54,7 +55,7 @@ public class ConfigClient {
 
     private Connection connectionService() {
         counterForInvokingConnenectionService++;
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
     public int getCounterForInvokingConnectionService() {
@@ -65,7 +66,7 @@ public class ConfigClient {
         counterForInvokingWritingService++;
         try {
             Thread.sleep(100);
-            throw new RuntimeException("WritingService failed");
+            throw new TestException("WritingService failed");
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableClient.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
 import java.sql.Connection;
 
 import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.StringFallbackHandler;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.CircuitBreaker;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
@@ -93,7 +94,7 @@ public class DisableClient {
     public Connection serviceD(long timeToSleep) {
         try {
             Thread.sleep(timeToSleep);
-            throw new RuntimeException("Timeout did not interrupt");
+            throw new TestException("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }
@@ -101,12 +102,12 @@ public class DisableClient {
     }
 
     private String nameService() {
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
     private Connection connectionService() {
         counterForInvokingConnenectionService++;
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
     public int getRetryCountForConnectionService() {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableTest.java
@@ -20,6 +20,7 @@
 package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
 
 import org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver.StringFallbackHandler;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.exceptions.TimeoutException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -51,7 +52,7 @@ public class DisableTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftDisableAllButFallback.jar")
-                .addClasses(DisableClient.class, StringFallbackHandler.class)
+                .addClasses(DisableClient.class, StringFallbackHandler.class, TestException.class)
                 .addAsManifestResource(new StringAsset("MP_Fault_Tolerance_NonFallback_Enabled=false"),
                         "microprofile-config.properties")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
@@ -75,7 +76,7 @@ public class DisableTest extends Arquillian {
         try {
             disableClient.serviceA();
             Assert.fail("serviceA should throw a RuntimeException in testRetryDisabled");
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Expected
         }
         Assert.assertEquals(disableClient.getRetryCountForConnectionService(), 1,
@@ -98,8 +99,8 @@ public class DisableTest extends Arquillian {
             System.out.println("testFallbackSuccess got result - " + result);
             Assert.assertTrue(result.contains("serviceB"),
                     "The message should be \"fallback for serviceB\"");
-        } catch (RuntimeException ex) {
-            Assert.fail("serviceB should not throw a RuntimeException in testFallbackSuccess");
+        } catch (TestException ex) {
+            Assert.fail("serviceB should not throw a RuntimeException in testFallbackSuccess", ex);
         }
         Assert.assertEquals(disableClient.getCounterForInvokingServiceB(), 1,
                 "The execution count should be 1 (0 retries + 1)");
@@ -118,7 +119,7 @@ public class DisableTest extends Arquillian {
 
             try {
                 disableClient.serviceC();
-            } catch (RuntimeException ex) {
+            } catch (TestException ex) {
                 // Expected
             } catch (Exception ex) {
                 // Not Expected
@@ -148,7 +149,7 @@ public class DisableTest extends Arquillian {
         } catch (TimeoutException ex) {
             // Not Expected
             Assert.fail("serviceD should throw a RuntimeException in testTimeout not a TimeoutException");
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             // Expected
         }
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackClassLevelClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackClassLevelClient.java
@@ -19,6 +19,7 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
@@ -58,7 +59,7 @@ public class FallbackClassLevelClient {
     }
 
     private String nameService() {
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackClient.java
@@ -19,10 +19,10 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
-import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 import jakarta.enterprise.context.RequestScoped;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackClient.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 import jakarta.enterprise.context.RequestScoped;
 
@@ -111,7 +112,7 @@ public class FallbackClient {
     }
 
     private String nameService() {
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackOnlyClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackOnlyClient.java
@@ -19,8 +19,8 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver;
 
-import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
+import org.eclipse.microprofile.faulttolerance.Fallback;
 
 import jakarta.enterprise.context.RequestScoped;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackOnlyClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackOnlyClient.java
@@ -20,6 +20,7 @@
 package org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver;
 
 import org.eclipse.microprofile.faulttolerance.Fallback;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 import jakarta.enterprise.context.RequestScoped;
 
@@ -59,6 +60,6 @@ public class FallbackOnlyClient {
     }
 
     private String nameService() {
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackWithBeanClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackWithBeanClient.java
@@ -21,6 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver;
 
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 import jakarta.enterprise.context.RequestScoped;
 
@@ -59,7 +60,7 @@ public class FallbackWithBeanClient {
     }
 
     private String nameService() {
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackWithBeanClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/fallback/clientserver/FallbackWithBeanClient.java
@@ -19,9 +19,9 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.fallback.clientserver;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 import jakarta.enterprise.context.RequestScoped;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClassLevelClientAbortOn.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClassLevelClientAbortOn.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver;
 import java.io.IOException;
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -44,7 +45,7 @@ public class RetryClassLevelClientAbortOn {
 
     private Connection connectionService() {
         counterForInvokingConnenectionService++;
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
     public int getRetryCountForConnectionService() {
@@ -63,7 +64,7 @@ public class RetryClassLevelClientAbortOn {
         counterForInvokingWritingService++;
         try {
             Thread.sleep(100);
-            throw new RuntimeException("WritingService failed");
+            throw new TestException("WritingService failed");
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClassLevelClientAbortOn.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClassLevelClientAbortOn.java
@@ -55,7 +55,7 @@ public class RetryClassLevelClientAbortOn {
     /**
      * serviceB is configured to retry on a RuntimeException. The WritingService throws RuntimeExceptions.
      */
-    @Retry(abortOn = {RuntimeException.class})
+    @Retry(abortOn = {TestException.class})
     public void serviceB() {
         writingService();
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClassLevelClientForMaxRetries.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClassLevelClientForMaxRetries.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver;
 import java.sql.Connection;
 import java.time.temporal.ChronoUnit;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -48,7 +49,7 @@ public class RetryClassLevelClientForMaxRetries {
 
     private Connection connectionService() {
         counterForInvokingConnenectionService++;
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
     public int getRetryCountForConnectionService() {
@@ -81,7 +82,7 @@ public class RetryClassLevelClientForMaxRetries {
         counterForInvokingWritingService++;
         try {
             Thread.sleep(100);
-            throw new RuntimeException("WritingService failed");
+            throw new TestException("WritingService failed");
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClassLevelClientRetryOn.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClassLevelClientRetryOn.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver;
 import java.io.IOException;
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -33,7 +34,7 @@ import jakarta.enterprise.context.RequestScoped;
  *
  */
 @RequestScoped
-@Retry(retryOn = {RuntimeException.class}, maxRetries = 3)
+@Retry(retryOn = {TestException.class}, maxRetries = 3)
 public class RetryClassLevelClientRetryOn {
     private int counterForInvokingConnenectionService;
     private int counterForInvokingWritingService;
@@ -44,7 +45,7 @@ public class RetryClassLevelClientRetryOn {
 
     private Connection connectionService() {
         counterForInvokingConnenectionService++;
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
     public int getRetryCountForConnectionService() {
@@ -53,7 +54,7 @@ public class RetryClassLevelClientRetryOn {
 
     /**
      * serviceB is configured to retry on an IOException. In practice the only exception that will be thrown by the
-     * WritingService is a RuntimeException.
+     * WritingService is a TestException.
      */
     @Retry(retryOn = {IOException.class})
     public void serviceB() {
@@ -64,7 +65,7 @@ public class RetryClassLevelClientRetryOn {
         counterForInvokingWritingService++;
         try {
             Thread.sleep(100);
-            throw new RuntimeException("WritingService failed");
+            throw new TestException("WritingService failed");
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientAbortOn.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientAbortOn.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver;
 import java.io.IOException;
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -44,7 +45,7 @@ public class RetryClientAbortOn {
 
     private Connection connectionService() {
         counterForInvokingConnenectionService++;
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
     public int getRetryCountForConnectionService() {
@@ -52,9 +53,9 @@ public class RetryClientAbortOn {
     }
 
     /**
-     * serviceB is configured to retry on a RuntimeException. The WritingService throws RuntimeExceptions.
+     * serviceB is configured to retry on a TestException. The WritingService throws TestException.
      */
-    @Retry(abortOn = {RuntimeException.class})
+    @Retry(abortOn = {TestException.class})
     public void serviceB() {
         writingService();
     }
@@ -63,7 +64,7 @@ public class RetryClientAbortOn {
         counterForInvokingWritingService++;
         try {
             Thread.sleep(100);
-            throw new RuntimeException("WritingService failed");
+            throw new TestException("WritingService failed");
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientForMaxRetries.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientForMaxRetries.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver;
 import java.sql.Connection;
 import java.time.temporal.ChronoUnit;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -48,7 +49,7 @@ public class RetryClientForMaxRetries {
 
     private Connection connectionService() {
         counterForInvokingConnenectionService++;
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
     public int getRetryCountForConnectionService() {
@@ -81,7 +82,7 @@ public class RetryClientForMaxRetries {
         counterForInvokingWritingService++;
         try {
             Thread.sleep(100);
-            throw new RuntimeException("WritingService failed");
+            throw new TestException("WritingService failed");
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientRetryOn.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientRetryOn.java
@@ -24,6 +24,7 @@ import java.sql.Connection;
 
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.exceptions.RetryChildException;
 import org.eclipse.microprofile.fault.tolerance.tck.retry.clientserver.exceptions.RetryParentException;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -38,14 +39,14 @@ import jakarta.enterprise.context.RequestScoped;
 public class RetryClientRetryOn {
     private int counterForInvokingConnenectionService;
     private int counterForInvokingWritingService;
-    @Retry(retryOn = {RuntimeException.class})
+    @Retry(retryOn = {TestException.class})
     public Connection serviceA() {
         return connectionService();
     }
 
     private Connection connectionService() {
         counterForInvokingConnenectionService++;
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
     /**
@@ -88,7 +89,7 @@ public class RetryClientRetryOn {
         counterForInvokingWritingService++;
         try {
             Thread.sleep(100);
-            throw new RuntimeException("WritingService failed");
+            throw new TestException("WritingService failed");
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientWithDelay.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientWithDelay.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -65,7 +66,7 @@ public class RetryClientWithDelay {
         timestampForConnectionService = currentTime;
 
         counterForInvokingConnenectionService++;
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
     public void assertDelayInRange() {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientWithNoDelayAndJitter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retry/clientserver/RetryClientWithNoDelayAndJitter.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -58,7 +59,7 @@ public class RetryClientWithNoDelayAndJitter {
         timestampForConnectionService = currentTime;
 
         counterForInvokingConnectionService++;
-        throw new RuntimeException("Connection failed");
+        throw new TestException("Connection failed");
     }
 
     public int getRetryCountForConnectionService() {

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retrytimeout/clientserver/RetryTimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/retrytimeout/clientserver/RetryTimeoutClient.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.retrytimeout.clientserver;
 import static org.testng.Assert.fail;
 
 import org.eclipse.microprofile.fault.tolerance.tck.util.TCKConfig;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 import org.eclipse.microprofile.faulttolerance.exceptions.BulkheadException;
@@ -68,7 +69,7 @@ public class RetryTimeoutClient {
         try {
             counterForInvokingServiceA++;
             Thread.sleep(timeToSleep);
-            throw new RuntimeException("Timeout did not interrupt");
+            throw new TestException("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/DefaultTimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/DefaultTimeoutClient.java
@@ -21,6 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver;
 
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -45,7 +46,7 @@ public class DefaultTimeoutClient {
     public Connection serviceA(long timeToSleep) {
         try {
             Thread.sleep(timeToSleep);
-            throw new RuntimeException("Timeout did not interrupt");
+            throw new TestException("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }
@@ -63,7 +64,7 @@ public class DefaultTimeoutClient {
     public Connection serviceB(long timeToSleep) {
         try {
             Thread.sleep(timeToSleep);
-            throw new RuntimeException("Timeout did not interrupt");
+            throw new TestException("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/ShorterTimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/ShorterTimeoutClient.java
@@ -21,6 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver;
 
 import java.sql.Connection;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -45,7 +46,7 @@ public class ShorterTimeoutClient {
     public Connection serviceA(long timeToSleep) {
         try {
             Thread.sleep(timeToSleep);
-            throw new RuntimeException("Timeout did not interrupt");
+            throw new TestException("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }
@@ -63,7 +64,7 @@ public class ShorterTimeoutClient {
     public Connection serviceB(long timeToSleep) {
         try {
             Thread.sleep(timeToSleep);
-            throw new RuntimeException("Timeout did not interrupt");
+            throw new TestException("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/TimeoutClient.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/timeout/clientserver/TimeoutClient.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.timeout.clientserver;
 import java.sql.Connection;
 import java.time.temporal.ChronoUnit;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -46,7 +47,7 @@ public class TimeoutClient {
     public Connection serviceA(long timeToSleep) {
         try {
             Thread.sleep(timeToSleep);
-            throw new RuntimeException("Timeout did not interrupt");
+            throw new TestException("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }
@@ -64,7 +65,7 @@ public class TimeoutClient {
     public Connection serviceB(long timeToSleep) {
         try {
             Thread.sleep(timeToSleep);
-            throw new RuntimeException("Timeout did not interrupt");
+            throw new TestException("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }
@@ -82,7 +83,7 @@ public class TimeoutClient {
     public Connection serviceC(long timeToSleep) {
         try {
             Thread.sleep(timeToSleep);
-            throw new RuntimeException("Timeout did not interrupt");
+            throw new TestException("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }
@@ -100,7 +101,7 @@ public class TimeoutClient {
     public Connection serviceD(long timeToSleepInMillis) {
         try {
             Thread.sleep(timeToSleepInMillis);
-            throw new RuntimeException("Timeout did not interrupt");
+            throw new TestException("Timeout did not interrupt");
         } catch (InterruptedException e) {
             // expected
         }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/BaseRetryOnClassAndMethodService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/BaseRetryOnClassAndMethodService.java
@@ -21,8 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
 import java.sql.Connection;
 
-import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
+import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/BaseRetryOnClassAndMethodService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/BaseRetryOnClassAndMethodService.java
@@ -19,10 +19,10 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
 import java.sql.Connection;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 import jakarta.enterprise.context.RequestScoped;
 
@@ -34,13 +34,13 @@ public class BaseRetryOnClassAndMethodService implements RetryService {
 
     @Override
     @Retry(maxRetries = 4)
-    public Connection service() throws IOException {
+    public Connection service() {
         nbCalls++;
         return delegate();
     }
 
-    protected Connection delegate() throws IOException {
-        throw new IOException("cannot access delegate service");
+    protected Connection delegate() {
+        throw new TestException("cannot access delegate service");
     }
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/BaseRetryOnClassService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/BaseRetryOnClassService.java
@@ -21,8 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
 import java.sql.Connection;
 
-import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
+import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/BaseRetryOnClassService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/BaseRetryOnClassService.java
@@ -19,10 +19,10 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
 import java.sql.Connection;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 import jakarta.enterprise.context.RequestScoped;
 
@@ -33,13 +33,13 @@ public class BaseRetryOnClassService implements RetryService {
     private int nbCalls = 0;
 
     @Override
-    public Connection service() throws IOException {
+    public Connection service() {
         nbCalls++;
         return delegate();
     }
 
-    protected Connection delegate() throws IOException {
-        throw new IOException("cannot access delegate service");
+    protected Connection delegate() {
+        throw new TestException("cannot access delegate service");
     }
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/BaseRetryOnMethodService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/BaseRetryOnMethodService.java
@@ -21,8 +21,8 @@ package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
 import java.sql.Connection;
 
-import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
+import org.eclipse.microprofile.faulttolerance.Retry;
 
 import jakarta.enterprise.context.RequestScoped;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/BaseRetryOnMethodService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/BaseRetryOnMethodService.java
@@ -19,10 +19,10 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
 import java.sql.Connection;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 import jakarta.enterprise.context.RequestScoped;
 
@@ -33,13 +33,13 @@ public class BaseRetryOnMethodService implements RetryService {
 
     @Override
     @Retry
-    public Connection service() throws IOException {
+    public Connection service() {
         nbCalls++;
         return delegate();
     }
 
-    protected Connection delegate() throws IOException {
-        throw new IOException("cannot access delegate service");
+    protected Connection delegate() {
+        throw new TestException("cannot access delegate service");
     }
 
     @Override

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassAndMethodServiceNoAnnotationMethodOverride.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassAndMethodServiceNoAnnotationMethodOverride.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
 import java.sql.Connection;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -28,7 +27,7 @@ import jakarta.enterprise.context.RequestScoped;
 @RS(RetryServiceType.BASE_ROCM_RETRY_MISSING_ON_METHOD)
 public class RetryOnClassAndMethodServiceNoAnnotationMethodOverride extends BaseRetryOnClassAndMethodService {
     @Override
-    public Connection service() throws IOException {
+    public Connection service() {
         return super.service();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassAndMethodServiceOverrideClassLevelMethodOverride.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassAndMethodServiceOverrideClassLevelMethodOverride.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
 import java.sql.Connection;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
@@ -31,7 +30,7 @@ import jakarta.enterprise.context.RequestScoped;
 @Retry(maxRetries = 5)
 public class RetryOnClassAndMethodServiceOverrideClassLevelMethodOverride extends BaseRetryOnClassAndMethodService {
     @Override
-    public Connection service() throws IOException {
+    public Connection service() {
         return super.service();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassAndMethodServiceOverrideMethodLevel.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassAndMethodServiceOverrideMethodLevel.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
 import java.sql.Connection;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
@@ -31,7 +30,7 @@ import jakarta.enterprise.context.RequestScoped;
 public class RetryOnClassAndMethodServiceOverrideMethodLevel extends BaseRetryOnClassAndMethodService {
     @Override
     @Retry(maxRetries = 5)
-    public Connection service() throws IOException {
+    public Connection service() {
         return super.service();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassServiceNoAnnotationOnOveriddenMethod.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassServiceNoAnnotationOnOveriddenMethod.java
@@ -24,11 +24,13 @@ import java.sql.Connection;
 
 import jakarta.enterprise.context.RequestScoped;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
+
 @RequestScoped
 @RS(RetryServiceType.BASE_ROC_RETRY_MISSING_ON_METHOD)
 public class RetryOnClassServiceNoAnnotationOnOveriddenMethod extends BaseRetryOnClassService {
     @Override
-    public Connection service() throws IOException {
+    public Connection service() {
         return super.service();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassServiceNoAnnotationOnOveriddenMethod.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassServiceNoAnnotationOnOveriddenMethod.java
@@ -19,12 +19,9 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
 import java.sql.Connection;
 
 import jakarta.enterprise.context.RequestScoped;
-
-import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 @RequestScoped
 @RS(RetryServiceType.BASE_ROC_RETRY_MISSING_ON_METHOD)

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassServiceOverrideClassLevelMethodOverride.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassServiceOverrideClassLevelMethodOverride.java
@@ -19,11 +19,9 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
 import java.sql.Connection;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 import jakarta.enterprise.context.RequestScoped;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassServiceOverrideClassLevelMethodOverride.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassServiceOverrideClassLevelMethodOverride.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.sql.Connection;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 import jakarta.enterprise.context.RequestScoped;
 
@@ -31,7 +32,7 @@ import jakarta.enterprise.context.RequestScoped;
 @Retry(maxRetries = 4)
 public class RetryOnClassServiceOverrideClassLevelMethodOverride extends BaseRetryOnClassService {
     @Override
-    public Connection service() throws IOException {
+    public Connection service() {
         return super.service();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassServiceOverrideMethodLevel.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassServiceOverrideMethodLevel.java
@@ -19,11 +19,9 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
 import java.sql.Connection;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
-import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 import jakarta.enterprise.context.RequestScoped;
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassServiceOverrideMethodLevel.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnClassServiceOverrideMethodLevel.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.sql.Connection;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 
 import jakarta.enterprise.context.RequestScoped;
 
@@ -37,7 +38,7 @@ import jakarta.enterprise.context.RequestScoped;
 public class RetryOnClassServiceOverrideMethodLevel extends BaseRetryOnClassService {
     @Override
     @Retry(maxRetries = 4)
-    public Connection service() throws IOException {
+    public Connection service() {
         return super.service();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnMethodServiceNoAnnotationOnOverridedMethod.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnMethodServiceNoAnnotationOnOverridedMethod.java
@@ -18,8 +18,6 @@
  * limitations under the License.
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
-
-import java.io.IOException;
 import java.sql.Connection;
 
 import jakarta.enterprise.context.RequestScoped;
@@ -28,7 +26,7 @@ import jakarta.enterprise.context.RequestScoped;
 @RS(RetryServiceType.BASE_ROM_RETRY_MISSING_ON_METHOD)
 public class RetryOnMethodServiceNoAnnotationOnOverridedMethod extends BaseRetryOnMethodService {
     @Override
-    public Connection service() throws IOException {
+    public Connection service() {
         return super.service();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnMethodServiceNoAnnotationOnOverridedMethod.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnMethodServiceNoAnnotationOnOverridedMethod.java
@@ -18,6 +18,7 @@
  * limitations under the License.
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
+
 import java.sql.Connection;
 
 import jakarta.enterprise.context.RequestScoped;

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnMethodServiceOverridedClassLevelMethodOverride.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnMethodServiceOverridedClassLevelMethodOverride.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
 import java.sql.Connection;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
@@ -31,7 +30,7 @@ import jakarta.enterprise.context.RequestScoped;
 @Retry(maxRetries = 4)
 public class RetryOnMethodServiceOverridedClassLevelMethodOverride extends BaseRetryOnMethodService {
     @Override
-    public Connection service() throws IOException {
+    public Connection service() {
         return super.service();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnMethodServiceOverridedMethodLevel.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryOnMethodServiceOverridedMethodLevel.java
@@ -19,7 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
 import java.sql.Connection;
 
 import org.eclipse.microprofile.faulttolerance.Retry;
@@ -31,7 +30,7 @@ import jakarta.enterprise.context.RequestScoped;
 public class RetryOnMethodServiceOverridedMethodLevel extends BaseRetryOnMethodService {
     @Override
     @Retry(maxRetries = 4)
-    public Connection service() throws IOException {
+    public Connection service() {
         return super.service();
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryService.java
@@ -19,11 +19,10 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
 import java.sql.Connection;
 
 public interface RetryService {
-    Connection service() throws IOException;
+    Connection service();
 
     int getNumberOfServiceCalls();
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryVisibilityTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryVisibilityTest.java
@@ -21,6 +21,7 @@ package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
 import java.io.IOException;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -42,7 +43,7 @@ public class RetryVisibilityTest extends Arquillian {
     public static WebArchive deploy() {
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftRetryVisibility.jar")
-                // .addClasses(
+                .addClasses(TestException.class
                 // RS.class,
                 // RetryServiceType.class,
                 // RetryService.class,
@@ -50,7 +51,7 @@ public class RetryVisibilityTest extends Arquillian {
                 // RetryOnClassServiceOverrideClassLevel.class,
                 // RetryOnClassServiceOverrideMethodLevel.class,
                 // RetryOnClassServiceNoAnnotationOnOveriddenMethod.class
-                // )
+                )
                 .addPackage("org.eclipse.microprofile.fault.tolerance.tck.visibility.retry")
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .as(JavaArchive.class);
@@ -272,11 +273,11 @@ public class RetryVisibilityTest extends Arquillian {
                             RetryVisibilityTest.class.getSimpleName(),
                             testName,
                             expectedNbCalls));
-        } catch (RuntimeException ex) {
+        } catch (TestException ex) {
             Assert.fail(String.format("no %s exception should have been thrown in %s#%s",
                     ex.getClass().getName(),
                     RetryVisibilityTest.class.getSimpleName(),
-                    testName));
+                    testName), ex);
         }
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryVisibilityTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/visibility/retry/RetryVisibilityTest.java
@@ -19,8 +19,6 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.visibility.retry;
 
-import java.io.IOException;
-
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
@@ -265,7 +263,7 @@ public class RetryVisibilityTest extends Arquillian {
             service.service();
             Assert.fail(String.format("in %s#%s service() should have failed",
                     RetryVisibilityTest.class.getSimpleName(), testName));
-        } catch (IOException re) {
+        } catch (TestException re) {
             Assert.assertEquals(
                     service.getNumberOfServiceCalls(),
                     expectedNbCalls,
@@ -273,7 +271,7 @@ public class RetryVisibilityTest extends Arquillian {
                             RetryVisibilityTest.class.getSimpleName(),
                             testName,
                             expectedNbCalls));
-        } catch (TestException ex) {
+        } catch (Exception ex) {
             Assert.fail(String.format("no %s exception should have been thrown in %s#%s",
                     ex.getClass().getName(),
                     RetryVisibilityTest.class.getSimpleName(),


### PR DESCRIPTION
…his is because I saw some genuine RuntimeExceptions causing failures in our build system and if runtime exceptions can appear where they are not expected the wrong runtime exception may appear where a runtime exception is expected

Where a runtime exception is not expected it also updates the error message to include the details of that exception

fixes #620