### PR TITLE
Make config disabled tests use `AsyncTaskManager`

### DIFF
--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -32,6 +32,9 @@ No.
 === Specification changes
 - Work with MicroProfile Telemetry Metrics (link:https://github.com/eclipse/microprofile-fault-tolerance/issues/622[#622])
 
+=== Other Changes
+- Removed use of unmanaged threads in TCK (link:https://github.com/eclipse/microprofile-fault-tolerance/issues/634[#634])
+
 [[release_notes_40]]
 == Release Notes for MicroProfile Fault Tolerance 4.0
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationGloballyEnableOnClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationGloballyEnableOnClassTest.java
@@ -19,12 +19,12 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCaller;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager.BarrierTask;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
@@ -74,7 +74,8 @@ public class DisableAnnotationGloballyEnableOnClassTest extends Arquillian {
                 .enable(DisableAnnotationClient.class, Timeout.class)
                 .enable(DisableAnnotationClient.class, Asynchronous.class)
                 .enable(DisableAnnotationClient.class, Fallback.class)
-                .enable(DisableAnnotationClient.class, Bulkhead.class);
+                .enable(DisableAnnotationClient.class, Bulkhead.class)
+                .enable(AsyncCaller.class, Asynchronous.class); // Needed by AsyncTaskManager
 
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftDisableGlobalEnableClass.jar")
@@ -155,35 +156,22 @@ public class DisableAnnotationGloballyEnableOnClassTest extends Arquillian {
 
     /**
      * Test whether Bulkhead is enabled on {@code waitWithBulkhead()}
-     *
-     * @throws InterruptedException
-     *             interrupted
-     * @throws ExecutionException
-     *             task was aborted
      */
     @Test
-    public void testBulkhead() throws ExecutionException, InterruptedException {
-        ExecutorService executor = Executors.newFixedThreadPool(10);
+    public void testBulkhead() {
 
-        // Start two executions at once
-        CompletableFuture<Void> waitingFuture = new CompletableFuture<>();
-        Future<?> result1 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-        Future<?> result2 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-
-        try {
-            disableClient.waitForBulkheadExecutions(2);
+        try (AsyncTaskManager taskManager = new AsyncTaskManager()) {
+            // Start two executions at once
+            BarrierTask<?> task1 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            BarrierTask<?> task2 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task1.assertAwaits();
+            task2.assertAwaits();
 
             // Try to start a third execution. This would throw a BulkheadException if Bulkhead is enabled.
             // Bulkhead is enabled on the class, so expect exception
-            Assert.assertThrows(BulkheadException.class,
-                    () -> disableClient.waitWithBulkhead(CompletableFuture.completedFuture(null)));
-        } finally {
-            // Clean up executor and first two executions
-            executor.shutdown();
-
-            waitingFuture.complete(null);
-            result1.get();
-            result2.get();
+            BarrierTask<?> task3 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task3.openBarrier();
+            task3.assertThrows(BulkheadException.class);
         }
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationGloballyEnableOnMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationGloballyEnableOnMethodTest.java
@@ -19,12 +19,12 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCaller;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager.BarrierTask;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
@@ -74,7 +74,8 @@ public class DisableAnnotationGloballyEnableOnMethodTest extends Arquillian {
                 .enable(DisableAnnotationClient.class, "failWithTimeout", Timeout.class)
                 .enable(DisableAnnotationClient.class, "asyncWaitThenReturn", Asynchronous.class)
                 .enable(DisableAnnotationClient.class, "failRetryOnceThenFallback", Fallback.class)
-                .enable(DisableAnnotationClient.class, "waitWithBulkhead", Bulkhead.class);
+                .enable(DisableAnnotationClient.class, "waitWithBulkhead", Bulkhead.class)
+                .enable(AsyncCaller.class, Asynchronous.class); // Needed by AsyncTaskManager
 
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftDisableGloballyEnableMethod.jar")
@@ -157,36 +158,22 @@ public class DisableAnnotationGloballyEnableOnMethodTest extends Arquillian {
 
     /**
      * Test whether Bulkhead is enabled on {@code waitWithBulkhead()}
-     *
-     * @throws InterruptedException
-     *             interrupted
-     * @throws ExecutionException
-     *             task was aborted
-     *
      */
     @Test
-    public void testBulkhead() throws ExecutionException, InterruptedException {
-        ExecutorService executor = Executors.newFixedThreadPool(10);
+    public void testBulkhead() {
 
-        // Start two executions at once
-        CompletableFuture<Void> waitingFuture = new CompletableFuture<>();
-        Future<?> result1 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-        Future<?> result2 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-
-        try {
-            disableClient.waitForBulkheadExecutions(2);
+        try (AsyncTaskManager taskManager = new AsyncTaskManager()) {
+            // Start two executions at once
+            BarrierTask<?> task1 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            BarrierTask<?> task2 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task1.assertAwaits();
+            task2.assertAwaits();
 
             // Try to start a third execution. This would throw a BulkheadException if Bulkhead is enabled.
             // Bulkhead is enabled on the method, so expect exception
-            Assert.assertThrows(BulkheadException.class,
-                    () -> disableClient.waitWithBulkhead(CompletableFuture.completedFuture(null)));
-        } finally {
-            // Clean up executor and first two executions
-            executor.shutdown();
-
-            waitingFuture.complete(null);
-            result1.get();
-            result2.get();
+            BarrierTask<?> task3 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task3.openBarrier();
+            task3.assertThrows(BulkheadException.class);
         }
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnClassEnableOnMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnClassEnableOnMethodTest.java
@@ -19,12 +19,12 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCaller;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager.BarrierTask;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
@@ -74,7 +74,8 @@ public class DisableAnnotationOnClassEnableOnMethodTest extends Arquillian {
                 .enable(DisableAnnotationClient.class, "failWithTimeout", Timeout.class)
                 .enable(DisableAnnotationClient.class, "asyncWaitThenReturn", Asynchronous.class)
                 .enable(DisableAnnotationClient.class, "failRetryOnceThenFallback", Fallback.class)
-                .enable(DisableAnnotationClient.class, "waitWithBulkhead", Bulkhead.class);
+                .enable(DisableAnnotationClient.class, "waitWithBulkhead", Bulkhead.class)
+                .enable(AsyncCaller.class, Asynchronous.class); // Needed by AsyncTaskManager;
 
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftDisableClassEnableMethod.jar")
@@ -156,35 +157,22 @@ public class DisableAnnotationOnClassEnableOnMethodTest extends Arquillian {
 
     /**
      * Test whether Bulkhead is enabled on {@code waitWithBulkhead()}
-     *
-     * @throws InterruptedException
-     *             interrupted
-     * @throws ExecutionException
-     *             task was aborted
      */
     @Test
-    public void testBulkhead() throws ExecutionException, InterruptedException {
-        ExecutorService executor = Executors.newFixedThreadPool(10);
+    public void testBulkhead() {
 
-        // Start two executions at once
-        CompletableFuture<Void> waitingFuture = new CompletableFuture<>();
-        Future<?> result1 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-        Future<?> result2 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-
-        try {
-            disableClient.waitForBulkheadExecutions(2);
+        try (AsyncTaskManager taskManager = new AsyncTaskManager()) {
+            // Start two executions at once
+            BarrierTask<?> task1 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            BarrierTask<?> task2 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task1.assertAwaits();
+            task2.assertAwaits();
 
             // Try to start a third execution. This would throw a BulkheadException if Bulkhead is enabled.
             // Bulkhead is enabled on the method, so expect exception
-            Assert.assertThrows(BulkheadException.class,
-                    () -> disableClient.waitWithBulkhead(CompletableFuture.completedFuture(null)));
-        } finally {
-            // Clean up executor and first two executions
-            executor.shutdown();
-
-            waitingFuture.complete(null);
-            result1.get();
-            result2.get();
+            BarrierTask<?> task3 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task3.openBarrier();
+            task3.assertThrows(BulkheadException.class);
         }
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnClassTest.java
@@ -19,12 +19,12 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCaller;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager.BarrierTask;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
@@ -68,7 +68,8 @@ public class DisableAnnotationOnClassTest extends Arquillian {
                 .disable(DisableAnnotationClient.class, Timeout.class)
                 .disable(DisableAnnotationClient.class, Asynchronous.class)
                 .disable(DisableAnnotationClient.class, Fallback.class)
-                .disable(DisableAnnotationClient.class, Bulkhead.class);
+                .disable(DisableAnnotationClient.class, Bulkhead.class)
+                .enable(AsyncCaller.class, Asynchronous.class); // Needed by AsyncTaskManager;
 
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftDisableClass.jar")
@@ -152,34 +153,22 @@ public class DisableAnnotationOnClassTest extends Arquillian {
 
     /**
      * Test whether Bulkhead is enabled on {@code waitWithBulkhead()}
-     *
-     * @throws InterruptedException
-     *             interrupted
-     * @throws ExecutionException
-     *             task was aborted
      */
     @Test
-    public void testBulkhead() throws ExecutionException, InterruptedException {
-        ExecutorService executor = Executors.newFixedThreadPool(10);
+    public void testBulkhead() {
 
-        // Start two executions at once
-        CompletableFuture<Void> waitingFuture = new CompletableFuture<>();
-        Future<?> result1 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-        Future<?> result2 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-
-        try {
-            disableClient.waitForBulkheadExecutions(2);
+        try (AsyncTaskManager taskManager = new AsyncTaskManager()) {
+            // Start two executions at once
+            BarrierTask<?> task1 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            BarrierTask<?> task2 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task1.assertAwaits();
+            task2.assertAwaits();
 
             // Try to start a third execution. This would throw a BulkheadException if Bulkhead is enabled.
             // Bulkhead is disabled on the class so no exception expected
-            disableClient.waitWithBulkhead(CompletableFuture.completedFuture(null));
-        } finally {
-            // Clean up executor and first two executions
-            executor.shutdown();
-
-            waitingFuture.complete(null);
-            result1.get();
-            result2.get();
+            BarrierTask<?> task3 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task3.openBarrier();
+            task3.assertSuccess();
         }
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnMethodsTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableAnnotationOnMethodsTest.java
@@ -19,12 +19,12 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCaller;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager.BarrierTask;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
@@ -68,7 +68,8 @@ public class DisableAnnotationOnMethodsTest extends Arquillian {
                 .disable(DisableAnnotationClient.class, "failWithCircuitBreaker", CircuitBreaker.class)
                 .disable(DisableAnnotationClient.class, "failWithTimeout", Timeout.class)
                 .disable(DisableAnnotationClient.class, "asyncWaitThenReturn", Asynchronous.class)
-                .disable(DisableAnnotationClient.class, "waitWithBulkhead", Bulkhead.class);
+                .disable(DisableAnnotationClient.class, "waitWithBulkhead", Bulkhead.class)
+                .enable(AsyncCaller.class, Asynchronous.class); // Needed by AsyncTaskManager;
 
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftDisableMethods.jar")
@@ -152,34 +153,22 @@ public class DisableAnnotationOnMethodsTest extends Arquillian {
 
     /**
      * Test whether Bulkhead is enabled on {@code waitWithBulkhead()}
-     *
-     * @throws InterruptedException
-     *             interrupted
-     * @throws ExecutionException
-     *             task was aborted
      */
     @Test
-    public void testBulkhead() throws ExecutionException, InterruptedException {
-        ExecutorService executor = Executors.newFixedThreadPool(10);
+    public void testBulkhead() {
 
-        // Start two executions at once
-        CompletableFuture<Void> waitingFuture = new CompletableFuture<>();
-        Future<?> result1 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-        Future<?> result2 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-
-        try {
-            disableClient.waitForBulkheadExecutions(2);
+        try (AsyncTaskManager taskManager = new AsyncTaskManager()) {
+            // Start two executions at once
+            BarrierTask<?> task1 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            BarrierTask<?> task2 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task1.assertAwaits();
+            task2.assertAwaits();
 
             // Try to start a third execution. This would throw a BulkheadException if Bulkhead is enabled.
             // Bulkhead is disabled on the method so no exception expected
-            disableClient.waitWithBulkhead(CompletableFuture.completedFuture(null));
-        } finally {
-            // Clean up executor and first two executions
-            executor.shutdown();
-
-            waitingFuture.complete(null);
-            result1.get();
-            result2.get();
+            BarrierTask<?> task3 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task3.openBarrier();
+            task3.assertSuccess();
         }
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableFTEnableOnClassTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableFTEnableOnClassTest.java
@@ -19,12 +19,12 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCaller;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager.BarrierTask;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
@@ -69,7 +69,8 @@ public class DisableFTEnableOnClassTest extends Arquillian {
                 .enable(DisableAnnotationClient.class, Asynchronous.class)
                 .enable(DisableAnnotationClient.class, Fallback.class)
                 .enable(DisableAnnotationClient.class, Bulkhead.class)
-                .disableGlobally();
+                .disableGlobally()
+                .enable(AsyncCaller.class, Asynchronous.class); // Needed by AsyncTaskManager;
 
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftDisableGlobalEnableClass.jar")
@@ -150,35 +151,22 @@ public class DisableFTEnableOnClassTest extends Arquillian {
 
     /**
      * Test whether Bulkhead is enabled on {@code waitWithBulkhead()}
-     *
-     * @throws InterruptedException
-     *             interrupted
-     * @throws ExecutionException
-     *             task was aborted
      */
     @Test
-    public void testBulkhead() throws ExecutionException, InterruptedException {
-        ExecutorService executor = Executors.newFixedThreadPool(10);
+    public void testBulkhead() {
 
-        // Start two executions at once
-        CompletableFuture<Void> waitingFuture = new CompletableFuture<>();
-        Future<?> result1 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-        Future<?> result2 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-
-        try {
-            disableClient.waitForBulkheadExecutions(2);
+        try (AsyncTaskManager taskManager = new AsyncTaskManager()) {
+            // Start two executions at once
+            BarrierTask<?> task1 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            BarrierTask<?> task2 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task1.assertAwaits();
+            task2.assertAwaits();
 
             // Try to start a third execution. This would throw a BulkheadException if Bulkhead is enabled.
             // Bulkhead is enabled on the class, so expect exception
-            Assert.assertThrows(BulkheadException.class,
-                    () -> disableClient.waitWithBulkhead(CompletableFuture.completedFuture(null)));
-        } finally {
-            // Clean up executor and first two executions
-            executor.shutdown();
-
-            waitingFuture.complete(null);
-            result1.get();
-            result2.get();
+            BarrierTask<?> task3 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task3.openBarrier();
+            task3.assertThrows(BulkheadException.class);
         }
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableFTEnableOnMethodTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/disableEnv/DisableFTEnableOnMethodTest.java
@@ -19,12 +19,12 @@
  *******************************************************************************/
 package org.eclipse.microprofile.fault.tolerance.tck.disableEnv;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncCaller;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager;
+import org.eclipse.microprofile.fault.tolerance.tck.util.AsyncTaskManager.BarrierTask;
 import org.eclipse.microprofile.fault.tolerance.tck.util.Packages;
 import org.eclipse.microprofile.fault.tolerance.tck.util.TestException;
 import org.eclipse.microprofile.faulttolerance.Asynchronous;
@@ -69,7 +69,8 @@ public class DisableFTEnableOnMethodTest extends Arquillian {
                 .enable(DisableAnnotationClient.class, "asyncWaitThenReturn", Asynchronous.class)
                 .enable(DisableAnnotationClient.class, "failRetryOnceThenFallback", Fallback.class)
                 .enable(DisableAnnotationClient.class, "waitWithBulkhead", Bulkhead.class)
-                .disableGlobally();
+                .disableGlobally()
+                .enable(AsyncCaller.class, Asynchronous.class); // Needed by AsyncTaskManager;
 
         JavaArchive testJar = ShrinkWrap
                 .create(JavaArchive.class, "ftDisableGloballyEnableMethod.jar")
@@ -136,35 +137,22 @@ public class DisableFTEnableOnMethodTest extends Arquillian {
 
     /**
      * Test whether Bulkhead is enabled on {@code waitWithBulkhead()}
-     *
-     * @throws InterruptedException
-     *             interrupted
-     * @throws ExecutionException
-     *             task was aborted
      */
     @Test
-    public void testBulkhead() throws ExecutionException, InterruptedException {
-        ExecutorService executor = Executors.newFixedThreadPool(10);
+    public void testBulkhead() {
 
-        // Start two executions at once
-        CompletableFuture<Void> waitingFuture = new CompletableFuture<>();
-        Future<?> result1 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-        Future<?> result2 = executor.submit(() -> disableClient.waitWithBulkhead(waitingFuture));
-
-        try {
-            disableClient.waitForBulkheadExecutions(2);
+        try (AsyncTaskManager taskManager = new AsyncTaskManager()) {
+            // Start two executions at once
+            BarrierTask<?> task1 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            BarrierTask<?> task2 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task1.assertAwaits();
+            task2.assertAwaits();
 
             // Try to start a third execution. This would throw a BulkheadException if Bulkhead is enabled.
             // Bulkhead is enabled on the method, so expect exception
-            Assert.assertThrows(BulkheadException.class,
-                    () -> disableClient.waitWithBulkhead(CompletableFuture.completedFuture(null)));
-        } finally {
-            // Clean up executor and first two executions
-            executor.shutdown();
-
-            waitingFuture.complete(null);
-            result1.get();
-            result2.get();
+            BarrierTask<?> task3 = taskManager.runBarrierTask(disableClient::waitWithBulkhead);
+            task3.openBarrier();
+            task3.assertThrows(BulkheadException.class);
         }
     }
 }


### PR DESCRIPTION
Previously these tests were using a fixed thread pool executor which will create unmanaged threads on a Jakarta EE server.

We already have `AsyncCaller` which is designed to avoid this, and `AsyncTaskManager` which provides additional framework for exactly these type of tests so we should use them here.

Unfortunately these test classes are also testing the disablement of the `@Asynchronous` annotation which `AsyncCaller` and `AsyncTaskManager` use. We could split these tests up, but it's easier to add additional config to enable the annotation for that class specifically.

Fixes #634