### PR TITLE
Minor Maven pom fixes that propagate to the public apidocs pages

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -26,11 +26,12 @@
     <properties>
         <bnd.version>5.0.0</bnd.version>
     </properties>
-    <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
+
     <artifactId>microprofile-fault-tolerance-api</artifactId>
     <version>4.1-SNAPSHOT</version>
     <name>microProfile-fault-tolerance-api</name>
     <description>Fault Tolerance APIs for MicroProfile :: API</description>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.enterprise</groupId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -29,7 +29,7 @@
 
     <artifactId>microprofile-fault-tolerance-api</artifactId>
     <version>4.1-SNAPSHOT</version>
-    <name>microProfile-fault-tolerance-api</name>
+    <name>MicroProfile Fault Tolerance API</name>
     <description>Fault Tolerance APIs for MicroProfile :: API</description>
 
     <dependencies>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -15,14 +15,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <!-- This is just for now and will not work if the API has a separate release 
+        <!-- This is just for now and will not work if the API has a separate release
             cycle than the rest. -->
         <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
         <artifactId>microprofile-fault-tolerance-parent</artifactId>
         <version>4.1-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.eclipse.microprofile.fault-tolerance</groupId>
     <artifactId>microprofile-fault-tolerance-tck</artifactId>
     <version>4.1-SNAPSHOT</version>
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -24,8 +24,9 @@
 
     <artifactId>microprofile-fault-tolerance-tck</artifactId>
     <version>4.1-SNAPSHOT</version>
-
+    <name>MicroProfile Fault Tolerance TCK</name>
     <description>Fault Tolerance for MicroProfile :: TCK</description>
+
     <properties>
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9_]*$</checkstyle.methodNameFormat>
         <microprofile-config-api.version>3.1</microprofile-config-api.version>


### PR DESCRIPTION
Mainly trying to fix the messy stylization of 'microProfile-fault-tolerance-api' on public apidocs pages:

https://download.eclipse.org/microprofile/microprofile-fault-tolerance-4.1-RC2/apidocs/

Also, building the project now, the module names are all nice and clean:

````
[INFO] Reactor Summary for MicroProfile Fault Tolerance 4.1-SNAPSHOT:
[INFO]
[INFO] MicroProfile Fault Tolerance ....................... SUCCESS [  4.982 s]
[INFO] MicroProfile Fault Tolerance API ................... SUCCESS [  4.178 s]
[INFO] MicroProfile Fault Tolerance TCK ................... SUCCESS [  7.763 s]
[INFO] MicroProfile Fault Tolerance Specification ......... SUCCESS [  7.148 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
````

