### PR TITLE
Avoid using test groups for test ordering

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/BulkheadTelemetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/BulkheadTelemetryTest.java
@@ -112,7 +112,7 @@ public class BulkheadTelemetryTest extends Arquillian {
         return result;
     }
 
-    @Test(groups = "main")
+    @Test
     public void bulkheadMetricTest() throws InterruptedException, ExecutionException, TimeoutException {
         TelemetryMetricGetter m = new TelemetryMetricGetter(BulkheadMetricBean.class, "waitFor");
         m.baselineMetrics();
@@ -145,7 +145,7 @@ public class BulkheadTelemetryTest extends Arquillian {
                 is(0L));
     }
 
-    @Test(groups = "main")
+    @Test
     public void bulkheadMetricRejectionTest() throws InterruptedException, ExecutionException, TimeoutException {
         TelemetryMetricGetter m = new TelemetryMetricGetter(BulkheadMetricBean.class, "waitFor");
         m.baselineMetrics();
@@ -178,7 +178,7 @@ public class BulkheadTelemetryTest extends Arquillian {
 
     }
 
-    @Test(groups = "main")
+    @Test
     public void bulkheadMetricHistogramTest() throws InterruptedException, ExecutionException, TimeoutException {
         TelemetryMetricGetter m = new TelemetryMetricGetter(BulkheadMetricBean.class, "waitForHistogram");
         m.baselineMetrics();
@@ -217,7 +217,7 @@ public class BulkheadTelemetryTest extends Arquillian {
         m.getBulkheadRunningDuration().assertBoundaries();
     }
 
-    @Test(groups = "main")
+    @Test
     public void bulkheadMetricAsyncTest() throws InterruptedException, ExecutionException, TimeoutException {
         TelemetryMetricGetter m = new TelemetryMetricGetter(BulkheadMetricBean.class, "waitForAsync");
         m.baselineMetrics();
@@ -265,7 +265,8 @@ public class BulkheadTelemetryTest extends Arquillian {
                 is(1L));
     }
 
-    @Test(dependsOnGroups = "main")
+    @Test(dependsOnMethods = {"bulkheadMetricTest", "bulkheadMetricRejectionTest", "bulkheadMetricHistogramTest",
+            "bulkheadMetricAsyncTest"})
     public void testMetricUnits() throws InterruptedException, ExecutionException {
         InMemoryMetricReader reader = InMemoryMetricReader.current();
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/CircuitBreakerTelemetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/CircuitBreakerTelemetryTest.java
@@ -117,7 +117,7 @@ public class CircuitBreakerTelemetryTest extends Arquillian {
         }
     }
 
-    @Test(groups = "main")
+    @Test
     public void testCircuitBreakerMetric() throws Exception {
         TelemetryMetricGetter m = new TelemetryMetricGetter(CircuitBreakerMetricBean.class, "doWork");
 
@@ -181,7 +181,7 @@ public class CircuitBreakerTelemetryTest extends Arquillian {
                 is(5L));
     }
 
-    @Test(dependsOnGroups = "main")
+    @Test(dependsOnMethods = "testCircuitBreakerMetric")
     public void testMetricUnits() throws InterruptedException, ExecutionException {
         InMemoryMetricReader reader = InMemoryMetricReader.current();
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/FallbackTelemetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/FallbackTelemetryTest.java
@@ -71,7 +71,7 @@ public class FallbackTelemetryTest extends Arquillian {
     @Inject
     private FallbackMetricBean fallbackBean;
 
-    @Test(groups = "main")
+    @Test
     public void fallbackMetricMethodTest() {
         TelemetryMetricGetter m = new TelemetryMetricGetter(FallbackMetricBean.class, "doWork");
         m.baselineMetrics();
@@ -124,7 +124,7 @@ public class FallbackTelemetryTest extends Arquillian {
                 is(1L));
     }
 
-    @Test(groups = "main")
+    @Test
     public void fallbackMetricHandlerTest() {
         TelemetryMetricGetter m = new TelemetryMetricGetter(FallbackMetricBean.class, "doWorkWithHandler");
         m.baselineMetrics();
@@ -177,7 +177,7 @@ public class FallbackTelemetryTest extends Arquillian {
                 is(1L));
     }
 
-    @Test(dependsOnGroups = "main")
+    @Test(dependsOnMethods = {"fallbackMetricMethodTest", "fallbackMetricHandlerTest"})
     public void testMetricUnits() throws InterruptedException, ExecutionException {
         InMemoryMetricReader reader = InMemoryMetricReader.current();
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/RetryTelemetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/RetryTelemetryTest.java
@@ -87,7 +87,7 @@ public class RetryTelemetryTest extends Arquillian {
     @Inject
     private RetryMetricBean retryBean;
 
-    @Test(groups = "main")
+    @Test
     public void testRetryMetricSuccessfulImmediately() {
         TelemetryMetricGetter m = new TelemetryMetricGetter(RetryMetricBean.class, "failSeveralTimes");
         m.baselineMetrics();
@@ -103,7 +103,7 @@ public class RetryTelemetryTest extends Arquillian {
                 m.getInvocations(EXCEPTION_THROWN, InvocationFallback.NOT_DEFINED).delta(), is(0L));
     }
 
-    @Test(groups = "main")
+    @Test
     public void testRetryMetricSuccessfulAfterRetry() {
         TelemetryMetricGetter m = new TelemetryMetricGetter(RetryMetricBean.class, "failSeveralTimes");
         m.baselineMetrics();
@@ -119,7 +119,7 @@ public class RetryTelemetryTest extends Arquillian {
                 m.getInvocations(EXCEPTION_THROWN, InvocationFallback.NOT_DEFINED).delta(), is(0L));
     }
 
-    @Test(groups = "main")
+    @Test
     public void testRetryMetricNonRetryableImmediately() {
         TelemetryMetricGetter m = new TelemetryMetricGetter(RetryMetricBean.class, "failSeveralTimesThenNonRetryable");
         m.baselineMetrics();
@@ -137,7 +137,7 @@ public class RetryTelemetryTest extends Arquillian {
                 m.getInvocations(EXCEPTION_THROWN, InvocationFallback.NOT_DEFINED).delta(), is(1L));
     }
 
-    @Test(groups = "main")
+    @Test
     public void testRetryMetricNonRetryableAfterRetries() {
         TelemetryMetricGetter m = new TelemetryMetricGetter(RetryMetricBean.class, "failSeveralTimesThenNonRetryable");
         m.baselineMetrics();
@@ -155,7 +155,7 @@ public class RetryTelemetryTest extends Arquillian {
                 m.getInvocations(EXCEPTION_THROWN, InvocationFallback.NOT_DEFINED).delta(), is(1L));
     }
 
-    @Test(groups = "main")
+    @Test
     public void testRetryMetricMaxRetries() {
         TelemetryMetricGetter m = new TelemetryMetricGetter(RetryMetricBean.class, "failSeveralTimes");
         m.baselineMetrics();
@@ -172,7 +172,7 @@ public class RetryTelemetryTest extends Arquillian {
                 m.getInvocations(EXCEPTION_THROWN, InvocationFallback.NOT_DEFINED).delta(), is(2L));
     }
 
-    @Test(groups = "main")
+    @Test
     public void testRetryMetricMaxRetriesHitButNoRetry() {
         // This is an edge case which can only occur when maxRetries = 0
         TelemetryMetricGetter m = new TelemetryMetricGetter(RetryMetricBean.class, "maxRetriesZero");
@@ -189,7 +189,7 @@ public class RetryTelemetryTest extends Arquillian {
                 m.getInvocations(EXCEPTION_THROWN, InvocationFallback.NOT_DEFINED).delta(), is(1L));
     }
 
-    @Test(groups = "main")
+    @Test
     public void testRetryMetricMaxDuration() {
         TelemetryMetricGetter m = new TelemetryMetricGetter(RetryMetricBean.class, "failAfterDelay");
         m.baselineMetrics();
@@ -206,7 +206,7 @@ public class RetryTelemetryTest extends Arquillian {
                 m.getInvocations(EXCEPTION_THROWN, InvocationFallback.NOT_DEFINED).delta(), is(1L));
     }
 
-    @Test(groups = "main")
+    @Test
     public void testRetryMetricMaxDurationNoRetries() {
         TelemetryMetricGetter m = new TelemetryMetricGetter(RetryMetricBean.class, "failAfterDelay");
         m.baselineMetrics();
@@ -224,7 +224,10 @@ public class RetryTelemetryTest extends Arquillian {
                 m.getInvocations(EXCEPTION_THROWN, InvocationFallback.NOT_DEFINED).delta(), is(1L));
     }
 
-    @Test(dependsOnGroups = "main")
+    @Test(dependsOnMethods = {"testRetryMetricSuccessfulImmediately", "testRetryMetricSuccessfulAfterRetry",
+            "testRetryMetricNonRetryableImmediately", "testRetryMetricNonRetryableAfterRetries",
+            "testRetryMetricMaxRetries", "testRetryMetricMaxRetriesHitButNoRetry", "testRetryMetricMaxDuration",
+            "testRetryMetricMaxDurationNoRetries"})
     public void testMetricUnits() throws InterruptedException, ExecutionException {
         InMemoryMetricReader reader = InMemoryMetricReader.current();
 

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/TimeoutTelemetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/TimeoutTelemetryTest.java
@@ -84,7 +84,7 @@ public class TimeoutTelemetryTest extends Arquillian {
     @Inject
     private TimeoutMetricBean timeoutBean;
 
-    @Test(groups = "main")
+    @Test
     public void testTimeoutMetric() {
         TelemetryMetricGetter m = new TelemetryMetricGetter(TimeoutMetricBean.class, "counterTestWorkForMillis");
         m.baselineMetrics();
@@ -104,7 +104,7 @@ public class TimeoutTelemetryTest extends Arquillian {
                 is(2L));
     }
 
-    @Test(groups = "main")
+    @Test
     public void testTimeoutHistogram() {
         TelemetryMetricGetter m = new TelemetryMetricGetter(TimeoutMetricBean.class, "histogramTestWorkForMillis");
 
@@ -117,7 +117,7 @@ public class TimeoutTelemetryTest extends Arquillian {
         m.getTimeoutExecutionDuration().assertBoundaries();
     }
 
-    @Test(dependsOnGroups = "main")
+    @Test(dependsOnMethods = {"testTimeoutMetric", "testTimeoutHistogram"})
     public void testMetricUnits() throws InterruptedException, ExecutionException {
         InMemoryMetricReader reader = InMemoryMetricReader.current();
 


### PR DESCRIPTION
Test groups are global, not just for single test. This means that multiple test classes may be "in progress" at the same time, which leads to issues in at least one implementation which has global state.

Instead of test groups and `dependsOnGroups`, this commit uses simple `dependsOnMethods`, which is local to the test class.