### PR TITLE
Remove broken Java 8 GH action build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11]
     name: build with jdk ${{matrix.java}}
 
     steps:


### PR DESCRIPTION
The newest version of maven does not work with Java 8. The jenkins build uses an older version of maven, but github actions have no intention of allowing the confiugration of the maven version actions/setup-java#457