### PR TITLE
baseline metrics in CircuitBreakerTelemetryTest

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/metrics/CircuitBreakerMetricTest.java
@@ -44,7 +44,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import jakarta.inject.Inject;
@@ -75,7 +75,7 @@ public class CircuitBreakerMetricTest extends Arquillian {
     @Inject
     private CircuitBreakerMetricBean cbBean;
 
-    @BeforeTest
+    @BeforeMethod
     public void closeTheCircuit() throws Exception {
 
         // Condition is needed because BeforeTest runs on both client and server

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/CircuitBreakerTelemetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/CircuitBreakerTelemetryTest.java
@@ -53,7 +53,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import io.opentelemetry.sdk.autoconfigure.spi.AutoConfigurationCustomizerProvider;
@@ -90,7 +90,7 @@ public class CircuitBreakerTelemetryTest extends Arquillian {
     @Inject
     private CircuitBreakerMetricBean cbBean;
 
-    @BeforeTest
+    @BeforeMethod
     public void closeTheCircuit() throws Exception {
 
         // Condition is needed because BeforeTest runs on both client and server

--- a/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/CircuitBreakerTelemetryTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/fault/tolerance/tck/telemetryMetrics/CircuitBreakerTelemetryTest.java
@@ -120,6 +120,7 @@ public class CircuitBreakerTelemetryTest extends Arquillian {
     @Test
     public void testCircuitBreakerMetric() throws Exception {
         TelemetryMetricGetter m = new TelemetryMetricGetter(CircuitBreakerMetricBean.class, "doWork");
+        m.baselineMetrics();
 
         // First failure, circuit remains closed
         expectTestException(() -> cbBean.doWork(Result.FAIL));


### PR DESCRIPTION
The call to `baselineMetrics()` after creating the `TelemetryMetricGetter` was missing in this test. Funnily enough, the MP Metrics counterpart of this test (`CircuitBreakerMetricTest`) baselines metrics correctly.

Fixes #656