### PR TITLE
Make InMemoryMetricReader not a bean

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/util/PullExporterAutoConfigurationCustomizerProvider.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/util/PullExporterAutoConfigurationCustomizerProvider.java
@@ -23,7 +23,6 @@ import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizer;
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
 import io.opentelemetry.sdk.autoconfigure.spi.ConfigProperties;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
-import jakarta.enterprise.inject.spi.CDI;
 
 public class PullExporterAutoConfigurationCustomizerProvider implements AutoConfigurationCustomizerProvider {
 
@@ -33,7 +32,7 @@ public class PullExporterAutoConfigurationCustomizerProvider implements AutoConf
 
     private SdkMeterProviderBuilder registerMeterProvider(SdkMeterProviderBuilder builder,
             ConfigProperties properties) {
-        InMemoryMetricReader exporter = CDI.current().select(InMemoryMetricReader.class).get();
+        InMemoryMetricReader exporter = InMemoryMetricReader.current();
         builder.registerMetricReader(exporter);
         return builder;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/util/TelemetryLongMetric.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/util/TelemetryLongMetric.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import org.eclipse.microprofile.fault.tolerance.tck.telemetryMetrics.util.TelemetryMetricDefinition.MetricType;
 
 import io.opentelemetry.sdk.metrics.data.LongPointData;
-import jakarta.enterprise.inject.spi.CDI;
 
 /**
  * Allows tests to get the value of a {@code Long} counter or gauge and compare it with a baseline.
@@ -55,12 +54,12 @@ public class TelemetryLongMetric {
      * @return the counter value, or zero if the metric doesn't exist
      */
     public long value() {
-        InMemoryMetricReader reader = CDI.current().select(InMemoryMetricReader.class).get();
+        InMemoryMetricReader reader = InMemoryMetricReader.current();
         return reader.readLongData(metricId);
     }
 
     public boolean isPresent() {
-        InMemoryMetricReader exporter = CDI.current().select(InMemoryMetricReader.class).get();
+        InMemoryMetricReader exporter = InMemoryMetricReader.current();
         Optional<LongPointData> latest = exporter.getMetric(metricId)
                 .flatMap(md -> InMemoryMetricReader.getLongPointData(md, metricId));
         return latest.isPresent();


### PR DESCRIPTION
While testing the metric test changes, I ran into an issue where the `InMemoryMetricReader` would not be registered correctly for the first test app. This turned out to be because Liberty was initializing OpenTelemetry before CDI was fully initialized.

This could be true for other runtimes as well, so I think we need to make the `InMemoryMetricReader` not depend on CDI.

I changed it to use a static singleton instance, which works in liberty, but I wasn't sure whether that would work for implementations using an embedded arquillian container. For this reason, I've also cleared the static instance when the reader is shut down, with the intention that each new app will get a new instance.