### PR TITLE
Use final version of Telemetry dependency

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -32,7 +32,7 @@
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9_]*$</checkstyle.methodNameFormat>
         <microprofile-config-api.version>3.1</microprofile-config-api.version>
         <microprofile-metrics-api.version>4.0</microprofile-metrics-api.version>
-        <microprofile-telemetry-api.version>2.0-RC2</microprofile-telemetry-api.version>
+        <microprofile-telemetry-api.version>2.0</microprofile-telemetry-api.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
In preparation for the 4.1 final release.

Builds expected to fail because Telemetry 2.0 is in the staging repo.